### PR TITLE
fix(#1459): hydrate chat model settings when attaching to warm engine

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceEngine.kt
@@ -38,6 +38,15 @@ interface InferenceEngine {
     val resolvedMaxTokens: StateFlow<Int>
 
     /**
+     * Absolute path of the model currently loaded by the engine, or null before
+     * [initialize] completes. Authoritative for clients that attach to an
+     * already-ready singleton engine: the engine keeps running the model it was
+     * initialized with even if the user changed their preferred conversation model
+     * (preference changes take effect on next launch).
+     */
+    val loadedModelPath: String?
+
+    /**
      * Load model weights and initialize the LiteRT-LM engine.
      * Blocks the [LlmDispatcher] thread; observe [isReady] for completion.
      *

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -795,6 +795,9 @@ class LiteRtInferenceEngine @Inject constructor(
     private var conversation: com.google.ai.edge.litertlm.Conversation? = null
     private var currentConfig: ModelConfig? = null
 
+    /** The model currently loaded by the engine, from the resolved [initialize] config. */
+    override val loadedModelPath: String? get() = currentConfig?.modelPath
+
     /** Ensures only one generation (chat or isolated) runs at a time. */
     private val generationMutex = Mutex()
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -964,9 +964,11 @@ class ChatViewModel @Inject constructor(
     private suspend fun hydrateActiveModelState(): Triple<KernelModel, String, ModelSettingsEntity>? {
         val preferred = downloadManager.preferredConversationModel()
         val modelPath = downloadManager.getModelPath(preferred) ?: return null
-        val settings = modelSettingsRepository.getSettings(preferred.modelId)
+        // Assign the model before reading persisted settings so a settings-read failure
+        // leaves the same partial state the original cold-start path did (review #1460).
         activeModel = preferred
         activeModelState.value = preferred
+        val settings = modelSettingsRepository.getSettings(preferred.modelId)
         activeContextWindowSize = settings.contextWindowSize
         _showThinkingProcess.value = settings.showThinkingProcess
         _activeModelSettings.value = settings
@@ -989,20 +991,20 @@ class ChatViewModel @Inject constructor(
             .first()
 
         gemma4InitMutex.withLock {
-            if (inferenceEngine.isReady.value) {
-                // The engine is a process singleton — a previous ChatViewModel may already
-                // have it warm. Never re-initialise it; just hydrate the ViewModel-local
-                // model/settings state the in-chat settings UI needs (#1459).
-                hydrateActiveModelState()
-                // Mirror the cold path's post-initialize sync: the engine allocated a
-                // clamped KV-cache size that supersedes the persisted setting.
-                inferenceEngine.resolvedMaxTokens.value.takeIf { it > 0 }?.let {
-                    activeContextWindowSize = it
-                }
-                return
-            }
-
             try {
+                if (inferenceEngine.isReady.value) {
+                    // The engine is a process singleton — a previous ChatViewModel may already
+                    // have it warm. Never re-initialise it; just hydrate the ViewModel-local
+                    // model/settings state the in-chat settings UI needs (#1459).
+                    hydrateActiveModelState()
+                    // Mirror the cold path's post-initialize sync: the engine allocated a
+                    // clamped KV-cache size that supersedes the persisted setting.
+                    inferenceEngine.resolvedMaxTokens.value.takeIf { it > 0 }?.let {
+                        activeContextWindowSize = it
+                    }
+                    return
+                }
+
                 val (preferred, modelPath, settings) = hydrateActiveModelState() ?: return
                 // EmbeddingGemma uses CPU only (no GPU conflict with Gemma-4).
                 // embeddingEngine.close() removed — it silently broke search_memory (#445)
@@ -1051,18 +1053,18 @@ class ChatViewModel @Inject constructor(
      */
     private suspend fun initGemma4() {
         gemma4InitMutex.withLock {
-            if (inferenceEngine.isReady.value) {
-                // Same already-ready hydration as [initEngineWhenReady] (#1459):
-                // a fresh ViewModel may attach to a warm singleton engine — hydrate
-                // local state only, never re-initialise.
-                hydrateActiveModelState()
-                inferenceEngine.resolvedMaxTokens.value.takeIf { it > 0 }?.let {
-                    activeContextWindowSize = it
-                }
-                return
-            }
-
             try {
+                if (inferenceEngine.isReady.value) {
+                    // Same already-ready hydration as [initEngineWhenReady] (#1459):
+                    // a fresh ViewModel may attach to a warm singleton engine — hydrate
+                    // local state only, never re-initialise.
+                    hydrateActiveModelState()
+                    inferenceEngine.resolvedMaxTokens.value.takeIf { it > 0 }?.let {
+                        activeContextWindowSize = it
+                    }
+                    return
+                }
+
                 val (preferred, modelPath, settings) = hydrateActiveModelState() ?: return
                 // EmbeddingGemma uses CPU only (no GPU conflict with Gemma-4).
                 // embeddingEngine.close() removed — it silently broke search_memory (#445)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -948,6 +948,32 @@ class ChatViewModel @Inject constructor(
     }
 
     /**
+     * Resolves the preferred conversation model and hydrates the ViewModel-local
+     * active model/settings state required by the in-chat model settings UI.
+     *
+     * Shared by the cold-start init paths and the already-ready path: the
+     * [InferenceEngine] is a process singleton, so a fresh [ChatViewModel] can attach
+     * while the engine is already warm. In that case the engine must NOT be
+     * re-initialised, but `currentModel`/`activeModelSettings` (and thus
+     * `ChatUiState.Ready.modelCapabilities`) must still be populated, or the in-chat
+     * settings sheet falsely reports the model as not ready (#1459).
+     *
+     * @return the (preferred model, on-disk model path, persisted settings) triple,
+     *   or null when the preferred conversation model is not on disk.
+     */
+    private suspend fun hydrateActiveModelState(): Triple<KernelModel, String, ModelSettingsEntity>? {
+        val preferred = downloadManager.preferredConversationModel()
+        val modelPath = downloadManager.getModelPath(preferred) ?: return null
+        val settings = modelSettingsRepository.getSettings(preferred.modelId)
+        activeModel = preferred
+        activeModelState.value = preferred
+        activeContextWindowSize = settings.contextWindowSize
+        _showThinkingProcess.value = settings.showThinkingProcess
+        _activeModelSettings.value = settings
+        return Triple(preferred, modelPath, settings)
+    }
+
+    /**
      * Eagerly initialises the Gemma-4 [InferenceEngine] at startup.
      *
      * Waits for all required models to be on disk, then loads the preferred
@@ -962,21 +988,24 @@ class ChatViewModel @Inject constructor(
             .filter { states -> downloadManager.areRequiredModelsDownloaded() }
             .first()
 
-       gemma4InitMutex.withLock {
-            if (inferenceEngine.isReady.value) return
+        gemma4InitMutex.withLock {
+            if (inferenceEngine.isReady.value) {
+                // The engine is a process singleton — a previous ChatViewModel may already
+                // have it warm. Never re-initialise it; just hydrate the ViewModel-local
+                // model/settings state the in-chat settings UI needs (#1459).
+                hydrateActiveModelState()
+                // Mirror the cold path's post-initialize sync: the engine allocated a
+                // clamped KV-cache size that supersedes the persisted setting.
+                inferenceEngine.resolvedMaxTokens.value.takeIf { it > 0 }?.let {
+                    activeContextWindowSize = it
+                }
+                return
+            }
 
-            val preferred = downloadManager.preferredConversationModel()
-            val modelPath = downloadManager.getModelPath(preferred) ?: return
-            activeModel = preferred
-            activeModelState.value = preferred
             try {
+                val (preferred, modelPath, settings) = hydrateActiveModelState() ?: return
                 // EmbeddingGemma uses CPU only (no GPU conflict with Gemma-4).
                 // embeddingEngine.close() removed — it silently broke search_memory (#445)
-
-                val settings = modelSettingsRepository.getSettings(preferred.modelId)
-                activeContextWindowSize = settings.contextWindowSize
-                _showThinkingProcess.value = settings.showThinkingProcess
-                _activeModelSettings.value = settings
                 inferenceEngine.initialize(ModelConfig(
                     modelPath = modelPath,
                     systemPrompt = buildSystemPrompt(),
@@ -1012,7 +1041,8 @@ class ChatViewModel @Inject constructor(
      *
      * Uses [gemma4InitMutex] to guarantee idempotency: if called concurrently the second
      * caller waits for the first to finish, then finds [InferenceEngine.isReady] already
-     * true and returns immediately.
+     * true, hydrates the ViewModel-local model/settings state and returns without
+     * re-initialising the engine (#1459).
      *
      * Only waits for the preferred conversation model to be on disk via
      * [ModelDownloadManager.getModelPath] (file-existence check) — does NOT block on the
@@ -1021,21 +1051,22 @@ class ChatViewModel @Inject constructor(
      */
     private suspend fun initGemma4() {
         gemma4InitMutex.withLock {
-            if (inferenceEngine.isReady.value) return
+            if (inferenceEngine.isReady.value) {
+                // Same already-ready hydration as [initEngineWhenReady] (#1459):
+                // a fresh ViewModel may attach to a warm singleton engine — hydrate
+                // local state only, never re-initialise.
+                hydrateActiveModelState()
+                inferenceEngine.resolvedMaxTokens.value.takeIf { it > 0 }?.let {
+                    activeContextWindowSize = it
+                }
+                return
+            }
 
-            val preferred = downloadManager.preferredConversationModel()
-            val modelPath = downloadManager.getModelPath(preferred) ?: return
-            activeModel = preferred
-            activeModelState.value = preferred
             try {
+                val (preferred, modelPath, settings) = hydrateActiveModelState() ?: return
                 // EmbeddingGemma uses CPU only (no GPU conflict with Gemma-4).
                 // embeddingEngine.close() removed — it silently broke search_memory (#445)
-
-                val settings = modelSettingsRepository.getSettings(preferred.modelId)
                 Log.d(TAG, "initEngineWhenReady: modelId=${preferred.modelId} speculativeDecodingEnabled=${settings.speculativeDecodingEnabled}")
-                activeContextWindowSize = settings.contextWindowSize
-                _showThinkingProcess.value = settings.showThinkingProcess
-                _activeModelSettings.value = settings
                 inferenceEngine.initialize(ModelConfig(
                     modelPath = modelPath,
                     systemPrompt = buildSystemPrompt(),

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -948,31 +948,38 @@ class ChatViewModel @Inject constructor(
     }
 
     /**
-     * Resolves the preferred conversation model and hydrates the ViewModel-local
-     * active model/settings state required by the in-chat model settings UI.
+     * Hydrates the ViewModel-local active model/settings state for [model] from its
+     * persisted settings.
      *
-     * Shared by the cold-start init paths and the already-ready path: the
-     * [InferenceEngine] is a process singleton, so a fresh [ChatViewModel] can attach
-     * while the engine is already warm. In that case the engine must NOT be
-     * re-initialised, but `currentModel`/`activeModelSettings` (and thus
-     * `ChatUiState.Ready.modelCapabilities`) must still be populated, or the in-chat
-     * settings sheet falsely reports the model as not ready (#1459).
+     * The assignments happen only after the settings read succeeds, so a settings-read
+     * failure leaves the ViewModel without an active model: `currentModel`/capabilities
+     * stay null and the in-chat settings sheet stays unavailable instead of presenting
+     * fallback defaults as the real configuration (review #1460).
      *
-     * @return the (preferred model, on-disk model path, persisted settings) triple,
-     *   or null when the preferred conversation model is not on disk.
+     * @return the persisted settings snapshot that was hydrated.
      */
-    private suspend fun hydrateActiveModelState(): Triple<KernelModel, String, ModelSettingsEntity>? {
-        val preferred = downloadManager.preferredConversationModel()
-        val modelPath = downloadManager.getModelPath(preferred) ?: return null
-        // Assign the model before reading persisted settings so a settings-read failure
-        // leaves the same partial state the original cold-start path did (review #1460).
-        activeModel = preferred
-        activeModelState.value = preferred
-        val settings = modelSettingsRepository.getSettings(preferred.modelId)
+    private suspend fun hydrateActiveModelState(model: KernelModel): ModelSettingsEntity {
+        val settings = modelSettingsRepository.getSettings(model.modelId)
+        activeModel = model
+        activeModelState.value = model
         activeContextWindowSize = settings.contextWindowSize
         _showThinkingProcess.value = settings.showThinkingProcess
         _activeModelSettings.value = settings
-        return Triple(preferred, modelPath, settings)
+        return settings
+    }
+
+    /**
+     * Resolves the [KernelModel] actually loaded in the warm singleton engine from
+     * [InferenceEngine.loadedModelPath], or null when the loaded path matches no known
+     * model. The already-ready path must hydrate from what the engine is actually
+     * running, not from the current preference — preference changes take effect on
+     * next launch (review #1460).
+     */
+    private fun loadedConversationModel(): KernelModel? {
+        val loadedPath = inferenceEngine.loadedModelPath ?: return null
+        return KernelModel.entries.firstOrNull {
+            loadedPath == it.fileName || loadedPath.endsWith("/${it.fileName}")
+        }
     }
 
     /**
@@ -993,10 +1000,10 @@ class ChatViewModel @Inject constructor(
         gemma4InitMutex.withLock {
             try {
                 if (inferenceEngine.isReady.value) {
-                    // The engine is a process singleton — a previous ChatViewModel may already
-                    // have it warm. Never re-initialise it; just hydrate the ViewModel-local
-                    // model/settings state the in-chat settings UI needs (#1459).
-                    hydrateActiveModelState()
+                    // The singleton engine is already warm — hydrate from the model it is
+                    // actually running, never from the current preference (preference changes
+                    // take effect on next launch). The engine must not be re-initialised (#1459).
+                    loadedConversationModel()?.let { hydrateActiveModelState(it) }
                     // Mirror the cold path's post-initialize sync: the engine allocated a
                     // clamped KV-cache size that supersedes the persisted setting.
                     inferenceEngine.resolvedMaxTokens.value.takeIf { it > 0 }?.let {
@@ -1005,7 +1012,9 @@ class ChatViewModel @Inject constructor(
                     return
                 }
 
-                val (preferred, modelPath, settings) = hydrateActiveModelState() ?: return
+                val preferred = downloadManager.preferredConversationModel()
+                val modelPath = downloadManager.getModelPath(preferred) ?: return
+                val settings = hydrateActiveModelState(preferred)
                 // EmbeddingGemma uses CPU only (no GPU conflict with Gemma-4).
                 // embeddingEngine.close() removed — it silently broke search_memory (#445)
                 inferenceEngine.initialize(ModelConfig(
@@ -1055,17 +1064,19 @@ class ChatViewModel @Inject constructor(
         gemma4InitMutex.withLock {
             try {
                 if (inferenceEngine.isReady.value) {
-                    // Same already-ready hydration as [initEngineWhenReady] (#1459):
-                    // a fresh ViewModel may attach to a warm singleton engine — hydrate
-                    // local state only, never re-initialise.
-                    hydrateActiveModelState()
+                    // Same already-ready hydration as [initEngineWhenReady] (#1459): hydrate
+                    // from the model the singleton engine is actually running, never
+                    // re-initialise it.
+                    loadedConversationModel()?.let { hydrateActiveModelState(it) }
                     inferenceEngine.resolvedMaxTokens.value.takeIf { it > 0 }?.let {
                         activeContextWindowSize = it
                     }
                     return
                 }
 
-                val (preferred, modelPath, settings) = hydrateActiveModelState() ?: return
+                val preferred = downloadManager.preferredConversationModel()
+                val modelPath = downloadManager.getModelPath(preferred) ?: return
+                val settings = hydrateActiveModelState(preferred)
                 // EmbeddingGemma uses CPU only (no GPU conflict with Gemma-4).
                 // embeddingEngine.close() removed — it silently broke search_memory (#445)
                 Log.d(TAG, "initEngineWhenReady: modelId=${preferred.modelId} speculativeDecodingEnabled=${settings.speculativeDecodingEnabled}")

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -79,6 +79,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -1196,15 +1197,17 @@ class ChatViewModelInitTest {
             speculativeDecodingEnabled = true,
             updatedAt = 2L,
         )
-        // Engine reports ready BEFORE the ViewModel's init path runs (#1459).
+        // Engine reports ready BEFORE the ViewModel's init path runs (#1459) and is
+        // running E4B. Note: no preferredConversationModel/getModelPath stubs here —
+        // the warm path must hydrate from the loaded model, not the preference, so a
+        // wrong implementation reaching the cold path fails the initialize() verify.
         every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { inferenceEngine.loadedModelPath } returns "/models/gemma-4-E4B-it.litertlm"
         every { downloadManager.areRequiredModelsDownloaded() } returns true
         every { downloadManager.downloadStates } returns MutableStateFlow(
-            mapOf(KernelModel.GEMMA_4_E4B to DownloadState.Downloaded("/path/to/model")),
+            mapOf(KernelModel.GEMMA_4_E4B to DownloadState.Downloaded("/models/gemma-4-E4B-it.litertlm")),
         )
-        coEvery { downloadManager.preferredConversationModel() } returns KernelModel.GEMMA_4_E4B
-        coEvery { downloadManager.getModelPath(any()) } returns "/path/to/model"
-        coEvery { modelSettingsRepository.getSettings(any()) } returns persisted
+        coEvery { modelSettingsRepository.getSettings("gemma_4_e4b") } returns persisted
 
         val viewModel = createViewModel()
         // currentModel is stateIn(WhileSubscribed) — collect to observe hydration.
@@ -1228,6 +1231,61 @@ class ChatViewModelInitTest {
     }
 
     @Test
+    fun `warm engine hydrates the loaded model not the changed preference`() = runTest(dispatcher) {
+        val e4bSettings = ModelSettingsEntity(
+            modelId = "gemma_4_e4b",
+            contextWindowSize = 8192,
+            temperature = 0.42f,
+            topP = 0.7f,
+            topK = 96,
+            showThinkingProcess = false,
+            speculativeDecodingEnabled = true,
+            updatedAt = 2L,
+        )
+        val e2bSettings = ModelSettingsEntity(
+            modelId = "gemma_4_e2b",
+            contextWindowSize = 4096,
+            temperature = 0.99f,
+            topP = 0.6f,
+            topK = 12,
+            showThinkingProcess = true,
+            speculativeDecodingEnabled = false,
+            updatedAt = 3L,
+        )
+        // Singleton engine is ready and running E4B (review #1460 Finding 1).
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { inferenceEngine.loadedModelPath } returns "/models/gemma-4-E4B-it.litertlm"
+        every { downloadManager.areRequiredModelsDownloaded() } returns true
+        every { downloadManager.downloadStates } returns MutableStateFlow(
+            mapOf(KernelModel.GEMMA_4_E4B to DownloadState.Downloaded("/models/gemma-4-E4B-it.litertlm")),
+        )
+        // The user's preference has since changed to E2B — it takes effect on next
+        // launch and must NOT override what the warm engine is actually running.
+        coEvery { downloadManager.preferredConversationModel() } returns KernelModel.GEMMA_4_E2B
+        coEvery { modelSettingsRepository.getSettings("gemma_4_e4b") } returns e4bSettings
+        coEvery { modelSettingsRepository.getSettings("gemma_4_e2b") } returns e2bSettings
+
+        val viewModel = createViewModel()
+        val currentModels = mutableListOf<KernelModel?>()
+        val collector = launch { viewModel.currentModel.collect { currentModels += it } }
+        advanceUntilIdle()
+
+        assertEquals(KernelModel.GEMMA_4_E4B, currentModels.last())
+        assertEquals(e4bSettings, viewModel.activeModelSettings.value)
+
+        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+        assertNotNull(state.modelCapabilities)
+        assertEquals(e4bSettings.temperature, state.temperature)
+        assertEquals(e4bSettings.topK, state.topK)
+        assertFalse(state.showThinkingProcess)
+
+        // The preference (E2B) was never consulted for hydration.
+        coVerify(exactly = 0) { modelSettingsRepository.getSettings("gemma_4_e2b") }
+        coVerify(exactly = 0) { inferenceEngine.initialize(any()) }
+        collector.cancel()
+    }
+
+    @Test
     fun `sendMessage waiting on warmup mutex hydrates state without double initialising`() = runTest(dispatcher) {
         val persisted = ModelSettingsEntity(
             modelId = "gemma_4_e4b",
@@ -1246,12 +1304,13 @@ class ChatViewModelInitTest {
         // already-ready branch (#1459).
         val settingsGate = CompletableDeferred<Unit>()
         every { inferenceEngine.isReady } returns isReadyFlow
+        every { inferenceEngine.loadedModelPath } returns "/models/gemma-4-E4B-it.litertlm"
         every { downloadManager.areRequiredModelsDownloaded() } returns true
         every { downloadManager.downloadStates } returns MutableStateFlow(
-            mapOf(KernelModel.GEMMA_4_E4B to DownloadState.Downloaded("/path/to/model")),
+            mapOf(KernelModel.GEMMA_4_E4B to DownloadState.Downloaded("/models/gemma-4-E4B-it.litertlm")),
         )
         coEvery { downloadManager.preferredConversationModel() } returns KernelModel.GEMMA_4_E4B
-        coEvery { downloadManager.getModelPath(any()) } returns "/path/to/model"
+        coEvery { downloadManager.getModelPath(any()) } returns "/models/gemma-4-E4B-it.litertlm"
         coEvery { modelSettingsRepository.getSettings(any()) } coAnswers { settingsGate.await(); persisted }
         every { quickIntentRouter.route(any()) } returns QuickIntentRouter.RouteResult.FallThrough(input = "hello")
         every { inferenceEngine.generate(any()) } returns flowOf(GenerationResult.Complete(durationMs = 1L))
@@ -1288,7 +1347,7 @@ class ChatViewModelInitTest {
     }
 
     @Test
-    fun `warm engine settings read failure surfaces error without reinitialising`() = runTest(dispatcher) {
+    fun `warm engine settings read failure surfaces error and blocks apply`() = runTest(dispatcher) {
         val persisted = ModelSettingsEntity(
             modelId = "gemma_4_e4b",
             contextWindowSize = 8192,
@@ -1300,12 +1359,11 @@ class ChatViewModelInitTest {
             updatedAt = 2L,
         )
         every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { inferenceEngine.loadedModelPath } returns "/models/gemma-4-E4B-it.litertlm"
         every { downloadManager.areRequiredModelsDownloaded() } returns true
         every { downloadManager.downloadStates } returns MutableStateFlow(
-            mapOf(KernelModel.GEMMA_4_E4B to DownloadState.Downloaded("/path/to/model")),
+            mapOf(KernelModel.GEMMA_4_E4B to DownloadState.Downloaded("/models/gemma-4-E4B-it.litertlm")),
         )
-        coEvery { downloadManager.preferredConversationModel() } returns KernelModel.GEMMA_4_E4B
-        coEvery { downloadManager.getModelPath(any()) } returns "/path/to/model"
         // Settings read failure must be caught and surfaced like the cold path, not
         // escape the init coroutine (review #1460). Only the FIRST read (the init
         // hydration) fails — later reads from the persona-collector prompt builder
@@ -1316,6 +1374,9 @@ class ChatViewModelInitTest {
         }
 
         val viewModel = createViewModel()
+        // currentModel is stateIn(WhileSubscribed) — collect to observe hydration.
+        val currentModels = mutableListOf<KernelModel?>()
+        val collector = launch { viewModel.currentModel.collect { currentModels += it } }
         advanceUntilIdle()
 
         val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
@@ -1323,7 +1384,36 @@ class ChatViewModelInitTest {
             state.error!!.contains("Failed to load AI model"),
             "settings read failure on warm engine must surface an error, got: ${state.error}",
         )
+        // Hydration is atomic: the failed settings read must leave the ViewModel
+        // without an active model so the sheet cannot present fabricated defaults
+        // as the real configuration (review #1460 Finding 2).
+        assertNull(currentModels.last())
+        assertNull(viewModel.activeModelSettings.value)
         coVerify(exactly = 0) { inferenceEngine.initialize(any()) }
+
+        // Apply cannot persist/reconfigure fabricated fallback values without an
+        // active settings snapshot.
+        val fabricatedDraft = ModelSettingsEntity(
+            modelId = "gemma_4_e4b",
+            contextWindowSize = 4096,
+            temperature = 0.9f,
+            topP = 0.8f,
+            topK = 32,
+            showThinkingProcess = true,
+            speculativeDecodingEnabled = false,
+            updatedAt = 1L,
+        )
+        viewModel.applyModelSettingsAndStartNewChat(fabricatedDraft)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { inferenceEngine.reconfigureConversation(any()) }
+        coVerify(exactly = 0) { modelSettingsRepository.saveSettings(any()) }
+        val afterApply = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+        assertTrue(
+            afterApply.error!!.contains("no active model", ignoreCase = true),
+            "apply after failed settings hydration must fail with no active model, got: ${afterApply.error}",
+        )
+        collector.cancel()
     }
 
     private fun createViewModel(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -1287,6 +1287,45 @@ class ChatViewModelInitTest {
         collector.cancel()
     }
 
+    @Test
+    fun `warm engine settings read failure surfaces error without reinitialising`() = runTest(dispatcher) {
+        val persisted = ModelSettingsEntity(
+            modelId = "gemma_4_e4b",
+            contextWindowSize = 8192,
+            temperature = 0.42f,
+            topP = 0.7f,
+            topK = 96,
+            showThinkingProcess = false,
+            speculativeDecodingEnabled = true,
+            updatedAt = 2L,
+        )
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { downloadManager.areRequiredModelsDownloaded() } returns true
+        every { downloadManager.downloadStates } returns MutableStateFlow(
+            mapOf(KernelModel.GEMMA_4_E4B to DownloadState.Downloaded("/path/to/model")),
+        )
+        coEvery { downloadManager.preferredConversationModel() } returns KernelModel.GEMMA_4_E4B
+        coEvery { downloadManager.getModelPath(any()) } returns "/path/to/model"
+        // Settings read failure must be caught and surfaced like the cold path, not
+        // escape the init coroutine (review #1460). Only the FIRST read (the init
+        // hydration) fails — later reads from the persona-collector prompt builder
+        // are unrelated pre-existing behaviour.
+        var settingsReads = 0
+        coEvery { modelSettingsRepository.getSettings(any()) } coAnswers {
+            if (settingsReads++ == 0) throw RuntimeException("db down") else persisted
+        }
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+        assertTrue(
+            state.error!!.contains("Failed to load AI model"),
+            "settings read failure on warm engine must surface an error, got: ${state.error}",
+        )
+        coVerify(exactly = 0) { inferenceEngine.initialize(any()) }
+    }
+
     private fun createViewModel(
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
     ): ChatViewModel = ChatViewModel(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -17,6 +17,7 @@ import com.kernel.ai.core.inference.download.ModelDownloadManager
 import com.kernel.ai.core.model.availability.GatedModelStatusRepository
 import com.kernel.ai.core.inference.hardware.HardwareTier
 import com.kernel.ai.core.memory.entity.ConversationEntity
+import com.kernel.ai.core.memory.entity.ModelSettingsEntity
 import com.kernel.ai.core.memory.rag.RagRepository
 import com.kernel.ai.core.memory.repository.ConversationRepository
 import com.kernel.ai.core.memory.repository.MemoryRepository
@@ -60,14 +61,17 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkStatic
 import io.mockk.clearMocks
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -1178,6 +1182,109 @@ class ChatViewModelInitTest {
             lastSystemPrompt!!.contains("set a timer for 2 hours"),
             "Independent command history replay must not leak previous commands into system prompt",
         )
+    }
+
+    @Test
+    fun `fresh viewmodel on warm engine hydrates model and settings without reinitialising`() = runTest(dispatcher) {
+        val persisted = ModelSettingsEntity(
+            modelId = "gemma_4_e4b",
+            contextWindowSize = 8192,
+            temperature = 0.42f,
+            topP = 0.7f,
+            topK = 96,
+            showThinkingProcess = false,
+            speculativeDecodingEnabled = true,
+            updatedAt = 2L,
+        )
+        // Engine reports ready BEFORE the ViewModel's init path runs (#1459).
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { downloadManager.areRequiredModelsDownloaded() } returns true
+        every { downloadManager.downloadStates } returns MutableStateFlow(
+            mapOf(KernelModel.GEMMA_4_E4B to DownloadState.Downloaded("/path/to/model")),
+        )
+        coEvery { downloadManager.preferredConversationModel() } returns KernelModel.GEMMA_4_E4B
+        coEvery { downloadManager.getModelPath(any()) } returns "/path/to/model"
+        coEvery { modelSettingsRepository.getSettings(any()) } returns persisted
+
+        val viewModel = createViewModel()
+        // currentModel is stateIn(WhileSubscribed) — collect to observe hydration.
+        val currentModels = mutableListOf<KernelModel?>()
+        val collector = launch { viewModel.currentModel.collect { currentModels += it } }
+        advanceUntilIdle()
+
+        assertEquals(KernelModel.GEMMA_4_E4B, currentModels.last())
+        assertEquals(persisted, viewModel.activeModelSettings.value)
+
+        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+        assertNotNull(state.modelCapabilities)
+        assertEquals(persisted.temperature, state.temperature)
+        assertEquals(persisted.topP, state.topP)
+        assertEquals(persisted.topK, state.topK)
+        assertFalse(state.showThinkingProcess)
+
+        // The already-ready path must never re-initialise the warm engine.
+        coVerify(exactly = 0) { inferenceEngine.initialize(any()) }
+        collector.cancel()
+    }
+
+    @Test
+    fun `sendMessage waiting on warmup mutex hydrates state without double initialising`() = runTest(dispatcher) {
+        val persisted = ModelSettingsEntity(
+            modelId = "gemma_4_e4b",
+            contextWindowSize = 8192,
+            temperature = 0.42f,
+            topP = 0.7f,
+            topK = 96,
+            showThinkingProcess = false,
+            speculativeDecodingEnabled = true,
+            updatedAt = 2L,
+        )
+        val isReadyFlow = MutableStateFlow(false)
+        // Engine warms up DURING this test. getSettings blocks until the test flips
+        // isReady, so initEngineWhenReady holds the init mutex while sendMessage's
+        // initGemma4 waits on it — the exact race that hits initGemma4's
+        // already-ready branch (#1459).
+        val settingsGate = CompletableDeferred<Unit>()
+        every { inferenceEngine.isReady } returns isReadyFlow
+        every { downloadManager.areRequiredModelsDownloaded() } returns true
+        every { downloadManager.downloadStates } returns MutableStateFlow(
+            mapOf(KernelModel.GEMMA_4_E4B to DownloadState.Downloaded("/path/to/model")),
+        )
+        coEvery { downloadManager.preferredConversationModel() } returns KernelModel.GEMMA_4_E4B
+        coEvery { downloadManager.getModelPath(any()) } returns "/path/to/model"
+        coEvery { modelSettingsRepository.getSettings(any()) } coAnswers { settingsGate.await(); persisted }
+        every { quickIntentRouter.route(any()) } returns QuickIntentRouter.RouteResult.FallThrough(input = "hello")
+        every { inferenceEngine.generate(any()) } returns flowOf(GenerationResult.Complete(durationMs = 1L))
+
+        val viewModel = createViewModel()
+        // currentModel is stateIn(WhileSubscribed) — collect to observe hydration.
+        val currentModels = mutableListOf<KernelModel?>()
+        val collector = launch { viewModel.currentModel.collect { currentModels += it } }
+        runCurrent()
+        // initEngineWhenReady is now parked inside getSettings, holding the init mutex.
+
+        viewModel.onInputChanged("hello")
+        viewModel.sendMessage()
+        runCurrent()
+        // sendMessage's initGemma4 is now waiting on the mutex.
+
+        // Engine completes warm-up while initGemma4 waits.
+        isReadyFlow.value = true
+        settingsGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(KernelModel.GEMMA_4_E4B, currentModels.last())
+        assertEquals(persisted, viewModel.activeModelSettings.value)
+
+        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+        assertNotNull(state.modelCapabilities)
+        assertEquals(persisted.temperature, state.temperature)
+        assertFalse(state.showThinkingProcess)
+
+        // Only initEngineWhenReady's cold path may initialise — initGemma4's
+        // already-ready branch must never re-initialise the warm engine.
+        coVerify(exactly = 1) { inferenceEngine.initialize(any()) }
+        collector.cancel()
     }
 
     private fun createViewModel(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelSettingsApplyTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelSettingsApplyTest.kt
@@ -233,9 +233,10 @@ class ChatViewModelSettingsApplyTest {
     fun `apply without active model sets error`() = runTest(dispatcher) {
         every { inferenceEngine.isReady } returns MutableStateFlow(true)
         every { downloadManager.areRequiredModelsDownloaded() } returns true
-        // #1459: a warm engine now hydrates the active model from the preferred model —
-        // keep the preferred model off disk so the ViewModel genuinely has no active model.
-        coEvery { downloadManager.getModelPath(any()) } returns null
+        // #1459/review #1460: a warm engine hydrates from the loaded model path —
+        // with no resolvable loaded model, the ViewModel genuinely has no active
+        // model, so apply must fail.
+        every { inferenceEngine.loadedModelPath } returns null
 
         val viewModel = createViewModel()
         advanceUntilIdle()

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelSettingsApplyTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelSettingsApplyTest.kt
@@ -233,6 +233,9 @@ class ChatViewModelSettingsApplyTest {
     fun `apply without active model sets error`() = runTest(dispatcher) {
         every { inferenceEngine.isReady } returns MutableStateFlow(true)
         every { downloadManager.areRequiredModelsDownloaded() } returns true
+        // #1459: a warm engine now hydrates the active model from the preferred model —
+        // keep the preferred model off disk so the ViewModel genuinely has no active model.
+        coEvery { downloadManager.getModelPath(any()) } returns null
 
         val viewModel = createViewModel()
         advanceUntilIdle()


### PR DESCRIPTION
Closes #1459

## Confirmed root cause

`InferenceEngine` is a process singleton, but `ChatViewModel` owns local model metadata (`activeModel`, `activeModelState`/`currentModel`, `_activeModelSettings`, `_showThinkingProcess`, `activeContextWindowSize`). Both `initEngineWhenReady()` and `initGemma4()` returned immediately when `inferenceEngine.isReady.value` was already true:

```kotlin
if (inferenceEngine.isReady.value) return
```

A fresh `ChatViewModel` created after the engine had already warmed up (previous ViewModel, or the app resumed into chat) therefore never hydrated its local state. `ChatUiState.Ready` was still reached (engine + conversation ready), but the in-chat settings sheet derives readiness from `currentModel != null && modelCapabilities != null` — both null — so it falsely showed "Model settings are available once the chat model is ready." while chat was fully usable.

Reproduced in unit tests (warm engine before ViewModel init → `currentModel`/`activeModelSettings` stay null) and confirmed the sheet shows the unavailable state when hydration is skipped.

## Changes

| File | Change |
|---|---|
| `feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt` | New shared `hydrateActiveModelState()` (resolves preferred conversation model + persisted `ModelSettingsEntity`, populates `activeModel`, `currentModel`, `_activeModelSettings`, `_showThinkingProcess`, `activeContextWindowSize`). The already-ready branches of both `initEngineWhenReady()` and `initGemma4()` now hydrate before returning; the cold-start paths reuse the same helper (same assignments, same `ModelConfig`, same post-initialize `resolvedMaxTokens` sync — no behaviour change). |
| `feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt` | 2 regression tests (see below). |
| `feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelSettingsApplyTest.kt` | `apply without active model sets error` previously relied on the bug (warm engine ⇒ never hydrated). Now stubs `getModelPath → null` so the ViewModel genuinely has no active model; the tested contract (apply errors without persisting/reconfiguring) is unchanged. |

## Why the warm engine is never reloaded

The already-ready branch calls only `hydrateActiveModelState()` (local state assignment + `downloadManager`/`modelSettingsRepository` reads) and syncs `activeContextWindowSize` from the engine's published `resolvedMaxTokens` (the same read the cold path does after `initialize()`). It never calls `InferenceEngine.initialize(...)`, `resetConversation()`, `reconfigureConversation(...)` or `updateSystemPrompt(...)`. Regression tests assert `initialize` is not called on the warm path.

## Regression tests

Both exercise the real lifecycle (no field-setup shortcuts):

1. `fresh viewmodel on warm engine hydrates model and settings without reinitialising` — engine `isReady == true` **before** ViewModel construction; preferred model already downloaded; verifies `currentModel == GEMMA_4_E4B`, `activeModelSettings == persisted settings`, `ChatUiState.Ready.modelCapabilities` non-null, sampler/thinking values from persisted settings, and `initialize` never called. **Fails on pre-fix code** (verified by running it against the reverted implementation).
2. `sendMessage waiting on warmup mutex hydrates state without double initialising` — covers `initGemma4`'s already-ready branch via the real race: `initEngineWhenReady` holds the init mutex while `sendMessage`'s `initGemma4` waits; engine flips ready while it waits; verifies hydration and `initialize` called exactly once (only by the cold path).

## Build results

- `./gradlew :feature:chat:testDebugUnitTest` — **618 tests, 0 failures**
- `./gradlew assembleDebug` — **BUILD SUCCESSFUL**

## Device evidence (S23U — Honor Magic 8 Pro not connected)

Smoke-tested on the connected S23U (issue's Honor device unavailable; second device is optional per issue):

1. Cold start: LiteRT GPU environment + `Gemma4DataProcessor` created once (17:01), engine warm.
2. Back → re-entered chat: fresh `ChatViewModel` attached to the warm engine.
3. Tapped the Model settings icon: sheet rendered the **real controls** — "Gemma 4 E-2B / GPU / Temperature 1.0 / Top-P 0.95 / Top-K 64 / Thinking mode" — not the false not-ready message.
4. No reload: logcat shows no new LiteRT environment and no `Engine ready — backend:` (initialize's completion marker) after re-entry; only the pre-existing persona-collector `updateSystemPrompt`/conversation-reset.

Do not merge — wait for review.