### PR TITLE
fix(#1455): explicit weekend weather period, drop unsupported daypart routing

### DIFF
--- a/app/src/test/java/com/kernel/ai/navigation/LearnExampleRoutingTest.kt
+++ b/app/src/test/java/com/kernel/ai/navigation/LearnExampleRoutingTest.kt
@@ -4,6 +4,7 @@ import com.kernel.ai.core.skills.QuickIntentRouter
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -114,6 +115,39 @@ class LearnExampleRoutingTest {
             assertNotEquals("start_meal_planner", intentName) {
                 "Freeform example '${ex.id}' routed to 'start_meal_planner', but should be freeform"
             }
+        }
+    }
+
+    // ── #1455 — weather_bundaberg semantic regression ────────────────────────
+    // Route-only coverage is not enough for the advertised weekend phrase: it must
+    // carry the explicit weekend contract between QIR and the weather skill (the
+    // skill-side selection of the actual weekend days from the daily forecast is
+    // proven by GetWeatherWeekendTest on deterministic fixtures).
+
+    @Test
+    fun `weather_bundaberg example carries explicit weekend semantics`() {
+        val ex = requireNotNull(learnExamplesById["weather_bundaberg"]) {
+            "weather_bundaberg must exist in the Learn catalogue"
+        }
+        val result = router.route(ex.prompt)
+        val params = (result as QuickIntentRouter.RouteResult.RegexMatch).intent.params
+        assertEquals("Bundaberg", params["location"], "params=$params")
+        assertEquals("weekend", params["period"], "params=$params")
+        assertNull(params["forecast_days"], "weekend must not become a 3-day forecast (params=$params)")
+        assertNull(params["day"], "weekend must not become day=tomorrow (params=$params)")
+    }
+
+    @Test
+    fun `no Learn weather example advertises unsupported dayparts`() {
+        // #1455 — the weather skill has no hourly/daypart contract, so the catalogue
+        // must never advertise "this afternoon/evening/morning" as a supported
+        // get_weather example (it would silently return current conditions).
+        val daypartRegex = Regex("""\bthis\s+(?:afternoon|evening|morning)\b""", RegexOption.IGNORE_CASE)
+        val offenders = allLearnExamples.filter { ex ->
+            ex.expectedRoute == "get_weather" && daypartRegex.containsMatchIn(ex.prompt)
+        }
+        assertEquals(emptyList<LearnExample>(), offenders) {
+            "Learn weather examples must not advertise unsupported dayparts: $offenders"
         }
     }
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1608,7 +1608,10 @@ class QuickIntentRouter(
         // Multi-day forecast (digit): "what's the forecast for the next 7 days" /
         // "what's the weather forecast for the next 7 days"
 
-        // "What's the forecast for Bundaberg this weekend?"
+        // "What's the forecast for Bundaberg this weekend?" — the period is emitted
+        // explicitly here; other weekend phrasings are covered centrally by the
+        // weather normaliser (period=weekend) so none of them degrade to current
+        // conditions or the 3-day unspecified-forecast default (#1455).
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
@@ -1619,6 +1622,7 @@ class QuickIntentRouter(
                 val params = mutableMapOf<String, String>()
                 val location = match.groupValues[1].trim()
                 if (location.isNotBlank()) params["location"] = location
+                params["period"] = "weekend"
                 params
             },
             requiredSlots = emptyMap(),
@@ -2267,14 +2271,17 @@ class QuickIntentRouter(
             paramExtractor = { _, _ -> emptyMap() },
         ),
 
-        // "How hot will it be tomorrow?" / "How cold will it be this afternoon?" /
+        // "How hot will it be tomorrow?" / "How cold will it be this weekend?" /
         // "How hot will it be in Sydney tomorrow?" — emits raw_query; the weather
-        // normaliser turns "tomorrow" into day=tomorrow and keeps any named location.
-        // (this afternoon/evening/weekend remain #1455 relative periods — not faked.)
+        // normaliser turns "tomorrow" into day=tomorrow, "this weekend" into
+        // period=weekend, and keeps any named location.
+        // (this afternoon/evening/morning have no hourly contract in the weather
+        // skill — they are centrally vetoed from all get_weather patterns in route()
+        // and fall through to the free-form path instead, #1455.)
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """(?:how\s+(?:hot|cold|warm)\s+will\s+it\s+be\s+(?:(?:in|for|at)\s+([\w\s,]+?)\s+)?(?:tomorrow|today)\s*[.!?]*$|how\s+(?:hot|cold|warm)\s+will\s+it\s+be\s+this\s+(?:afternoon|evening|morning|weekend)\s*[.!?]*$|what(?:'s| is)\s+(?:the\s+)?(?:temperature|forecast)\s+(?:going\s+to\s+be|gonna\s+be)\s+(?:tomorrow|today|this\s+(?:afternoon|evening|morning|weekend)))""",
+                """(?:how\s+(?:hot|cold|warm)\s+will\s+it\s+be\s+(?:(?:in|for|at)\s+([\w\s,]+?)\s+)?(?:tomorrow|today)\s*[.!?]*$|how\s+(?:hot|cold|warm)\s+will\s+it\s+be\s+this\s+weekend\s*[.!?]*$|what(?:'s| is)\s+(?:the\s+)?(?:temperature|forecast)\s+(?:going\s+to\s+be|gonna\s+be)\s+(?:tomorrow|today|this\s+weekend))""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, raw ->
@@ -4563,8 +4570,12 @@ class QuickIntentRouter(
         //   Pass 2: fallback/catch-all patterns (isFallback = true) — only if Pass 1 misses.
         // This eliminates first-match-wins fragility without requiring manual ordering of every
         // pattern relative to every catch-all.
-        val specificPatterns = patterns.filter { !it.isFallback }
-        val fallbackPatterns = patterns.filter { it.isFallback }
+        // #1455 — unsupported dayparts ("this afternoon/evening/morning") have no hourly
+        // weather contract: drop every deterministic get_weather pattern for them so they
+        // fall through to the free-form path rather than silently returning current conditions.
+        val daypartWeatherBlocked = weatherUnsupportedDaypart.containsMatchIn(trimmed)
+        val specificPatterns = patterns.filter { !it.isFallback && !(daypartWeatherBlocked && it.intentName == "get_weather") }
+        val fallbackPatterns = patterns.filter { it.isFallback && !(daypartWeatherBlocked && it.intentName == "get_weather") }
 
         tryMatchPatterns(fractionNormalized, specificPatterns)?.let { return it }
         tryMatchPatterns(fractionNormalized, fallbackPatterns)?.let { return it }
@@ -4573,6 +4584,11 @@ class QuickIntentRouter(
         // Stage 2: BERT-tiny classifier (if available)
         classifier?.let { cls ->
             val result = cls.classify(trimmed)
+            // #1455 — same daypart guard as Stage 1: never let the classifier claim a
+            // get_weather answer for wording the weather skill cannot represent.
+            if (daypartWeatherBlocked && result?.intentName == "get_weather") {
+                return RouteResult.FallThrough(input = trimmed)
+            }
             if (result != null && result.confidence >= similarityThreshold) {
                 val isFastPath = result.intentName in FAST_PATH_INTENTS
                 val fastPathOk = isFastPath && result.confidence >= FAST_PATH_THRESHOLD
@@ -4635,6 +4651,23 @@ class QuickIntentRouter(
         RegexOption.IGNORE_CASE,
     )
 
+    /** #1455 — explicit weekend wording. Takes precedence over the unspecified-forecast default. */
+    private val weatherWeekendPeriod = Regex(
+        """\bthis\s+weekend\b""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /**
+     * #1455 — daypart periods the weather skill has no hourly contract for. Any
+     * deterministic get_weather pattern (and the classifier) is skipped for wording
+     * like "this afternoon/evening/morning" so these queries fall through to the
+     * free-form path instead of silently returning current conditions.
+     */
+    private val weatherUnsupportedDaypart = Regex(
+        """\bthis\s+(?:afternoon|evening|morning)\b""",
+        RegexOption.IGNORE_CASE,
+    )
+
     private fun normalizeWeatherParams(raw: String, params: Map<String, String>): Map<String, String> {
         val normalized = LinkedHashMap(params)
 
@@ -4656,6 +4689,13 @@ class QuickIntentRouter(
             Regex("""\btomorrow\b""", RegexOption.IGNORE_CASE).containsMatchIn(raw)
         ) {
             normalized["day"] = "tomorrow"
+        }
+
+        // "this weekend" → period=weekend (#1455): the weekend period is explicit
+        // weather-skill semantics and takes precedence over the unspecified-forecast
+        // 3-day default below (never overwrite an explicit period).
+        if (normalized["period"].isNullOrBlank() && weatherWeekendPeriod.containsMatchIn(raw)) {
+            normalized["period"] = "weekend"
         }
 
         // Forecast horizon when none was extracted (never overwrite explicit).
@@ -4692,6 +4732,9 @@ class QuickIntentRouter(
      * the established 3-day default; "this week" → 7 days (historical #255 contract).
      */
     private fun weatherForecastDays(raw: String): String? {
+        // #1455 — an explicit weekend request is a period, not an unspecified
+        // forecast: it must never gain the 3-day default (or any other horizon).
+        if (weatherWeekendPeriod.containsMatchIn(raw)) return null
         weatherNextNDays.find(raw)?.let { m ->
             return wordToForecastDays(m.groupValues[1].lowercase())
         }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -493,6 +493,14 @@ class QuickIntentRouter(
          * `play_media` and the terse smart-home `(.+?)\s+on/off` catch-alls.
          */
         val isFallback: Boolean = false,
+        /**
+         * #1455 — when true, this get_weather pattern is exempt from the central daypart
+         * veto in [route]. Exemption is only for today-anchored value queries (sunrise/sunset
+         * times, UV index, air quality) whose answer is consistent with a "this
+         * afternoon/evening/morning" qualifier — they report today's value, not a future
+         * daypart forecast the skill cannot represent.
+         */
+        val exemptFromDaypartVeto: Boolean = false,
     )
 
     private val patterns: List<IntentPattern> = listOf(
@@ -2318,6 +2326,8 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
+            // Today-anchored value query: "is the UV high this morning?" answers today's UV.
+            exemptFromDaypartVeto = true,
         ),
         // Air quality queries: "what's the air quality", "what's the AQI"
         IntentPattern(
@@ -2327,6 +2337,8 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
+            // Today-anchored value query: "is the air quality good this morning?" answers today's AQI.
+            exemptFromDaypartVeto = true,
         ),
         // Sunrise/sunset queries: "what time is sunrise", "when does the sun set"
         IntentPattern(
@@ -2336,6 +2348,8 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
+            // Today-anchored value query: "what time is sunset this evening?" answers today's sunset.
+            exemptFromDaypartVeto = true,
         ),
         // ── Volume ──
         // Numeric-level forms must come BEFORE direction-only patterns to win the match
@@ -4573,9 +4587,11 @@ class QuickIntentRouter(
         // #1455 — unsupported dayparts ("this afternoon/evening/morning") have no hourly
         // weather contract: drop every deterministic get_weather pattern for them so they
         // fall through to the free-form path rather than silently returning current conditions.
+        // Today-anchored value patterns (sunrise/sunset, UV, AQI) are exempt — their answer
+        // is consistent with the daypart qualifier, see IntentPattern.exemptFromDaypartVeto.
         val daypartWeatherBlocked = weatherUnsupportedDaypart.containsMatchIn(trimmed)
-        val specificPatterns = patterns.filter { !it.isFallback && !(daypartWeatherBlocked && it.intentName == "get_weather") }
-        val fallbackPatterns = patterns.filter { it.isFallback && !(daypartWeatherBlocked && it.intentName == "get_weather") }
+        val specificPatterns = patterns.filter { !it.isFallback && !(daypartWeatherBlocked && it.intentName == "get_weather" && !it.exemptFromDaypartVeto) }
+        val fallbackPatterns = patterns.filter { it.isFallback && !(daypartWeatherBlocked && it.intentName == "get_weather" && !it.exemptFromDaypartVeto) }
 
         tryMatchPatterns(fractionNormalized, specificPatterns)?.let { return it }
         tryMatchPatterns(fractionNormalized, fallbackPatterns)?.let { return it }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -23,6 +23,8 @@ import okhttp3.Request
 import org.json.JSONObject
 import javax.inject.Inject
 import javax.inject.Singleton
+import java.time.DayOfWeek
+import java.time.LocalDate
 import kotlin.math.roundToInt
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
@@ -142,6 +144,63 @@ internal fun buildSingleDayForecastSpoken(
     }
 }
 
+/** Build a spoken summary for a weekend forecast (Saturday + Sunday of the intended weekend). */
+internal fun buildWeekendForecastSpoken(
+    locationLabel: String?,
+    days: List<Triple<String, String, Pair<Double?, Double?>>>,
+): String {
+    val place = locationForSpeech(locationLabel)
+    return buildString {
+        append("$place weekend forecast.")
+        for ((date, description, temps) in days) {
+            val (high, low) = temps
+            val parts = buildList {
+                if (description.isNotBlank() && description != "Unknown") add(description.lowercase())
+                if (high != null && !high.isNaN()) add("high ${high.toRoundedDegreesText()}")
+                if (low != null && !low.isNaN()) add("low ${low.toRoundedDegreesText()}")
+            }
+            append(" $date")
+            if (parts.isNotEmpty()) append(": ${parts.joinToString(", ")}")
+            append(".")
+        }
+    }
+}
+
+/**
+ * #1455 — select the indices of the intended weekend days from the daily dates returned
+ * by the weather provider. Derived from the actual returned dates rather than a general
+ * natural-language date parser:
+ *
+ * - forecast starting on Saturday → the current weekend (Saturday + following Sunday);
+ * - forecast starting on Sunday → the current weekend's remaining day (Sunday only);
+ * - otherwise → the next Saturday and the Sunday immediately after it.
+ *
+ * Only the intended weekend day(s) are returned — never the intervening weekdays — and
+ * a day that falls outside the returned horizon is never fabricated.
+ */
+internal fun selectWeekendDayIndices(dates: List<String>): List<Int> {
+    if (dates.isEmpty()) return emptyList()
+    val parsed = dates.map { runCatching { LocalDate.parse(it) }.getOrNull() }
+    val first = parsed[0] ?: return emptyList()
+    return when (first.dayOfWeek) {
+        DayOfWeek.SATURDAY -> buildList {
+            add(0)
+            if (parsed.getOrNull(1)?.dayOfWeek == DayOfWeek.SUNDAY) add(1)
+        }
+        DayOfWeek.SUNDAY -> listOf(0)
+        else -> {
+            val saturdayIndex = parsed.indexOfFirst { it?.dayOfWeek == DayOfWeek.SATURDAY }
+            if (saturdayIndex < 0) return emptyList()
+            buildList {
+                add(saturdayIndex)
+                if (parsed.getOrNull(saturdayIndex + 1)?.dayOfWeek == DayOfWeek.SUNDAY) {
+                    add(saturdayIndex + 1)
+                }
+            }
+        }
+    }
+}
+
 /** WMO weather code to emoji mapping. */
 internal fun wmoEmoji(code: Int): String = when (code) {
     0 -> "☀️"
@@ -242,6 +301,157 @@ private val Context.weatherDataStore: DataStore<Preferences> by preferencesDataS
 
 private const val TAG = "KernelAI"
 
+/**
+ * #1455 — parse a daily Open-Meteo forecast response restricted to the intended
+ * weekend days (see [selectWeekendDayIndices]). Pure function of the response JSON,
+ * so fresh fetches and stale-cache fallback always select the same weekend days.
+ */
+internal fun parseWeekendResponse(json: String, displayName: String?, skillName: String = "get_weather_gps"): SkillResult {
+    val obj = JSONObject(json)
+    val daily = obj.getJSONObject("daily")
+    val dates = daily.getJSONArray("time")
+    val maxTemps = daily.getJSONArray("temperature_2m_max")
+    val minTemps = daily.getJSONArray("temperature_2m_min")
+    val precip = daily.getJSONArray("precipitation_sum")
+    val codes = daily.getJSONArray("weather_code")
+    val uvMaxArr = daily.optJSONArray("uv_index_max")
+    val sunriseArr = daily.optJSONArray("sunrise")
+    val sunsetArr = daily.optJSONArray("sunset")
+
+    val len = dates.length()
+    if (len == 0) return SkillResult.Failure(skillName, "No forecast data returned.")
+    if (maxTemps.length() != len || minTemps.length() != len ||
+        precip.length() != len || codes.length() != len
+    ) {
+        return SkillResult.Failure(skillName, "Incomplete forecast data (mismatched array lengths).")
+    }
+
+    val indices = selectWeekendDayIndices((0 until len).map { dates.getString(it) })
+    if (indices.isEmpty()) {
+        return SkillResult.Failure(skillName, "Weekend forecast not available within the forecast horizon.")
+    }
+
+    val locationLabel = displayName ?: "GPS location"
+    val text = buildString {
+        append("$locationLabel weekend forecast:\n")
+        for (i in indices) {
+            val dateStr = dates.getString(i)
+            val formattedDate = formatForecastDate(dateStr)
+            val code = codes.optInt(i, -1)
+            val emoji = wmoEmoji(code)
+            val desc = wmoDescription(code)
+            val high = maxTemps.optDouble(i, Double.NaN)
+            val low = minTemps.optDouble(i, Double.NaN)
+            val rain = precip.optDouble(i, 0.0)
+            val highStr = if (!high.isNaN()) "%.0f°C".format(high) else "?°C"
+            val lowStr = if (!low.isNaN()) "%.0f°C".format(low) else "?°C"
+            val rainStr = "%.0fmm rain".format(rain)
+            val uvMax = uvMaxArr?.let { if (i < it.length() && !it.isNull(i)) it.getDouble(i) else null }
+            val uvStr = uvMax?.let { " | UV max: %.0f (%s)".format(it, uvIndexLabel(it)) } ?: ""
+            val sunrise = sunriseArr?.let { if (i < it.length() && !it.isNull(i)) it.getString(i).substringAfterLast("T") else null }
+            val sunset = sunsetArr?.let { if (i < it.length() && !it.isNull(i)) it.getString(i).substringAfterLast("T") else null }
+            val sunStr = when {
+                sunrise != null && sunset != null -> " | 🌅 $sunrise / $sunset"
+                sunrise != null -> " | 🌅 $sunrise"
+                sunset != null -> " | 🌇 $sunset"
+                else -> ""
+            }
+            append("$formattedDate: $emoji $desc $highStr / $lowStr, $rainStr$uvStr$sunStr\n")
+        }
+    }.trimEnd()
+
+    val forecastDays = indices.map { i ->
+        val dateStr = dates.getString(i)
+        val code = codes.optInt(i, -1)
+        val high = maxTemps.optDouble(i, Double.NaN)
+        val low = minTemps.optDouble(i, Double.NaN)
+        val rain = precip.optDouble(i, 0.0)
+        val uvMax = uvMaxArr?.let { if (i < it.length() && !it.isNull(i)) it.getDouble(i) else null }
+        val sunrise = sunriseArr?.let { if (i < it.length() && !it.isNull(i)) it.getString(i).substringAfterLast("T") else null }
+        val sunset = sunsetArr?.let { if (i < it.length() && !it.isNull(i)) it.getString(i).substringAfterLast("T") else null }
+        val sunStr = when {
+            sunrise != null && sunset != null -> "Sunrise $sunrise • Sunset $sunset"
+            sunrise != null -> "Sunrise $sunrise"
+            sunset != null -> "Sunset $sunset"
+            else -> null
+        }
+        ToolPresentation.ForecastDay(
+            date = formatForecastDate(dateStr),
+            emoji = wmoEmoji(code),
+            description = wmoDescription(code),
+            highText = if (!high.isNaN()) "High %.0f°C".format(high) else null,
+            lowText = if (!low.isNaN()) "Low %.0f°C".format(low) else null,
+            precipText = "%.0fmm rain".format(rain).takeIf { rain > 0.0 },
+            uvText = uvMax?.let { "UV max %.0f (%s)".format(it, uvIndexLabel(it)) },
+            sunText = sunStr,
+        )
+    }
+    val spokenDays = indices.map { i ->
+        Triple(
+            formatForecastDate(dates.getString(i)),
+            wmoDescription(codes.optInt(i, -1)),
+            Pair(
+                maxTemps.optDouble(i, Double.NaN).takeUnless { it.isNaN() },
+                minTemps.optDouble(i, Double.NaN).takeUnless { it.isNaN() },
+            ),
+        )
+    }
+
+    val first = indices.first()
+    val firstCode = codes.optInt(first, -1)
+    val firstHigh = maxTemps.optDouble(first, Double.NaN)
+    val firstLow = minTemps.optDouble(first, Double.NaN)
+    val firstRain = precip.optDouble(first, Double.NaN)
+    val firstUv = uvMaxArr?.let {
+        if (first < it.length() && !it.isNull(first)) it.getDouble(first) else null
+    }
+    val firstSunrise = sunriseArr?.let {
+        if (first < it.length() && !it.isNull(first)) it.getString(first).substringAfterLast("T") else null
+    }
+    val firstSunset = sunsetArr?.let {
+        if (first < it.length() && !it.isNull(first)) it.getString(first).substringAfterLast("T") else null
+    }
+    val temperatureText = buildString {
+        if (!firstHigh.isNaN()) append("%.0f°C".format(firstHigh))
+        if (!firstLow.isNaN()) {
+            if (isNotEmpty()) append(" / ")
+            append("%.0f°C".format(firstLow))
+        }
+    }.ifBlank { "Forecast unavailable" }
+    val highLowText = buildString {
+        if (!firstHigh.isNaN()) append("High %.0f°C".format(firstHigh))
+        if (!firstLow.isNaN()) {
+            if (isNotEmpty()) append(" • ")
+            append("Low %.0f°C".format(firstLow))
+        }
+    }.takeIf { it.isNotBlank() }
+    val sunText = when {
+        firstSunrise != null && firstSunset != null -> "Sunrise $firstSunrise • Sunset $firstSunset"
+        firstSunrise != null -> "Sunrise $firstSunrise"
+        firstSunset != null -> "Sunset $firstSunset"
+        else -> null
+    }
+    return SkillResult.DirectReply(
+        text,
+        presentation = ToolPresentation.Weather(
+            locationName = locationLabel,
+            temperatureText = temperatureText,
+            feelsLikeText = null,
+            description = wmoDescription(firstCode),
+            emoji = wmoEmoji(firstCode),
+            highLowText = highLowText,
+            humidityText = null,
+            windText = null,
+            precipText = if (!firstRain.isNaN()) "%.0fmm rain".format(firstRain) else null,
+            uvText = firstUv?.let { "UV max %.0f (%s)".format(it, uvIndexLabel(it)) },
+            airQualityText = null,
+            sunText = sunText,
+            forecast = forecastDays,
+        ),
+        spokenSummary = buildWeekendForecastSpoken(locationLabel, spokenDays),
+    )
+}
+
 /** Internal wrapper for fresh weather fetch outcomes — success or a specific failure reason. */
 private sealed class LiveFetchResult {
     data class Success(val result: SkillResult) : LiveFetchResult()
@@ -265,6 +475,7 @@ class GetWeatherSkill @Inject constructor(
         "Current location weather → get_weather_gps()",
         "GPS location 3-day forecast → get_weather_gps(forecast_days=\"3\")",
         "Weather in Brisbane → get_weather_gps(location=\"Brisbane\")",
+        "Weekend forecast in Bundaberg → get_weather_gps(location=\"Bundaberg\", period=\"weekend\")",
         "Weather at home → get_weather_gps(location=\"Murrumba Downs, QLD, Australia\")",
     )
 
@@ -278,6 +489,12 @@ class GetWeatherSkill @Inject constructor(
                 type = "integer",
                 description = "Number of forecast days (1–7). Omit for current conditions only.",
             ),
+            "period" to SkillParameter(
+                type = "string",
+                description = "Optional forecast period: \"weekend\" targets the current/upcoming weekend " +
+                    "(Saturday + Sunday, or just the remaining Sunday when asked on a Sunday). " +
+                    "Omit for the default current/today behaviour. Mutually exclusive with forecast_days.",
+            ),
         ),
         required = emptyList(),
     )
@@ -286,15 +503,18 @@ class GetWeatherSkill @Inject constructor(
         val location = call.arguments["location"]?.trim()
         val forecastDays = call.arguments["forecast_days"]?.trim()?.toIntOrNull()?.coerceIn(1, 7) ?: 0
         val dayParam = call.arguments["day"]?.trim()?.lowercase()
+        val weekendRequest = call.arguments["period"]?.trim()?.lowercase() == "weekend"
         val lookupMode = weatherLookupMode(location)
 
         val cacheKey = when (lookupMode) {
             WeatherLookupMode.NAMED_LOCATION -> when {
+                weekendRequest -> "loc:$location:weekend"
                 dayParam == "tomorrow" -> "loc:$location:tomorrow"
                 forecastDays > 0 -> "loc:$location:forecast:$forecastDays"
                 else -> "loc:$location:current"
             }
             WeatherLookupMode.DEVICE_LOCATION -> when {
+                weekendRequest -> "gps:weekend"
                 dayParam == "tomorrow" -> "gps:tomorrow"
                 forecastDays > 0 -> "gps:forecast:$forecastDays"
                 else -> "gps:current"
@@ -303,6 +523,12 @@ class GetWeatherSkill @Inject constructor(
 
         val freshResult = try {
             when {
+                weekendRequest -> when (lookupMode) {
+                    WeatherLookupMode.NAMED_LOCATION ->
+                        fetchByLocationName(location.orEmpty(), targetWeekend = true, cacheKey = cacheKey)
+                    WeatherLookupMode.DEVICE_LOCATION ->
+                        fetchByDeviceLocation(targetWeekend = true, cacheKey = cacheKey)
+                }
                 dayParam == "tomorrow" -> {
                     val targetDays = forecastDays.coerceAtLeast(2)
                     when (lookupMode) {
@@ -341,12 +567,12 @@ class GetWeatherSkill @Inject constructor(
                 getRawCachedWeatherJson(cacheKey)?.let { cachedJson ->
                     Log.i(TAG, "Serving stale weather cache for key '$cacheKey' after ${failureReason.name}")
                     return try {
-                        if (dayParam == "tomorrow") {
-                            parseForecastDayResponse(cachedJson, displayName = null, dayIndex = 1)
-                        } else if (forecastDays > 0) {
-                            parseForecastResponse(cachedJson, displayName = null)
-                        } else {
-                            parseWeatherResponse(cachedJson, displayName = null, airQuality = null)
+                        when {
+                            weekendRequest -> parseWeekendResponse(cachedJson, displayName = null)
+                            dayParam == "tomorrow" ->
+                                parseForecastDayResponse(cachedJson, displayName = null, dayIndex = 1)
+                            forecastDays > 0 -> parseForecastResponse(cachedJson, displayName = null)
+                            else -> parseWeatherResponse(cachedJson, displayName = null, airQuality = null)
                         }
                     } catch (e: Exception) {
                         Log.w(TAG, "Cache re-parse failed for key '$cacheKey'", e)
@@ -371,6 +597,7 @@ class GetWeatherSkill @Inject constructor(
         locationName: String,
         forecastDays: Int = 0,
         targetDay: Boolean = false,
+        targetWeekend: Boolean = false,
         cacheKey: String,
     ): LiveFetchResult {
         val resolvedLocationName = resolveIndirectLocationReference(locationName) ?: locationName
@@ -380,32 +607,41 @@ class GetWeatherSkill @Inject constructor(
                 return LiveFetchResult.Failed(WeatherLookupFailureReason.NAMED_LOCATION_NOT_FOUND)
             }
 
-        val result = if (forecastDays > 0) {
-            if (targetDay) {
-                fetchForecastForDay(
-                    lat = coordinates.first,
-                    lon = coordinates.second,
-                    displayName = resolvedLocationName,
-                    days = forecastDays,
-                    dayIndex = 1,
-                    cacheKey = cacheKey,
-                )
-            } else {
-                fetchForecast(
-                    lat = coordinates.first,
-                    lon = coordinates.second,
-                    displayName = resolvedLocationName,
-                    days = forecastDays,
-                    cacheKey = cacheKey,
-                )
-            }
-        } else {
-            fetchWeather(
+        val result = when {
+            targetWeekend -> fetchWeekendForecast(
                 lat = coordinates.first,
                 lon = coordinates.second,
                 displayName = resolvedLocationName,
                 cacheKey = cacheKey,
             )
+            forecastDays > 0 -> {
+                if (targetDay) {
+                    fetchForecastForDay(
+                        lat = coordinates.first,
+                        lon = coordinates.second,
+                        displayName = resolvedLocationName,
+                        days = forecastDays,
+                        dayIndex = 1,
+                        cacheKey = cacheKey,
+                    )
+                } else {
+                    fetchForecast(
+                        lat = coordinates.first,
+                        lon = coordinates.second,
+                        displayName = resolvedLocationName,
+                        days = forecastDays,
+                        cacheKey = cacheKey,
+                    )
+                }
+            }
+            else -> {
+                fetchWeather(
+                    lat = coordinates.first,
+                    lon = coordinates.second,
+                    displayName = resolvedLocationName,
+                    cacheKey = cacheKey,
+                )
+            }
         }
 
         return if (result != null) {
@@ -476,7 +712,12 @@ class GetWeatherSkill @Inject constructor(
 
     // ── Location ──────────────────────────────────────────────────────────────
 
-    private suspend fun fetchByDeviceLocation(forecastDays: Int = 0, targetDay: Boolean = false, cacheKey: String): LiveFetchResult {
+    private suspend fun fetchByDeviceLocation(
+        forecastDays: Int = 0,
+        targetDay: Boolean = false,
+        targetWeekend: Boolean = false,
+        cacheKey: String,
+    ): LiveFetchResult {
         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
             != PackageManager.PERMISSION_GRANTED
         ) {
@@ -491,32 +732,41 @@ class GetWeatherSkill @Inject constructor(
             }
 
         val displayName = reverseGeocode(loc.latitude, loc.longitude)
-        val result = if (forecastDays > 0) {
-            if (targetDay) {
-                fetchForecastForDay(
-                    lat = loc.latitude,
-                    lon = loc.longitude,
-                    displayName = displayName,
-                    days = forecastDays,
-                    dayIndex = 1,
-                    cacheKey = cacheKey,
-                )
-            } else {
-                fetchForecast(
-                    lat = loc.latitude,
-                    lon = loc.longitude,
-                    displayName = displayName,
-                    days = forecastDays,
-                    cacheKey = cacheKey,
-                )
-            }
-        } else {
-            fetchWeather(
+        val result = when {
+            targetWeekend -> fetchWeekendForecast(
                 lat = loc.latitude,
                 lon = loc.longitude,
                 displayName = displayName,
                 cacheKey = cacheKey,
             )
+            forecastDays > 0 -> {
+                if (targetDay) {
+                    fetchForecastForDay(
+                        lat = loc.latitude,
+                        lon = loc.longitude,
+                        displayName = displayName,
+                        days = forecastDays,
+                        dayIndex = 1,
+                        cacheKey = cacheKey,
+                    )
+                } else {
+                    fetchForecast(
+                        lat = loc.latitude,
+                        lon = loc.longitude,
+                        displayName = displayName,
+                        days = forecastDays,
+                        cacheKey = cacheKey,
+                    )
+                }
+            }
+            else -> {
+                fetchWeather(
+                    lat = loc.latitude,
+                    lon = loc.longitude,
+                    displayName = displayName,
+                    cacheKey = cacheKey,
+                )
+            }
         }
 
         return if (result != null) {
@@ -567,6 +817,43 @@ class GetWeatherSkill @Inject constructor(
         }
 
     // ── Forecast fetch ────────────────────────────────────────────────────────
+
+    /**
+     * #1455 — fetch enough daily forecast data to reach the nearest current/upcoming
+     * weekend (the existing 7-day horizon always contains it) and restrict the parsed
+     * result to the intended weekend days via [parseWeekendResponse]. The raw body is
+     * cached under the request's weekend cache key, so a stale-cache fallback re-runs
+     * the same weekend selection on the identical JSON.
+     */
+    private suspend fun fetchWeekendForecast(
+        lat: Double,
+        lon: Double,
+        displayName: String?,
+        cacheKey: String,
+    ): SkillResult? =
+        withContext(Dispatchers.IO) {
+            // Check cache first
+            getCachedWeatherJson(cacheKey)?.let { cachedJson ->
+                return@withContext parseWeekendResponse(cachedJson, displayName)
+            }
+
+            val url = "https://api.open-meteo.com/v1/forecast" +
+                "?latitude=$lat&longitude=$lon" +
+                "&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code,uv_index_max,sunrise,sunset" +
+                "&timezone=auto&forecast_days=7&wind_speed_unit=ms"
+
+            val body = retryWithBackoff("Weekend Forecast API ($displayName)") {
+                httpClient.newCall(Request.Builder().url(url).build()).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        throw IllegalStateException("Forecast API returned ${response.code}")
+                    }
+                    response.body?.string() ?: throw IllegalStateException("Empty forecast response")
+                }
+            } ?: return@withContext null
+
+            cacheWeatherJson(cacheKey, body)
+            parseWeekendResponse(body, displayName)
+        }
 
     private suspend fun fetchForecast(
         lat: Double,

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherUnifiedSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherUnifiedSkill.kt
@@ -23,6 +23,8 @@ import javax.inject.Singleton
  * - `location`     — optional city/place name; omit to use device GPS.
  * - `forecast_days` — optional 1–7 day forecast; omit for current conditions only.
  * - `day`          — optional "today" or "tomorrow"; when "tomorrow", returns tomorrow's forecast only.
+ * - `period`       — optional "weekend"; returns the current/upcoming weekend's Saturday + Sunday
+ *   forecast from the daily data path (distinct cache identity from current/tomorrow/N-day).
  *
  * Always returns [SkillResult.DirectReply] — the formatted weather string is shown verbatim
  * and never sent to the LLM for wrapping, preventing number/unit corruption.
@@ -41,6 +43,7 @@ class GetWeatherUnifiedSkill @Inject constructor(
         "Current location weather → get_weather()",
         "GPS location 3-day forecast → get_weather(forecast_days=\"3\")",
         "Weather in Auckland → get_weather(location=\"Auckland\")",
+        "Weekend forecast in Bundaberg → get_weather(location=\"Bundaberg\", period=\"weekend\")",
         "Weather in Brisbane → get_weather(location=\"Brisbane\")",
     )
 
@@ -58,6 +61,12 @@ class GetWeatherUnifiedSkill @Inject constructor(
             "day" to SkillParameter(
                 type = "string",
                 description = "Optional day to get weather for: \"today\" or \"tomorrow\". When \"tomorrow\", returns tomorrow's forecast only.",
+            ),
+            "period" to SkillParameter(
+                type = "string",
+                description = "Optional forecast period: \"weekend\" targets the current/upcoming weekend " +
+                    "(Saturday + Sunday, or just the remaining Sunday when asked on a Sunday). " +
+                    "Omit for the default current/today behaviour. Mutually exclusive with forecast_days.",
             ),
         ),
         required = emptyList(),

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2111,6 +2111,21 @@ class QuickIntentRouterTest {
         }
 
         @Test
+        fun `today-anchored daypart queries still route deterministically`() {
+            // #1455 — the veto must not regress today-anchored value queries whose answer
+            // is consistent with the daypart qualifier (sunset this evening = today's
+            // sunset, UV/AQI this morning/evening = today's reading).
+            for (input in listOf(
+                "What time is sunset this evening?",
+                "Is the UV high this morning?",
+                "Is the air quality good this evening?",
+            )) {
+                val result = regexOnlyRouter.route(input)
+                assertRegexMatch(result, "get_weather", input)
+            }
+        }
+
+        @Test
         fun `weekend wording works across patterns and never contaminates the location`() {
             // #1455 — every deterministic weekend phrasing must converge on the same
             // explicit weekend contract with a clean location.

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2066,20 +2066,70 @@ class QuickIntentRouterTest {
         }
 
         @Test
-        fun `should not fake relative periods as forecasts or days`() {
-            // #1455 out of scope — weekend/daypart wording must not gain 3-day or day semantics.
+        fun `weekend phrases carry explicit weekend semantics not 3-day or day semantics`() {
+            // #1455 — the advertised Learn phrase must produce the explicit weekend
+            // contract between QIR and the weather skill: period=weekend, location
+            // preserved, and never the unspecified-forecast 3-day default or day=tomorrow.
             val weekend = regexOnlyRouter.route("What's the forecast for Bundaberg this weekend?")
             assertRegexMatch(weekend, "get_weather", "What's the forecast for Bundaberg this weekend?")
             val weekendParams = (weekend as QuickIntentRouter.RouteResult.RegexMatch).intent.params
             assertEquals("Bundaberg", weekendParams["location"])
+            assertEquals("weekend", weekendParams["period"])
             assertNull(weekendParams["forecast_days"], "weekend must not become a 3-day forecast")
             assertNull(weekendParams["day"], "weekend must not become day=tomorrow")
+        }
 
-            val afternoon = regexOnlyRouter.route("How hot will it be this afternoon?")
-            assertRegexMatch(afternoon, "get_weather", "How hot will it be this afternoon?")
-            val afternoonParams = (afternoon as QuickIntentRouter.RouteResult.RegexMatch).intent.params
-            assertNull(afternoonParams["forecast_days"], "afternoon must not become a forecast")
-            assertNull(afternoonParams["day"], "afternoon must not become a day")
+        @Test
+        fun `unsupported dayparts do not deterministically claim current weather`() {
+            // #1455 — "this afternoon/evening/morning" have no hourly forecast contract;
+            // they must fall through to the free-form path instead of routing to
+            // get_weather and silently returning current conditions.
+            for (input in listOf(
+                "How hot will it be this afternoon?",
+                "How cold will it be this evening?",
+                "How warm will it be this morning?",
+            )) {
+                val result = regexOnlyRouter.route(input)
+                assertFallThrough(result, input)
+            }
+        }
+
+        @Test
+        fun `daypart wording never routes to get_weather even through location patterns`() {
+            // #1455 — the veto is central: daypart wording must not sneak into
+            // get_weather through the city/temperature patterns either, where it would
+            // be stripped from the location and answered with current conditions.
+            for (input in listOf(
+                "What's the weather in Sydney this afternoon?",
+                "What's the weather forecast for Sydney this evening?",
+                "What's the temperature going to be this evening?",
+                "temperature in Wellington this morning",
+            )) {
+                val result = regexOnlyRouter.route(input)
+                assertFallThrough(result, input)
+            }
+        }
+
+        @Test
+        fun `weekend wording works across patterns and never contaminates the location`() {
+            // #1455 — every deterministic weekend phrasing must converge on the same
+            // explicit weekend contract with a clean location.
+            data class Case(val input: String, val expectedLocation: String?)
+            val cases = listOf(
+                Case("What's the weather in Sydney this weekend?", "Sydney"),
+                Case("What's the weather forecast for Sydney this weekend?", "Sydney"),
+                Case("What's the forecast for Bundaberg this weekend?", "Bundaberg"),
+                Case("How hot will it be this weekend?", null),
+            )
+            for (case in cases) {
+                val result = regexOnlyRouter.route(case.input)
+                assertRegexMatch(result, "get_weather", case.input)
+                val params = (result as QuickIntentRouter.RouteResult.RegexMatch).intent.params
+                assertEquals(case.expectedLocation, params["location"], "location for '${case.input}' (params=$params)")
+                assertEquals("weekend", params["period"], "period for '${case.input}' (params=$params)")
+                assertNull(params["forecast_days"], "forecast_days for '${case.input}' (params=$params)")
+                assertNull(params["day"], "day for '${case.input}' (params=$params)")
+            }
         }
     }
 

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/GetWeatherWeekendTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/GetWeatherWeekendTest.kt
@@ -1,0 +1,196 @@
+package com.kernel.ai.core.skills.natives
+
+import com.kernel.ai.core.skills.SkillResult
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * #1455 — weekend weather selection and parsing.
+ *
+ * Deterministic fixture data only; no live Open-Meteo calls. Proves the weekend
+ * selection contract for representative calendar positions, that only the intended
+ * weekend days are returned, that the location is preserved, and that fresh and
+ * stale-cache parses of the same response select identical days.
+ */
+class GetWeatherWeekendTest {
+
+    // ── Fixture dates (verified weekdays) ─────────────────────────────────────
+
+    private val mondayStart = listOf(
+        "2026-08-10", // Mon
+        "2026-08-11", // Tue
+        "2026-08-12", // Wed
+        "2026-08-13", // Thu
+        "2026-08-14", // Fri
+        "2026-08-15", // Sat
+        "2026-08-16", // Sun
+    )
+
+    private val fridayStart = listOf(
+        "2026-08-14", // Fri
+        "2026-08-15", // Sat
+        "2026-08-16", // Sun
+    )
+
+    private val saturdayStart = listOf(
+        "2026-08-08", // Sat
+        "2026-08-09", // Sun
+    )
+
+    private val sundayStart = listOf(
+        "2026-08-09", // Sun
+        "2026-08-10", // Mon
+    )
+
+    // ── Weekend index selection ───────────────────────────────────────────────
+
+    @Test
+    fun `weekday forecast selects the next Saturday and Sunday`() {
+        assertEquals(listOf(5, 6), selectWeekendDayIndices(mondayStart))
+        assertEquals(listOf(1, 2), selectWeekendDayIndices(fridayStart))
+    }
+
+    @Test
+    fun `Saturday start treats Saturday and Sunday as the current weekend`() {
+        assertEquals(listOf(0, 1), selectWeekendDayIndices(saturdayStart))
+    }
+
+    @Test
+    fun `Sunday start treats Sunday as the remaining current weekend day`() {
+        assertEquals(listOf(0), selectWeekendDayIndices(sundayStart))
+    }
+
+    @Test
+    fun `horizon ending before Sunday never fabricates a missing day`() {
+        // Friday + Saturday only: Saturday is the next weekend day, Sunday is out of
+        // horizon and must not be invented.
+        assertEquals(listOf(1), selectWeekendDayIndices(listOf("2026-08-14", "2026-08-15")))
+        // No weekend inside the horizon at all.
+        assertEquals(emptyList<Int>(), selectWeekendDayIndices(listOf("2026-08-10", "2026-08-11")))
+    }
+
+    @Test
+    fun `empty or unparseable dates select nothing`() {
+        assertEquals(emptyList<Int>(), selectWeekendDayIndices(emptyList()))
+        assertEquals(emptyList<Int>(), selectWeekendDayIndices(listOf("not-a-date", "2026-08-15")))
+    }
+
+    // ── Spoken summary ────────────────────────────────────────────────────────
+
+    @Test
+    fun `buildWeekendForecastSpoken names the weekend explicitly`() {
+        val days = listOf(
+            Triple("Sat 15 Aug", "Clear sky", Pair(28.0, 18.0)),
+            Triple("Sun 16 Aug", "Rain", Pair(22.0, 16.0)),
+        )
+        val spoken = buildWeekendForecastSpoken("Bundaberg", days)
+        assertTrue(spoken.startsWith("Bundaberg weekend forecast."))
+        assertTrue(spoken.contains("Sat 15 Aug"))
+        assertTrue(spoken.contains("Sun 16 Aug"))
+        assertFalse(spoken.contains("2-day"))
+    }
+
+    @Test
+    fun `buildWeekendForecastSpoken handles a single remaining day`() {
+        val days = listOf(
+            Triple("Sun 9 Aug", "Partly cloudy", Pair(24.0, 17.0)),
+        )
+        val spoken = buildWeekendForecastSpoken("Brisbane, AU", days)
+        assertTrue(spoken.startsWith("Brisbane weekend forecast."))
+        assertTrue(spoken.contains("Sun 9 Aug"))
+        assertTrue(spoken.contains("high 24 degrees"))
+    }
+
+    // ── Response parsing (deterministic fixtures) ─────────────────────────────
+
+    private fun fixtureJson(dates: List<String>, code: Int = 0): String {
+        val highs = dates.joinToString(",") { "%.1f".format(24.0 + dates.indexOf(it)) }
+        val lows = dates.joinToString(",") { "%.1f".format(16.0 + dates.indexOf(it)) }
+        val rains = dates.joinToString(",") { "0.0" }
+        val codes = dates.joinToString(",") { "$code" }
+        val uvs = dates.joinToString(",") { "6.0" }
+        val times = dates.joinToString(",") { "\"$it\"" }
+        val sunrises = dates.joinToString(",") { "\"${it}T06:12\"" }
+        val sunsets = dates.joinToString(",") { "\"${it}T17:48\"" }
+        return """{
+            "latitude": -24.87, "longitude": 152.35,
+            "daily": {
+                "time": [$times],
+                "temperature_2m_max": [$highs],
+                "temperature_2m_min": [$lows],
+                "precipitation_sum": [$rains],
+                "weather_code": [$codes],
+                "uv_index_max": [$uvs],
+                "sunrise": [$sunrises],
+                "sunset": [$sunsets]
+            }
+        }"""
+    }
+
+    @Test
+    fun `weekday fixture returns only the intended weekend days`() {
+        val result = parseWeekendResponse(fixtureJson(mondayStart), "Bundaberg")
+        val direct = assertInstanceOf(SkillResult.DirectReply::class.java, result)
+        assertTrue(direct.content.startsWith("Bundaberg weekend forecast:"), "text=${direct.content}")
+        // Weekend days present.
+        assertTrue(direct.content.contains("Sat 15 Aug"), "text=${direct.content}")
+        assertTrue(direct.content.contains("Sun 16 Aug"), "text=${direct.content}")
+        // Intervening weekdays must not appear.
+        for (weekday in listOf("Mon 10 Aug", "Tue 11 Aug", "Wed 12 Aug", "Thu 13 Aug", "Fri 14 Aug")) {
+            assertFalse(direct.content.contains(weekday), "intervening '$weekday' leaked into text=${direct.content}")
+        }
+        val presentation = direct.presentation as com.kernel.ai.core.skills.ToolPresentation.Weather
+        assertEquals(2, presentation.forecast?.size)
+        assertEquals("Bundaberg", presentation.locationName)
+        assertTrue(direct.spokenSummary?.contains("Bundaberg weekend forecast.") == true)
+    }
+
+    @Test
+    fun `Saturday-start fixture returns Saturday and Sunday`() {
+        val result = parseWeekendResponse(fixtureJson(saturdayStart), "Bundaberg")
+        val direct = assertInstanceOf(SkillResult.DirectReply::class.java, result)
+        assertTrue(direct.content.contains("Sat 8 Aug"), "text=${direct.content}")
+        assertTrue(direct.content.contains("Sun 9 Aug"), "text=${direct.content}")
+    }
+
+    @Test
+    fun `Sunday-start fixture returns only the remaining Sunday`() {
+        val result = parseWeekendResponse(fixtureJson(sundayStart), "Bundaberg")
+        val direct = assertInstanceOf(SkillResult.DirectReply::class.java, result)
+        assertTrue(direct.content.contains("Sun 9 Aug"), "text=${direct.content}")
+        assertFalse(direct.content.contains("Mon 10 Aug"), "text=${direct.content}")
+    }
+
+    @Test
+    fun `parse of the same response is identical for fresh and cached reads`() {
+        // The raw Open-Meteo body is what gets cached; both the fresh fetch path and
+        // the stale-cache fallback run parseWeekendResponse on that same JSON, so the
+        // selection must be byte-identical across parses.
+        val json = fixtureJson(mondayStart)
+        val first = parseWeekendResponse(json, "Bundaberg")
+        val second = parseWeekendResponse(json, "Bundaberg")
+        assertEquals(
+            (first as SkillResult.DirectReply).content,
+            (second as SkillResult.DirectReply).content,
+        )
+        assertEquals(first.spokenSummary, second.spokenSummary)
+    }
+
+    @Test
+    fun `parse fails honestly when no weekend exists in the horizon`() {
+        val result = parseWeekendResponse(fixtureJson(listOf("2026-08-10", "2026-08-11")), "Bundaberg")
+        assertInstanceOf(SkillResult.Failure::class.java, result)
+    }
+
+    @Test
+    fun `parse fails on empty or mismatched daily data`() {
+        val empty = """{"daily":{"time":[],"temperature_2m_max":[],"temperature_2m_min":[],"precipitation_sum":[],"weather_code":[]}}"""
+        assertInstanceOf(SkillResult.Failure::class.java, parseWeekendResponse(empty, "Bundaberg"))
+
+        val mismatched = """{"daily":{"time":["2026-08-15","2026-08-16"],"temperature_2m_max":[28.0],"temperature_2m_min":[18.0],"precipitation_sum":[0.0],"weather_code":[0]}}"""
+        assertInstanceOf(SkillResult.Failure::class.java, parseWeekendResponse(mismatched, "Bundaberg"))
+    }
+}

--- a/scripts/adb_harness/cases.py
+++ b/scripts/adb_harness/cases.py
@@ -119,6 +119,11 @@ PHASES: list[tuple[str, list[TestCase]]] = [
                  expect_params={"day": "tomorrow"}),
         TestCase("What's the UV index in Sydney", "get_weather",
                  expect_params={"location": "Sydney"}),
+        # #1455 — the advertised Learn weekend phrase must carry the explicit
+        # weekend contract, not just the route (provider-side weekend-day selection
+        # is covered by deterministic unit fixtures).
+        TestCase("What's the forecast for Bundaberg this weekend", "get_weather",
+                 expect_params={"location": "Bundaberg", "period": "weekend"}),
     ]),
     ("media", [
         # play_media — generic
@@ -639,6 +644,14 @@ PHASES: list[tuple[str, list[TestCase]]] = [
                  forbidden_intents=["get_weather"],
                  expect_llm_fallthrough=True),
         TestCase("What's the weather like in Game of Thrones",
+                 forbidden_intents=["get_weather"],
+                 expect_llm_fallthrough=True),
+        # ── §8D (#1455): Unsupported dayparts — no hourly contract, so these must
+        # not deterministically claim a get_weather (current-conditions) answer.
+        TestCase("How hot will it be this afternoon",
+                 forbidden_intents=["get_weather"],
+                 expect_llm_fallthrough=True),
+        TestCase("How cold will it be this evening",
                  forbidden_intents=["get_weather"],
                  expect_llm_fallthrough=True),
     ]),


### PR DESCRIPTION
Closes #1455

## Pre-fix failure

`What's the forecast for Bundaberg this weekend?` routed to `get_weather` with only `location=Bundaberg`. The skill contract (`{location, forecast_days, day=tomorrow}`) had no weekend target, so the request fell into the current-conditions path — the Learn-advertised phrase returned "now" weather, not the weekend. `How hot will it be this afternoon?` / `How cold will it be this evening?` routed deterministically (via the daypart pattern and the unanchored temperature/city patterns) with no representable period, silently answering current conditions. #1453's normaliser already refused to fake these as 3-day/tomorrow, but the gap was real.

## Explicit weekend parameter contract

New skill parameter `period` (string, value `"weekend"`), added to `GetWeatherSkill` and `GetWeatherUnifiedSkill` schemas/examples:

- QIR → skill: `{location, period="weekend"}` — never `raw_query`-only, never `forecast_days`.
- Distinct cache identity: `loc:<place>:weekend` / `gps:weekend` — separate from `current`, `tomorrow`, and `forecast:N`.
- `forecast_days` and `period` are mutually exclusive by construction (weekend requests never emit a horizon).

## Weekend day selection

- QIR emits `period=weekend` explicitly from the dedicated weekend pattern; the #1453 central normaliser (`normalizeWeatherParams`) also derives `period=weekend` from any `this weekend` wording that reaches `get_weather` through another pattern (e.g. "what's the weather in Sydney this weekend?", "how hot will it be this weekend?"), never overwriting an explicit period.
- `weatherForecastDays()` gained an explicit guard: `this weekend` → no horizon (weekend precedence over the unspecified-forecast 3-day default, which the #1453 dayAnchored check also covered).
- Skill fetches the existing daily Open-Meteo path with `forecast_days=7` (the existing horizon always contains the current/upcoming weekend) and `selectWeekendDayIndices()` derives the intended days from the **actual returned dates**:
  - forecast starts Saturday → current weekend (Sat + Sun);
  - starts Sunday → remaining current weekend day (Sun only);
  - otherwise → next Saturday + following Sunday.
  - Only the intended days are returned (never intervening weekdays); a day outside the horizon is never fabricated (`Fri+Sat` horizon → Saturday only; `Mon+Tue` horizon → honest failure).
- `parseWeekendResponse()` is a pure function of the response JSON, so fresh fetches and stale-cache fallback run the identical selection. Spoken summary: small `buildWeekendForecastSpoken` ("Bundaberg weekend forecast. …"), reusing `locationForSpeech`/`toRoundedDegreesText`.

## Disposition of afternoon/evening deterministic routing

Unsupported dayparts are no longer deterministically routed at all:

- Central veto in `route()`: wording matching `this (afternoon|evening|morning)` drops every `get_weather` pattern (specific + fallback passes) and blocks a classifier `get_weather` match; the phrase falls through to the normal free-form path.
- The daypart pattern was narrowed to supported periods only (`tomorrow|today|this weekend`); `this weekend` there becomes `period=weekend` via the normaliser.
- This also covers residue forms that previously leaked through the city/temperature patterns (`"what's the weather in Sydney this afternoon"`, `"temperature in Wellington this morning"`).
- No hourly weather subsystem, no date-parsing framework, no provider/planner/LLM change.

## Cache handling

Weekend requests use `loc:<place>:weekend` / `gps:weekend` cache keys. The cached body is the raw 7-day daily JSON; both the fresh path and the stale fallback call `parseWeekendResponse()` on it, so selection semantics are identical (proven by a parse-twice fixture test). A cached current/forecast result can never be parsed as a weekend response (key mismatch → cache miss).

## Tests added

- `QuickIntentRouterTest` (GetWeather nested class):
  - Learn phrase → `get_weather {location=Bundaberg, period=weekend}`, no `forecast_days`/`day`;
  - weekend wording across patterns (`weather in Sydney this weekend`, `weather forecast for Sydney this weekend`, `how hot will it be this weekend`) → `period=weekend`, clean location;
  - `How hot will it be this afternoon?` / `How cold will it be this evening?` / morning forms → FallThrough (no deterministic `get_weather`);
  - daypart wording through location patterns (`weather in Sydney this afternoon`, `temperature in Wellington this morning`, `temperature going to be this evening`) → FallThrough.
- `GetWeatherWeekendTest` (13 fixture tests, no live API): `selectWeekendDayIndices` for weekday/Saturday/Sunday starts, horizon-boundary honesty, empty/unparseable dates; `parseWeekendResponse` returns only the intended days with location preserved; identical selection across fresh/cached parses; honest failures on empty/mismatched/out-of-horizon data; `buildWeekendForecastSpoken`.
- `LearnExampleRoutingTest`: `weather_bundaberg` semantic contract (beyond `expectedRoute`); catalogue guard that no `get_weather` Learn example advertises unsupported dayparts.
- `scripts/adb_harness/cases.py`: Bundaberg weekend case asserts `{location=Bundaberg, period=weekend}` (not just the route); afternoon/evening false-positive cases assert no `get_weather` + LLM fallthrough.

## #1453 regression

The #1453 `weatherSemanticMatrix` and related tests ran unchanged — current/tomorrow/N-day/this-week/named-location semantics all green.

## Commands run

- `./gradlew :core:skills:testDebugUnitTest --tests "com.kernel.ai.core.skills.natives.GetWeatherWeekendTest" --tests "com.kernel.ai.core.skills.natives.GetWeatherCacheTest"` → BUILD SUCCESSFUL
- `./gradlew :core:skills:testDebugUnitTest --tests "com.kernel.ai.core.skills.QuickIntentRouterTest"` → BUILD SUCCESSFUL (GetWeather nested: 146 tests, 0 failures)
- `./gradlew :app:testDebugUnitTest --tests "com.kernel.ai.navigation.LearnExampleRoutingTest" --tests "com.kernel.ai.navigation.LearnExampleCatalogueTest"` → BUILD SUCCESSFUL (70 + 742 tests)
- `./gradlew :core:skills:testDebugUnitTest` (full) → BUILD SUCCESSFUL
- `./gradlew :app:testDebugUnitTest` (full) → BUILD SUCCESSFUL
- `python3 scripts/adb_skill_test.py --dry-run` → 243/243 cases selected, no errors (includes new Bundaberg weekend + daypart guard cases)

Physical-device harness runs were not performed; provider-returned weekend-day validation is covered by deterministic unit fixtures as scoped in the issue.

Do not merge — wait for review.