### PR TITLE
fix(#1454): scope TTS pronoun normalisation to user-supplied values

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -621,6 +621,7 @@ class ActionsViewModel @Inject constructor(
                     pending.inputMode,
                     result.entity.resultText,
                     spokenOverride = result.spokenSummary,
+                    userValues = pending.params.values,
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "ActionsViewModel: onPhonePermissionGranted failed — ${e.message}", e)
@@ -796,6 +797,7 @@ class ActionsViewModel @Inject constructor(
                     pending.inputMode,
                     result.entity.resultText,
                     spokenOverride = result.spokenSummary,
+                    userValues = pending.params.values,
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "ActionsViewModel: onWeatherLocationPermissionGranted failed — ${e.message}", e)
@@ -907,6 +909,7 @@ class ActionsViewModel @Inject constructor(
                     pending.inputMode,
                     result.entity.resultText,
                     spokenOverride = result.spokenSummary,
+                    userValues = pending.params.values,
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "ActionsViewModel: onContactPermissionGranted failed — ${e.message}", e)
@@ -999,6 +1002,7 @@ class ActionsViewModel @Inject constructor(
                     pending.inputMode,
                     result.entity.resultText,
                     spokenOverride = result.spokenSummary,
+                    userValues = pending.params.values,
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "ActionsViewModel: onCalendarPermissionGranted failed — ${e.message}", e)
@@ -1255,6 +1259,7 @@ class ActionsViewModel @Inject constructor(
                         pending.inputMode,
                         result.entity.resultText,
                         spokenOverride = result.spokenSummary,
+                        userValues = pending.params.values,
                     )
                 } catch (e: Exception) {
                     Log.e(TAG, "ActionsViewModel: onDndResumeCheck failed — ${e.message}", e)
@@ -1331,6 +1336,7 @@ class ActionsViewModel @Inject constructor(
                         pending.inputMode,
                         result.entity.resultText,
                         spokenOverride = result.spokenSummary,
+                        userValues = pending.params.values,
                     )
                 } catch (e: Exception) {
                     Log.e(TAG, "ActionsViewModel: onWriteSettingsResumeCheck failed — ${e.message}", e)
@@ -1422,7 +1428,7 @@ class ActionsViewModel @Inject constructor(
                                 inputMode = inputMode,
                             )
                             quickActionDao.insert(result.entity)
-                            speakForVoice(inputMode, result.entity.resultText, spokenOverride = result.spokenSummary)
+                            speakForVoice(inputMode, result.entity.resultText, spokenOverride = result.spokenSummary, userValues = routeResult.intent.params.values)
                         }
                     }
                     is QuickIntentRouter.RouteResult.ClassifierMatch -> {
@@ -1436,7 +1442,7 @@ class ActionsViewModel @Inject constructor(
                                 inputMode = inputMode,
                             )
                             quickActionDao.insert(result.entity)
-                            speakForVoice(inputMode, result.entity.resultText, spokenOverride = result.spokenSummary)
+                            speakForVoice(inputMode, result.entity.resultText, spokenOverride = result.spokenSummary, userValues = routeResult.intent.params.values)
                         }
                     }
                 }
@@ -1542,6 +1548,7 @@ class ActionsViewModel @Inject constructor(
                     result.entity.resultText,
                     delayMs = if (pending.inputMode == InputMode.Voice) VOICE_REPLY_TTS_DELAY_MS else 0L,
                     spokenOverride = result.spokenSummary,
+                    userValues = mergedParams.values,
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "ActionsViewModel: onSlotReply failed — ${e.message}", e)
@@ -1998,11 +2005,12 @@ class ActionsViewModel @Inject constructor(
         text: String,
         delayMs: Long = 0L,
         spokenOverride: String? = null,
+        userValues: Collection<String> = emptyList(),
     ) {
         if (inputMode != InputMode.Voice) return
         if (!spokenResponsesEnabled) return
         val summary = spokenOverride?.takeIf { it.isNotBlank() }
-            ?: normalisePronounsForTts(toSpokenSummary(text))
+            ?: normaliseUserValuesForTts(toSpokenSummary(text), userValues)
         if (summary.isBlank()) return
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()
@@ -2067,6 +2075,18 @@ class ActionsViewModel @Inject constructor(
         }
         return toSpokenSummary((prefix + interpolated).trim())
     }
