### PR TITLE
fix(#1453): centralise weather QIR parameter semantics

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2101,6 +2101,21 @@ class QuickIntentRouter(
             ),
             paramExtractor = { _, _ -> mapOf("day" to "tomorrow") },
         ),
+        // "What's the weather like this week in <city>" — historical #255 contract:
+        // "this week" means a 7-day horizon. The normaliser adds forecast_days=7.
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+(?:like\s+)?this\s+week\s+in\s+([\w\s,]+?)[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val location = match.groupValues[1].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                }
+            },
+        ),
         // City-named weather: "weather in Auckland" / "what's the weather in London" /
         // "weather forecast for Paris" — captures city into `location` param.
         IntentPattern(
@@ -2139,6 +2154,22 @@ class QuickIntentRouter(
             ),
             paramExtractor = { _, _ -> emptyMap() },
         ),
+        // "What's the forecast for Sydney?" — plain forecast with a named location and no
+        // explicit horizon. The normaliser applies the 3-day explicit-forecast default and
+        // strips any temporal tail from the captured location.
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """(?:what(?:'s| is)\s+)?(?:the\s+)?forecast\s+for\s+(?!the\s+next\b|a\s+(?:few|couple)\b|\d+\s+days\b)([\w\s,]+?)[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val location = match.groupValues[1].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                }
+            },
+        ),
         // Word-form bare forecast: "five day forecast", "five-day forecast"
         IntentPattern(
             intentName = "get_weather",
@@ -2155,14 +2186,20 @@ class QuickIntentRouter(
                 mapOf("forecast_days" to (wordToNum[daysWord] ?: daysWord))
             },
         ),
-        // Precipitation: current state only — "will it rain", "is it raining", "do I need an umbrella"
+        // Precipitation: current state only — "will it rain", "is it raining", "do I need an umbrella",
+        // with optional named location: "will it rain in Sydney today" (location preserved by #1453)
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """(?:will\s+it\s+rain(?:\s+today|\s+tonight)?\s*[.!?]*$|is\s+it\s+(?:going\s+to|gonna)\s+rain(?:\s+today|\s+tonight)?\s*[.!?]*$|is\s+it\s+raining|do\s+i\s+need\s+(?:an?\s+)?umbrella|chance\s+of\s+rain(?:\s+today|\s+tonight)?)""",
+                """(?:will\s+it\s+rain|is\s+it\s+(?:going\s+to|gonna)\s+rain)(?:\s+(?:in|for|at)\s+([\w\s,]+?))?(?:\s+today|\s+tonight)?\s*[.!?]*$|is\s+it\s+raining|do\s+i\s+need\s+(?:an?\s+)?umbrella|chance\s+of\s+rain(?:\s+today|\s+tonight)?""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { match, _ ->
+                val location = match.groupValues.getOrNull(1)?.trim()?.takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                }
+            },
         ),
         // ── Rain over the next N days ──
         // "is it going to rain over the next N days"
@@ -2230,14 +2267,22 @@ class QuickIntentRouter(
             paramExtractor = { _, _ -> emptyMap() },
         ),
 