+
+    /**
+     * Applies [normalisePronounsForTts] only to known user-supplied values embedded in
+     * assistant-authored result text, keeping the surrounding framing literal (#1454).
+     * Mirrors [buildSpokenSlotPrompt]: user-originated phrases such as "my wife" are echoed
+     * naturally as "your wife", while Jandal-authored first-person text ("I couldn't find
+     * that location…") is spoken verbatim.
+     */
+    private fun normaliseUserValuesForTts(text: String, userValues: Collection<String>): String =
+        userValues.fold(text) { acc, value ->
+            if (value.isBlank()) acc else acc.replace(value, normalisePronounsForTts(value))
+        }
 
     private fun toSpokenSummary(text: String): String {
         val normalized = text.lineSequence()

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -4107,4 +4107,109 @@ class ActionsViewModelVoiceTest {
         // which happens upstream. This test documents current behaviour.
         assertEquals("Type your request in the quick command bar.", viewModel.error.value)
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // #1454 — pronoun normalisation provenance (assistant text vs user values)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `assistant authored error text is spoken from Jandal perspective without pronoun rewrite`() = runTest(dispatcher) {
+        val weatherSkill = mockk<Skill>()
+        val displayText =
+            "I couldn't find that location for weather. Try another city, like \"weather in Brisbane\"."
+
+        every { quickIntentRouter.route("what's the weather in Brisbane") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "get_weather",
+                    params = mapOf("location" to "Brisbane"),
+                ),
+            )
+        every { skillRegistry.get("get_weather") } returns weatherSkill
+        every { weatherSkill.name } returns "get_weather"
+        every { weatherSkill.description } returns "Get weather"
+        every { weatherSkill.schema } returns SkillSchema()
+        coEvery { weatherSkill.execute(any()) } returns SkillResult.DirectReply(displayText)
+
+        viewModel.executeAction("what's the weather in Brisbane", InputMode.Voice)
+        advanceUntilIdle()
+
+        // Spoken text must keep Jandal's first person — no "You couldn't find…".
+        coVerify(exactly = 1) {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> { it.text == displayText },
+            )
+        }
+        // Displayed result text is unaffected.
+        coVerify(exactly = 1) {
+            quickActionDao.insert(match { it.resultText == displayText })
+        }
+    }
+
+    @Test
+    fun `assistant authored first person variants are spoken verbatim`() = runTest(dispatcher) {
+        val variants = listOf(
+            "I'm unable to do that.",
+            "I've already checked.",
+            "I'll try again.",
+            "I'd need a location.",
+            "That's my result.",
+            "The choice is mine.",
+            "I can handle it myself.",
+        )
+        variants.forEachIndexed { index, text ->
+            val query = "speak variant ${'a' + index}"
+            val intentName = "speak_variant_$index"
+            val skill = mockk<Skill>()
+            every { quickIntentRouter.route(query) } returns
+                QuickIntentRouter.RouteResult.RegexMatch(
+                    QuickIntentRouter.MatchedIntent(intentName, emptyMap()),
+                )
+            every { skillRegistry.get(intentName) } returns skill
+            every { skill.name } returns intentName
+            every { skill.description } returns "Speak variant"
+            every { skill.schema } returns SkillSchema()
+            coEvery { skill.execute(any()) } returns SkillResult.DirectReply(text)
+
+            viewModel.executeAction(query, InputMode.Voice)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                voiceOutputController.speak(
+                    match<VoiceSpeakRequest> { it.text == text },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `user originated contact value in result text still receives second person normalisation`() = runTest(dispatcher) {
+        val smsSkill = mockk<Skill>()
+        every { quickIntentRouter.route("send a text message to my wife") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "send_sms",
+                    params = mapOf("contact" to "my wife"),
+                ),
+            )
+        every { skillRegistry.get("send_sms") } returns smsSkill
+        every { smsSkill.name } returns "send_sms"
+        every { smsSkill.description } returns "Send SMS"
+        every { smsSkill.schema } returns SkillSchema()
+        coEvery { smsSkill.execute(any()) } returns SkillResult.Success("SMS composer opened for my wife.")
+
+        viewModel.executeAction("send a text message to my wife", InputMode.Voice)
+        advanceUntilIdle()
+
+        // #828: user-originated values echoed in the result still flip to second person.
+        coVerify(exactly = 1) {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> { it.text == "SMS composer opened for your wife." },
+            )
+        }
+        // Displayed result text is unaffected.
+        coVerify(exactly = 1) {
+            quickActionDao.insert(match { it.resultText == "SMS composer opened for my wife." })
+        }
+    }
 }


### PR DESCRIPTION
Closes #1454

## Root cause

`ActionsViewModel.speakForVoice()` applied `normalisePronounsForTts()` as a blanket transform to any assistant-authored result/error text that fell through to the fallback speech path:

```kotlin
val summary = spokenOverride?.takeIf { it.isNotBlank() }
    ?: normalisePronounsForTts(toSpokenSummary(text))
```

First-person→second-person rewriting is only correct for user-originated phrases (the #828 use case). When the text is Jandal-authored — e.g. `GetWeatherSkill`'s `DirectReply("I couldn't find that location for weather. …")`, which has no spoken summary — the blanket transform corrupted it into "You couldn't find that location for weather…". This is the same over-broad application class fixed for slot prompts in #1012 (see `buildSpokenSlotPrompt` KDoc: only interpolated user values are flipped, framing stays literal).

## Change

Exactly one behavioural change, at the existing Quick Actions speech call site (`feature/chat/.../ActionsViewModel.kt`):

- `speakForVoice()` gained a `userValues: Collection<String> = emptyList()` parameter; the fallback now runs the new `normaliseUserValuesForTts()` helper instead of blanket `normalisePronounsForTts(toSpokenSummary(text))`.
- `normaliseUserValuesForTts()` applies `normalisePronounsForTts()` **only to each known user-supplied value occurrence** embedded in the text, leaving all surrounding assistant-authored framing verbatim — mirroring `buildSpokenSlotPrompt`'s per-value pattern.
- Callers that know user-supplied values pass them: `executeAction` route params, `onSlotReply` merged params, and the six permission-retry handlers (`pending.params`). Error/fallthrough/handoff paths have no user values and pass nothing.

No changes to `normalisePronounsForTts()` (utility unchanged, its 14 unit tests untouched), `VoiceOutputController`, speech chunking, slot prompts, or displayed text.

## Why #828 behaviour remains preserved

- **Slot prompts:** `buildSpokenSlotPrompt` still flips pronouns on interpolated user values only (`{contact}` = "my wife" → "your wife") and passes the result via `spokenOverride` — unchanged code path.
- **Result echoes:** user-originated values embedded in skill results still flip — `send_sms`'s `"SMS composer opened for my wife."` is spoken as `"SMS composer opened for your wife."` because `contact = "my wife"` is a known user value.
- **Assistant text:** no longer touched — `"I couldn't find that location for weather."` is spoken verbatim.

## Tests added (`ActionsViewModelVoiceTest`)

1. `assistant authored error text is spoken from Jandal perspective without pronoun rewrite` — weather `DirectReply` with the issue's exact text spoken with `I`, not `you`; displayed `resultText` asserted unchanged.
2. `assistant authored first person variants are spoken verbatim` — compact loop over `I'm` / `I've` / `I'll` / `I'd` / `my` / `mine` / `myself` representative examples, each exercised through the real voice speech path.
3. `user originated contact value in result text still receives second person normalisation` — send_sms result echo `"SMS composer opened for my wife."` spoken as `"…your wife."`; displayed `resultText` asserted unchanged.

All three exercise the actual `executeAction` → skill → `speakForVoice` → `voiceOutputController.speak()` path, not just the string utility.

## Verification

- `./gradlew :feature:chat:testDebugUnitTest --tests "com.kernel.ai.feature.chat.ActionsViewModelVoiceTest"` → **132/132 pass** (includes the 3 new tests).
- `./gradlew :feature:chat:testDebugUnitTest` (full module) → **616/616 pass, 0 skipped**, including `normalisePronounsForTts` utility tests (14/14), slot-prompt `your wife` voice tests, and `ChatViewModelVoiceTest` (42/42).

Do not merge — wait for review.