-        // "How hot will it be tomorrow?" / "How cold will it be this afternoon?"
+        // "How hot will it be tomorrow?" / "How cold will it be this afternoon?" /
+        // "How hot will it be in Sydney tomorrow?" — emits raw_query; the weather
+        // normaliser turns "tomorrow" into day=tomorrow and keeps any named location.
+        // (this afternoon/evening/weekend remain #1455 relative periods — not faked.)
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """(?:how\s+(?:hot|cold|warm)\s+will\s+it\s+be\s+(?:tomorrow|today|this\s+(?:afternoon|evening|morning|weekend))\s*[.!?]*$|what(?:'s| is)\s+(?:the\s+)?(?:temperature|forecast)\s+(?:going\s+to\s+be|gonna\s+be)\s+(?:tomorrow|today|this\s+(?:afternoon|evening|morning|weekend)))""",
+                """(?:how\s+(?:hot|cold|warm)\s+will\s+it\s+be\s+(?:(?:in|for|at)\s+([\w\s,]+?)\s+)?(?:tomorrow|today)\s*[.!?]*$|how\s+(?:hot|cold|warm)\s+will\s+it\s+be\s+this\s+(?:afternoon|evening|morning|weekend)\s*[.!?]*$|what(?:'s| is)\s+(?:the\s+)?(?:temperature|forecast)\s+(?:going\s+to\s+be|gonna\s+be)\s+(?:tomorrow|today|this\s+(?:afternoon|evening|morning|weekend)))""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
+            paramExtractor = { match, raw ->
+                val params = mutableMapOf("raw_query" to raw)
+                val location = match.groupValues.getOrNull(1)?.trim()?.takeIf { it.isNotEmpty() }
+                if (location != null) params["location"] = location
+                params
+            },
             requiredSlots = emptyMap(),
         ),
         // "temperature in Wellington" — city-specific temperature query
@@ -4427,7 +4472,13 @@ class QuickIntentRouter(
     private fun tryMatchPatterns(trimmed: String, candidates: List<IntentPattern>): RouteResult? {
         for (pattern in candidates) {
             val match = pattern.regex.find(trimmed) ?: continue
-            val params = pattern.paramExtractor(match, trimmed)
+            val extracted = pattern.paramExtractor(match, trimmed)
+            // #1453 — weather parameter-semantic normalisation: every deterministic
+            // get_weather match shares one conservative normaliser so forecast
+            // horizons, "tomorrow", "this week", and named locations survive
+            // regardless of which pattern matched.
+            val params =
+                if (pattern.intentName == "get_weather") normalizeWeatherParams(trimmed, extracted) else extracted
             val missingSlot = missingRequiredSlot(pattern.requiredSlots, params)
             val intent = MatchedIntent(
                 intentName = pattern.intentName,
@@ -4555,6 +4606,122 @@ class QuickIntentRouter(
         // #1227 — STT mishearing: "30 first" → "31st" (thirty-first split into "30 first").
         // Only correct the specific observed artifact; general ordinal handling is not needed.
         return stripped.replace(Regex("""\b30\s+first\b""", RegexOption.IGNORE_CASE), "31st")
+    }
+
+    // ── Weather semantic normalisation (#1453) ─────────────────────────────────
+    // Every deterministic get_weather match passes through this helper so that
+    // temporal semantics (forecast horizon, "tomorrow", "this week") and named
+    // locations survive regardless of which pattern matched. Conservative by
+    // design: explicit params are never overwritten, temporal wording is never
+    // passed to geocoding, and ordinary current-weather queries gain no
+    // forecast semantics.
+
+    private val weatherNextNDays = Regex(
+        """\b(?:the\s+)?next\s+(few|one|two|three|four|five|six|seven|eight|nine|ten|\d{1,2})\s+days\b""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    private val weatherNDayForecast = Regex(
+        """\b(few|one|two|three|four|five|six|seven|eight|nine|ten|\d{1,2})\s*[ -]?\s*day\s+(?:weather\s+)?forecast\b""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    private val weatherTemporalTail = Regex(
+        """(?i)(?:(?:^|\s+)(?:for|over|in|on|at)?\s*(?:the\s+)?next\s+(?:few|one|two|three|four|five|six|seven|eight|nine|ten|\d{1,2})\s+days|(?:^|\s+)(?:for|over|in|on|at)?\s*(?:tomorrow|today|tonight|now)|(?:^|\s+)this\s+(?:week|weekend|afternoon|evening|morning))$""",
+    )
+
+    private val weatherLocationPrefix = Regex(
+        """\b(?:in|for|at)\s+(?!the\s+next\b|a\s+(?:few|couple)\b|tomorrow\b|today\b|tonight\b|now\b|this\s+(?:week|weekend|afternoon|evening|morning)\b|\d+\s+days\b)([A-Za-z][\w\s,]*)""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    private fun normalizeWeatherParams(raw: String, params: Map<String, String>): Map<String, String> {
+        val normalized = LinkedHashMap(params)
+
+        // Clean temporal wording out of an extracted location before geocoding —
+        // e.g. "Sydney for the next 5 days" → "Sydney".
+        normalized["location"]?.let { location ->
+            val cleaned = stripWeatherTemporal(location)
+            if (cleaned.isBlank()) normalized.remove("location") else normalized["location"] = cleaned
+        }
+
+        // Recover a named location from the raw utterance when the matched pattern
+        // emitted none (e.g. UV/AQI/sunset patterns match only their prefix).
+        if (normalized["location"].isNullOrBlank()) {
+            recoverWeatherLocation(raw)?.let { normalized["location"] = it }
+        }
+
+        // "tomorrow" → day=tomorrow (never overwrite an explicit day).
+        if (normalized["day"].isNullOrBlank() &&
+            Regex("""\btomorrow\b""", RegexOption.IGNORE_CASE).containsMatchIn(raw)
+        ) {
+            normalized["day"] = "tomorrow"
+        }
+
+        // Forecast horizon when none was extracted (never overwrite explicit).
+        if (normalized["forecast_days"].isNullOrBlank()) {
+            weatherForecastDays(raw)?.let { normalized["forecast_days"] = it }
+        }
+        return normalized
+    }
+
+    /** Remove trailing temporal phrases from a captured location before geocoding. */
+    private fun stripWeatherTemporal(location: String): String {
+        var current = location.trim()
+        while (true) {
+            val stripped = weatherTemporalTail.replaceFirst(current, "").trim().trimEnd(',')
+            if (stripped == current) return current
+            current = stripped
+        }
+    }
+
+    /**
+     * Recover a named location from raw weather text when the matched pattern did not
+     * extract one. Narrowly weather-specific: temporal prepositions such as
+     * "for the next 5 days" are never treated as locations.
+     */
+    private fun recoverWeatherLocation(raw: String): String? {
+        val match = weatherLocationPrefix.find(raw) ?: return null
+        val cleaned = stripWeatherTemporal(match.groupValues[1])
+        return cleaned.takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Determine the forecast horizon from the utterance, or null when the user asked
+     * for current conditions. Explicit "forecast" without any horizon/day anchor gets
+     * the established 3-day default; "this week" → 7 days (historical #255 contract).
+     */
+    private fun weatherForecastDays(raw: String): String? {
+        weatherNextNDays.find(raw)?.let { m ->
+            return wordToForecastDays(m.groupValues[1].lowercase())
+        }
+        weatherNDayForecast.find(raw)?.let { m ->
+            return wordToForecastDays(m.groupValues[1].lowercase())
+        }
+        if (Regex("""\bthis\s+week\b""", RegexOption.IGNORE_CASE).containsMatchIn(raw)) return "7"
+        if (Regex("""\bforecast\b""", RegexOption.IGNORE_CASE).containsMatchIn(raw)) {
+            val dayAnchored = Regex(
+                """\b(?:tomorrow|today|tonight|weekend|this\s+(?:week|weekend|afternoon|evening|morning))\b""",
+                RegexOption.IGNORE_CASE,
+            ).containsMatchIn(raw)
+            if (!dayAnchored) return "3"
+        }
+        return null
+    }
+
+    private fun wordToForecastDays(word: String): String? = when (word) {
+        "few", "couple" -> "3"
+        "one" -> "1"
+        "two" -> "2"
+        "three" -> "3"
+        "four" -> "4"
+        "five" -> "5"
+        "six" -> "6"
+        "seven" -> "7"
+        "eight" -> "8"
+        "nine" -> "9"
+        "ten" -> "10"
+        else -> word.toIntOrNull()?.toString()
     }
 
     // ── Parameter parsing helpers ─────────────────────────────────────────────

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2016,6 +2016,71 @@ class QuickIntentRouterTest {
             val result = regexOnlyRouter.route(input)
             assertRegexMatch(result, "get_weather", input)
         }
+
+        @ParameterizedTest(name = "Semantics (#1453): \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#weatherSemanticMatrix")
+        fun `should preserve weather parameter semantics`(
+            input: String,
+            expectedLocation: String?,
+            expectedForecastDays: String?,
+            expectedDay: String?,
+        ) {
+            val result = regexOnlyRouter.route(input)
+            assertRegexMatch(result, "get_weather", input)
+            val params = (result as QuickIntentRouter.RouteResult.RegexMatch).intent.params
+            assertEquals(expectedLocation, params["location"], "location for '$input' (params=$params)")
+            assertEquals(expectedForecastDays, params["forecast_days"], "forecast_days for '$input' (params=$params)")
+            assertEquals(expectedDay, params["day"], "day for '$input' (params=$params)")
+        }
+
+        @Test
+        fun `should not add forecast semantics to plain current weather queries`() {
+            for (input in listOf("What's the weather?", "What's the weather in Sydney?", "What's the weather today?")) {
+                val result = regexOnlyRouter.route(input)
+                assertRegexMatch(result, "get_weather", input)
+                val params = (result as QuickIntentRouter.RouteResult.RegexMatch).intent.params
+                assertNull(params["forecast_days"], "forecast_days for '$input': ${params["forecast_days"]}")
+                assertNull(params["day"], "day for '$input': ${params["day"]}")
+            }
+        }
+
+        @Test
+        fun `should never include temporal phrases in the location`() {
+            val inputs = listOf(
+                "What's the weather in Sydney for the next 5 days",
+                "What's the weather in Sydney over the next five days",
+                "What's the weather like this week in Auckland",
+                "What's the weather in Sydney this week",
+                "What's the forecast for Sydney over the next 5 days",
+            )
+            for (input in inputs) {
+                val result = regexOnlyRouter.route(input)
+                assertRegexMatch(result, "get_weather", input)
+                val location = (result as QuickIntentRouter.RouteResult.RegexMatch).intent.params["location"]
+                assertNotNull(location, "location missing for '$input'")
+                val lower = location!!.lowercase()
+                for (temporal in listOf("next", "week", "day", "tomorrow")) {
+                    assertFalse(lower.contains(temporal), "temporal '$temporal' leaked into location for '$input': $location")
+                }
+            }
+        }
+
+        @Test
+        fun `should not fake relative periods as forecasts or days`() {
+            // #1455 out of scope — weekend/daypart wording must not gain 3-day or day semantics.
+            val weekend = regexOnlyRouter.route("What's the forecast for Bundaberg this weekend?")
+            assertRegexMatch(weekend, "get_weather", "What's the forecast for Bundaberg this weekend?")
+            val weekendParams = (weekend as QuickIntentRouter.RouteResult.RegexMatch).intent.params
+            assertEquals("Bundaberg", weekendParams["location"])
+            assertNull(weekendParams["forecast_days"], "weekend must not become a 3-day forecast")
+            assertNull(weekendParams["day"], "weekend must not become day=tomorrow")
+
+            val afternoon = regexOnlyRouter.route("How hot will it be this afternoon?")
+            assertRegexMatch(afternoon, "get_weather", "How hot will it be this afternoon?")
+            val afternoonParams = (afternoon as QuickIntentRouter.RouteResult.RegexMatch).intent.params
+            assertNull(afternoonParams["forecast_days"], "afternoon must not become a forecast")
+            assertNull(afternoonParams["day"], "afternoon must not become a day")
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -3546,6 +3611,51 @@ class QuickIntentRouterTest {
             Arguments.of("sunset time"),
             Arguments.of("when is sunrise"),
             Arguments.of("when is sunset"),
+        )
+
+        /**
+         * #1453 — parameter-level weather semantic matrix: (input, expectedLocation,
+         * expectedForecastDays, expectedDay). A route to get_weather alone is not
+         * enough — the skill contract makes missing params mean "current conditions"
+         * or "device GPS", so every row asserts the exact relevant params.
+         */
+        @JvmStatic
+        fun weatherSemanticMatrix(): Stream<Arguments> = Stream.of(
+            // CURRENT — no forecast semantics
+            Arguments.of("What's the weather?", null, null, null),
+            Arguments.of("What's the weather in Sydney?", "Sydney", null, null),
+            Arguments.of("What's the weather in Sydney today", "Sydney", null, null),
+            // UNSPECIFIED FORECAST — explicit "forecast" without a horizon → 3-day default
+            Arguments.of("What's the forecast?", null, "3", null),
+            Arguments.of("What's the weather forecast?", null, "3", null),
+            Arguments.of("What's the weather forecast for Sydney?", "Sydney", "3", null),
+            Arguments.of("What's the forecast for Sydney?", "Sydney", "3", null),
+            Arguments.of("Weather forecast for Sydney", "Sydney", "3", null),
+            // EXPLICIT N-DAY — location and horizon preserved regardless of ordering
+            Arguments.of("What's the forecast for the next 5 days?", null, "5", null),
+            Arguments.of("What's the weather in Sydney for the next 5 days?", "Sydney", "5", null),
+            Arguments.of("What's the weather for the next 5 days in Sydney?", "Sydney", "5", null),
+            Arguments.of("What's the weather in Sydney over the next five days?", "Sydney", "5", null),
+            Arguments.of("What's the weather for Sydney next 5 days", "Sydney", "5", null),
+            Arguments.of("What's the forecast for Sydney over the next 5 days?", "Sydney", "5", null),
+            // FEW DAYS — "next few days" → 3
+            Arguments.of("What's the weather over the next few days?", null, "3", null),
+            Arguments.of("What's the weather over the next few days in Sydney?", "Sydney", "3", null),
+            // TOMORROW — including wording that previously emitted only raw_query
+            Arguments.of("What's the weather tomorrow?", null, null, "tomorrow"),
+            Arguments.of("What's the weather in Sydney tomorrow?", "Sydney", null, "tomorrow"),
+            Arguments.of("How hot will it be tomorrow?", null, null, "tomorrow"),
+            Arguments.of("How hot will it be in Sydney tomorrow?", "Sydney", null, "tomorrow"),
+            Arguments.of("What's the forecast for tomorrow?", null, null, "tomorrow"),
+            // THIS WEEK — historical #255 contract → 7-day horizon
+            Arguments.of("What's the weather this week?", null, "7", null),
+            Arguments.of("What's the weather like this week in Auckland?", "Auckland", "7", null),
+            Arguments.of("What's the weather in Sydney this week?", "Sydney", "7", null),
+            // NAMED METRICS — explicit location must not silently fall back to GPS
+            Arguments.of("What's the UV index in Sydney?", "Sydney", null, null),
+            Arguments.of("What's the air quality in Sydney?", "Sydney", null, null),
+            Arguments.of("When is sunset in Sydney?", "Sydney", null, null),
+            Arguments.of("Will it rain in Sydney today?", "Sydney", null, null),
         )
 
         // ── Save Memory ──────────────────────────────────────────────────────────

--- a/scripts/adb_harness/cases.py
+++ b/scripts/adb_harness/cases.py
@@ -93,15 +93,32 @@ PHASES: list[tuple[str, list[TestCase]]] = [
     ("weather", [
         # #1318 — bare/local weather and forecast
         TestCase("what's the weather", "get_weather"),
-        TestCase("what's the 5-day forecast", "get_weather"),
+        TestCase("what's the 5-day forecast", "get_weather",
+                 expect_params={"forecast_days": "5"}),
         # Location-based weather
-        TestCase("what's the weather in Auckland", "get_weather"),
+        TestCase("what's the weather in Auckland", "get_weather",
+                 expect_params={"location": "Auckland"}),
         TestCase("will it rain today", "get_weather"),
         TestCase("how hot is it outside", "get_weather"),
         TestCase("do I need an umbrella today", "get_weather"),
         TestCase("what's it like outside", "get_weather"),
         TestCase("is it gonna rain tomorrow", "get_weather"),
-        TestCase("temperature in Wellington", "get_weather"),
+        TestCase("temperature in Wellington", "get_weather",
+                 expect_params={"location": "Wellington"}),
+        # #1453 — weather semantic integrity: assert params, not just the route.
+        # "Action: get_weather" with the wrong parameters must fail these cases.
+        TestCase("What's the weather in Sydney for the next 5 days", "get_weather",
+                 expect_params={"location": "Sydney", "forecast_days": "5"}),
+        TestCase("What's the weather forecast for Sydney", "get_weather",
+                 expect_params={"location": "Sydney", "forecast_days": "3"}),
+        TestCase("What's the forecast", "get_weather",
+                 expect_params={"forecast_days": "3"}),
+        TestCase("What's the weather like this week in Auckland", "get_weather",
+                 expect_params={"location": "Auckland", "forecast_days": "7"}),
+        TestCase("How hot will it be tomorrow", "get_weather",
+                 expect_params={"day": "tomorrow"}),
+        TestCase("What's the UV index in Sydney", "get_weather",
+                 expect_params={"location": "Sydney"}),
     ]),
     ("media", [
         # play_media — generic


### PR DESCRIPTION
Closes #1453

## Root cause

`QuickIntentRouter` has ~30 overlapping weather regexes, each returning its own final param map with no shared post-match semantic normalisation. Two observed failures:

- `What's the weather in Sydney for the next 5 days` → generic city pattern captures the whole tail → `location="Sydney for the next 5 days"` → geocode fails ("I couldn't find that location for weather...").
- `What's the weather forecast for Sydney` → routes with `location=Sydney` but no `forecast_days`; `GetWeatherSkill` deterministically treats missing horizon as current conditions.

Same class: bare `forecast` → empty map (current conditions); `this week` → no horizon; `How hot will it be tomorrow?` → `raw_query` only (unconsumed by the skill); UV/AQI/sunset/rain with a named place → no location (silent GPS fallback).

## Implementation

**Central normaliser** — `normalizeWeatherParams()` applied at the `tryMatchPatterns` seam so every deterministic `get_weather` regex match shares one semantic path:

- never overwrites explicit `location` / `day` / `forecast_days`
- strips temporal tails from captured locations before geocoding (`"Sydney for the next 5 days"` → `Sydney`)
- `tomorrow` → `day=tomorrow` (including wording that previously emitted only `raw_query`)
- `next N days` / `N day forecast` (digit + word forms) → `forecast_days=N`; `next few days` → 3
- `this week` → `forecast_days=7` (restores historical #255 contract)
- explicit `forecast` with no horizon/day anchor → `forecast_days=3`; ordinary current-weather queries never gain forecast semantics
- narrow weather-specific location recovery for metric patterns (UV/AQI/sunset); temporal prepositions (`for the next 5 days`) are never mistaken for locations

**Matcher changes** (only where no base matcher existed): plain `forecast for <location>`; `weather like/this week in <location>`; rain pattern with optional `in/for/at <place>`; tomorrow-metric pattern with optional named location.

No #1455 work: weekend/daypart wording is excluded from the 3-day default and day mapping; `GetWeatherSkill` / `GetWeatherUnifiedSkill` untouched.

## Tests

- `QuickIntentRouterTest` — added parameter-level semantic matrix (30 rows) + negative guards: current queries gain no forecast semantics, temporal phrases never appear in `location`, weekend/daypart not faked. **Passing** (143 GetWeather executions).
- `:core:skills:testDebugUnitTest` (full module) — **passing**.
- Host-side harness: `scripts/tests/test_harness_cumulative_semantics.py` 6/6 OK; `adb_skill_test.py --dry-run --phases weather` selects 15 cases.
- `scripts/adb_harness/cases.py` — representative weather cases now assert `expect_params` (location/forecast_days/day), so `Action: get_weather` with wrong parameters fails: the two Sydney reproductions, `What's the forecast` → 3, Auckland `this week` → 7, `How hot will it be tomorrow` → `day=tomorrow`, `What's the UV index in Sydney` → `location=Sydney`.

## Semantic matrix covered (exact params asserted)

| Scope | Implicit | Named |
|---|---|---|
| Current | `What's the weather?` → no forecast/day | `What's the weather in Sydney?` → `location=Sydney` |
| Unspecified forecast | `What's the forecast?` → `forecast_days=3` | `What's the weather forecast for Sydney?` / `What's the forecast for Sydney?` → `location=Sydney, forecast_days=3` |
| Explicit N-day | `…forecast for the next 5 days?` → 5 | location before/after duration, digit + word forms → correct `location` + `forecast_days` |
| Few days | `…over the next few days?` → 3 | `…in Sydney?` → `Sydney` + 3 |
| Tomorrow | `What's the weather tomorrow?` / `How hot will it be tomorrow?` → `day=tomorrow` | `…in Sydney tomorrow?` / `How hot will it be in Sydney tomorrow?` → location + `day=tomorrow` |
| This week | `What's the weather this week?` → 7 | `What's the weather like this week in Auckland?` / `…in Sydney this week?` → location + 7 |
| Named metrics | — | UV / AQI / sunset / rain in Sydney → `location=Sydney` |

## Remaining limitation

Relative periods (`this weekend`, `this afternoon/evening`) still route with current-conditions semantics — unchanged pre-existing behavior, tracked separately in #1455.

Do not merge — wait for review.