### PR TITLE
fix(#1463): recover Android TTS when default engine is stale

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidTextToSpeechController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidTextToSpeechController.kt
@@ -29,10 +29,50 @@ private const val PLAYBACK_TIMEOUT_MS = 30_000L
 
 private const val TAG = "KernelAI"
 
+/**
+ * Test seam for [AndroidTextToSpeechController]: creates a [TextToSpeech] instance using
+ * either the configured default engine (`enginePackage == null`) or an explicit engine
+ * package (the recovery path).
+ */
+internal fun interface TextToSpeechFactory {
+    fun create(listener: TextToSpeech.OnInitListener, enginePackage: String?): TextToSpeech
+}
+
 @Singleton
 class AndroidTextToSpeechController @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : VoiceOutputController {
+
+    private var ttsFactory: TextToSpeechFactory = TextToSpeechFactory { listener, enginePackage ->
+        if (enginePackage == null) {
+            TextToSpeech(context, listener)
+        } else {
+            TextToSpeech(context, listener, enginePackage)
+        }
+    }
+
+    /**
+     * Package the implicit default-engine attempt targeted, captured from
+     * [TextToSpeech.getDefaultEngine] so the recovery path never retries the engine that
+     * just failed. The recovery path never reads or writes the device's global
+     * `Settings.Secure.TTS_DEFAULT_SYNTH` value.
+     */
+    private var defaultEnginePackage: String? = null
+
+    /**
+     * Installed engines captured from the default-engine attempt via
+     * [TextToSpeech.getEngines] (SDK 35+ exposes engine enumeration as an instance API;
+     * it reads the package manager, independent of init success). Used only by the
+     * recovery path in [selectFallbackEngine].
+     */
+    private var installedEngines: List<TextToSpeech.EngineInfo>? = null
+
+    internal constructor(
+        context: Context,
+        ttsFactory: TextToSpeechFactory,
+    ) : this(context) {
+        this.ttsFactory = ttsFactory
+    }
 
     private data class ActivePlayback(
         val token: Long,
@@ -241,12 +281,42 @@ class AndroidTextToSpeechController @Inject constructor(
             return@withContext waitForInit(existingInit)
         }
 
+        // Normal path (#1463): use Android's configured default engine, exactly as before.
+        val defaultEngine = initializeEngine(enginePackage = null)
+        if (defaultEngine != null) {
+            return@withContext defaultEngine
+        }
+
+        // Recovery path (#1463): the configured default engine is stale or missing. Pick an
+        // actually installed engine (never the one that just failed) and retry once with the
+        // explicit-engine constructor. The device's global TTS default is never modified.
+        val fallbackPackage = selectFallbackEngine()
+        if (fallbackPackage == null) {
+            Log.w(
+                TAG,
+                "AndroidTextToSpeechController: default TTS engine unavailable and no installed " +
+                    "engine found for recovery; reporting Unavailable.",
+            )
+            return@withContext null
+        }
+        Log.i(
+            TAG,
+            "AndroidTextToSpeechController: default TTS engine unavailable; retrying with " +
+                "installed engine package $fallbackPackage.",
+        )
+        initializeEngine(enginePackage = fallbackPackage)
+    }
+
+    private suspend fun initializeEngine(enginePackage: String?): TextToSpeech? {
         val deferred = CompletableDeferred<Int>()
         initDeferred = deferred
 
-        val engine = TextToSpeech(context) { status ->
-            if (!deferred.isCompleted) deferred.complete(status)
-        }
+        val engine = ttsFactory.create(
+            listener = { status ->
+                if (!deferred.isCompleted) deferred.complete(status)
+            },
+            enginePackage = enginePackage,
+        )
         engine.setAudioAttributes(
             AudioAttributes.Builder()
                 .setUsage(AudioAttributes.USAGE_ASSISTANT)
@@ -287,20 +357,45 @@ class AndroidTextToSpeechController @Inject constructor(
             }
         )
         textToSpeech = engine
-        waitForInit(deferred)
+        val ready = waitForInit(deferred)
+        if (enginePackage == null && ready == null) {
+            // The default-engine attempt failed: capture the engine it targeted and the
+            // installed-engine snapshot so the recovery path can pick a different engine.
+            defaultEnginePackage = engine.defaultEngine
+            installedEngines = engine.engines
+        }
+        return ready
     }
+
+    /**
+     * Deterministic recovery selection: [TextToSpeech.getEngines] already returns the
+     * actually installed engines in the platform's own order (engine service priority), so
+     * take the first entry, skipping the package the default-engine attempt just failed on.
+     * Only installed engines are considered; the global TTS default setting is never read
+     * or written here.
+     */
+    private fun selectFallbackEngine(): String? =
+        (installedEngines ?: emptyList())
+            .asSequence()
+            .map { it.name }
+            .filter { enginePackage -> enginePackage != null && enginePackage != defaultEnginePackage }
+            .firstOrNull()
 
     private suspend fun waitForInit(deferred: CompletableDeferred<Int>): TextToSpeech? {
         val status = deferred.await()
-        return if (status == TextToSpeech.SUCCESS) {
-            textToSpeech
-        } else {
-            Log.w(TAG, "AndroidTextToSpeechController: init failed with status=$status")
+        if (status == TextToSpeech.SUCCESS) {
+            return textToSpeech
+        }
+        Log.w(TAG, "AndroidTextToSpeechController: init failed with status=$status")
+        // Only the caller that owns the current attempt performs cleanup, and only if no
+        // newer attempt (the recovery retry) has already replaced it. Concurrent waiters on
+        // a superseded attempt return failure without touching the newer instance.
+        if (initDeferred === deferred) {
             textToSpeech?.shutdown()
             textToSpeech = null
             initDeferred = null
-            null
         }
+        return null
     }
 
     private fun onUtteranceFinished(utteranceId: String?) {

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidTextToSpeechControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidTextToSpeechControllerTest.kt
@@ -1,0 +1,274 @@
+package com.kernel.ai.core.voice
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.speech.tts.TextToSpeech
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import io.mockk.verify
+import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Focused tests for #1463: Android TTS recovery when the configured default engine is
+ * stale/unavailable. The real [TextToSpeech] constructor is replaced with the controller's
+ * local seam ([TextToSpeechFactory]); the fake instances control init statuses and report
+ * installed engines from [TextToSpeech.getEngines], so discovery is fully controlled.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AndroidTextToSpeechControllerTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val context = mockk<Context>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        stubFrameworkBuilders()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkConstructor(AudioFocusRequest.Builder::class)
+        unmockkConstructor(AudioAttributes.Builder::class)
+    }
+
+    /**
+     * Fires the init listener synchronously so tests control per-attempt init status.
+     * [installedEngines] controls what the created instance reports from
+     * [TextToSpeech.getEngines] — the discovery source for the recovery path.
+     */
+    private class FakeTtsFactory(
+        private val initStatuses: List<Int> = listOf(TextToSpeech.SUCCESS),
+        private val defaultEnginePackage: String? = null,
+        private val installedEngines: List<TextToSpeech.EngineInfo> = emptyList(),
+    ) : TextToSpeechFactory {
+        val created = mutableListOf<TextToSpeech>()
+        val packages = mutableListOf<String?>()
+
+        override fun create(listener: TextToSpeech.OnInitListener, enginePackage: String?): TextToSpeech {
+            val engine = mockk<TextToSpeech>(relaxed = true)
+            if (defaultEnginePackage != null) {
+                every { engine.defaultEngine } returns defaultEnginePackage
+            }
+            every { engine.engines } returns installedEngines
+            created += engine
+            packages += enginePackage
+            // repeat the last configured status for any additional attempts
+            val status = initStatuses.getOrElse(created.size - 1) { initStatuses.last() }
+            listener.onInit(status)
+            return engine
+        }
+    }
+
+    private fun engineInfo(name: String): TextToSpeech.EngineInfo =
+        TextToSpeech.EngineInfo().apply { this.name = name }
+
+    private fun buildController(
+        factory: FakeTtsFactory = FakeTtsFactory(),
+    ): Pair<AndroidTextToSpeechController, FakeTtsFactory> {
+        val controller = AndroidTextToSpeechController(context, factory)
+        return controller to factory
+    }
+
+    /**
+     * Real Android fluent builders (AudioAttributes.Builder, AudioFocusRequest.Builder)
+     * return null from every method under the JVM unit-test stub, so their fluent chains
+     * would NPE. Intercept construction and route each chain onto a fully stubbed builder
+     * mock instead.
+     */
+    private fun stubFrameworkBuilders() {
+        val audioManager = mockk<AudioManager>(relaxed = true)
+        every { context.getSystemService(Context.AUDIO_SERVICE) } returns audioManager
+        every { audioManager.requestAudioFocus(any()) } returns AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+
+        val audioAttributes = mockk<AudioAttributes>(relaxed = true)
+        val attributesBuilder = mockk<AudioAttributes.Builder>()
+        every { attributesBuilder.setUsage(any()) } returns attributesBuilder
+        every { attributesBuilder.setContentType(any()) } returns attributesBuilder
+        every { attributesBuilder.build() } returns audioAttributes
+        mockkConstructor(AudioAttributes.Builder::class)
+        every { anyConstructed<AudioAttributes.Builder>().setUsage(any()) } returns attributesBuilder
+        every { anyConstructed<AudioAttributes.Builder>().setContentType(any()) } returns attributesBuilder
+
+        val focusRequest = mockk<AudioFocusRequest>(relaxed = true)
+        val focusBuilder = mockk<AudioFocusRequest.Builder>()
+        every { focusBuilder.setAudioAttributes(any()) } returns focusBuilder
+        every { focusBuilder.setAcceptsDelayedFocusGain(any()) } returns focusBuilder
+        every { focusBuilder.setWillPauseWhenDucked(any()) } returns focusBuilder
+        every { focusBuilder.setOnAudioFocusChangeListener(any()) } returns focusBuilder
+        every { focusBuilder.build() } returns focusRequest
+        mockkConstructor(AudioFocusRequest.Builder::class)
+        every { anyConstructed<AudioFocusRequest.Builder>().setAudioAttributes(any()) } returns focusBuilder
+        every { anyConstructed<AudioFocusRequest.Builder>().setAcceptsDelayedFocusGain(any()) } returns focusBuilder
+        every { anyConstructed<AudioFocusRequest.Builder>().setWillPauseWhenDucked(any()) } returns focusBuilder
+        every { anyConstructed<AudioFocusRequest.Builder>().setOnAudioFocusChangeListener(any()) } returns focusBuilder
+    }
+
+    @Test
+    fun `valid default engine initialises without discovery or explicit-engine retry`() =
+        runTest(dispatcher) {
+            val (controller, factory) = buildController()
+
+            val result = controller.warmUp()
+
+            assertEquals(VoiceOutputResult.Spoken, result)
+            // normal default-engine constructor only; no engine discovery, no retry
+            assertEquals(1, factory.created.size)
+            assertNull(factory.packages[0])
+            verify(exactly = 0) { factory.created[0].getEngines() }
+            verify(exactly = 0) { factory.created[0].shutdown() }
+        }
+
+    @Test
+    fun `stale default engine shuts down failed instance then retries installed engine`() =
+        runTest(dispatcher) {
+            val (controller, factory) = buildController(
+                factory = FakeTtsFactory(
+                    initStatuses = listOf(TextToSpeech.ERROR, TextToSpeech.SUCCESS),
+                    installedEngines = listOf(engineInfo("com.google.android.tts")),
+                ),
+            )
+
+            val result = controller.warmUp()
+
+            assertEquals(VoiceOutputResult.Spoken, result)
+            // default attempt (null package) failed, discovery ran, then one explicit retry
+            assertEquals(2, factory.created.size)
+            assertEquals(listOf(null, "com.google.android.tts"), factory.packages)
+            verify { factory.created[0].getEngines() }
+            verify { factory.created[0].shutdown() }
+            verify(exactly = 0) { factory.created[1].shutdown() }
+        }
+
+    @Test
+    fun `recovery skips the failed default package when it is still listed as installed`() =
+        runTest(dispatcher) {
+            val (controller, factory) = buildController(
+                factory = FakeTtsFactory(
+                    initStatuses = listOf(TextToSpeech.ERROR, TextToSpeech.SUCCESS),
+                    defaultEnginePackage = "com.example.broken",
+                    installedEngines = listOf(
+                        engineInfo("com.example.broken"),
+                        engineInfo("com.google.android.tts"),
+                    ),
+                ),
+            )
+
+            val result = controller.warmUp()
+
+            assertEquals(VoiceOutputResult.Spoken, result)
+            assertEquals(listOf(null, "com.google.android.tts"), factory.packages)
+            verify { factory.created[0].shutdown() }
+        }
+
+    @Test
+    fun `warmUp after successful fallback reuses the recovered engine`() =
+        runTest(dispatcher) {
+            val (controller, factory) = buildController(
+                factory = FakeTtsFactory(
+                    initStatuses = listOf(TextToSpeech.ERROR, TextToSpeech.SUCCESS),
+                    installedEngines = listOf(engineInfo("com.google.android.tts")),
+                ),
+            )
+
+            val first = controller.warmUp()
+            val second = controller.warmUp()
+
+            assertEquals(VoiceOutputResult.Spoken, first)
+            assertEquals(VoiceOutputResult.Spoken, second)
+            // default attempt + one recovery retry, and no recreation on the second warmUp
+            assertEquals(2, factory.created.size)
+            verify(exactly = 1) { factory.created[0].getEngines() }
+            verify(exactly = 0) { factory.created[1].shutdown() }
+        }
+
+    @Test
+    fun `no usable engine returns Unavailable and leaves clean state for later retry`() =
+        runTest(dispatcher) {
+            val (controller, factory) = buildController(
+                factory = FakeTtsFactory(
+                    initStatuses = listOf(TextToSpeech.ERROR, TextToSpeech.ERROR),
+                    installedEngines = listOf(engineInfo("com.google.android.tts")),
+                ),
+            )
+
+            val first = controller.warmUp()
+            val second = controller.warmUp()
+
+            assertTrue(first is VoiceOutputResult.Unavailable)
+            assertTrue(second is VoiceOutputResult.Unavailable)
+            // the second warmUp re-attempts from scratch (default + recovery): no stale
+            // instance is reused and no unresolved init deferred blocks a later caller
+            assertEquals(4, factory.created.size)
+            factory.created.forEach { verify { it.shutdown() } }
+        }
+
+    @Test
+    fun `no installed engines means no retry attempt`() = runTest(dispatcher) {
+        val (controller, factory) = buildController(
+            factory = FakeTtsFactory(initStatuses = listOf(TextToSpeech.ERROR)),
+        )
+
+        val result = controller.warmUp()
+
+        assertTrue(result is VoiceOutputResult.Unavailable)
+        // discovery ran (getEngines on the failed default instance) but found nothing
+        assertEquals(1, factory.created.size)
+        verify { factory.created[0].getEngines() }
+        verify { factory.created[0].shutdown() }
+    }
+
+    @Test
+    fun `speak uses the recovered engine after fallback`() = runTest(dispatcher) {
+        val (controller, factory) = buildController(
+            factory = FakeTtsFactory(
+                initStatuses = listOf(TextToSpeech.ERROR, TextToSpeech.SUCCESS),
+                installedEngines = listOf(engineInfo("com.google.android.tts")),
+            ),
+        )
+
+        val result = controller.speak(VoiceSpeakRequest(text = "hello", locale = Locale.US))
+
+        assertEquals(VoiceOutputResult.Spoken, result)
+        val recovered = factory.created[1]
+        verify { recovered.speak("hello", TextToSpeech.QUEUE_FLUSH, any(), any()) }
+        verify(exactly = 0) { factory.created[0].speak(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `streaming session uses the recovered engine after fallback`() = runTest(dispatcher) {
+        val (controller, factory) = buildController(
+            factory = FakeTtsFactory(
+                initStatuses = listOf(TextToSpeech.ERROR, TextToSpeech.SUCCESS),
+                installedEngines = listOf(engineInfo("com.google.android.tts")),
+            ),
+        )
+
+        val session = controller.openStreamingSession(
+            VoiceSpeakRequest(text = "", locale = Locale.US),
+        )
+        val result = session.append("streamed reply", isFinal = true)
+
+        assertEquals(VoiceOutputResult.Spoken, result)
+        val recovered = factory.created[1]
+        verify { recovered.speak("streamed reply", TextToSpeech.QUEUE_FLUSH, any(), any()) }
+        verify(exactly = 0) { factory.created[0].speak(any(), any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
Closes #1463

## Proven device failure being fixed

On the Honor Magic 8 Pro (`tts_default_synth = com.samsung.SMT`, Samsung engine **not installed**, only `com.google.android.tts` installed), the normal Android TTS path produced **no speech**: `AndroidTextToSpeechController` constructed `TextToSpeech(context)` against the stale configured default, init failed, and the controller returned `Unavailable` — a silent, broken fallback. Pointing the device default at the installed Google engine made the same path speak (evidence from #1449 bounded investigation, original device setting restored afterwards).

## Recovery policy

In `AndroidTextToSpeechController.ensureReady()`:

1. **Normal path unchanged** — construct `TextToSpeech(context)` with the configured default engine. If init succeeds, retain and use that engine; no discovery, no retry, no Google-TTS forcing.
2. **Recovery path** — only when default-engine init fails:
   - the failed instance is shut down and cleared (`waitForInit`, now ownership-guarded so a concurrent waiter can never tear down a newer attempt);
   - installed engines are inspected via the default attempt's `TextToSpeech.getEngines()` (SDK 35+ instance API; reads the package manager, independent of init state);
   - **selection rule**: first engine in Android's `getEngines()` order (the platform's engine-priority order), skipping the package that just failed — deterministic, only actually installed engines considered, never hard-coded to Google TTS;
   - retried **once** with the explicit-engine constructor `TextToSpeech(context, listener, package)`; the recovered instance is retained for `warmUp()`/`speak()`/streaming.
3. **Failure semantics** — if no installed engine exists or the retry also fails: `VoiceOutputResult.Unavailable`, clean state (no stale instance, no unresolved `initDeferred`), safe to retry later.
4. `Settings.Secure.TTS_DEFAULT_SYNTH` is **never read or written**; no privileged settings access.

## Files changed

- `core/voice/src/main/java/com/kernel/ai/core/voice/AndroidTextToSpeechController.kt` — recovery path; local `TextToSpeechFactory` test seam (construction only; no abstraction layer).
- `core/voice/src/test/java/com/kernel/ai/core/voice/AndroidTextToSpeechControllerTest.kt` — new focused tests (8).

No changes to `FallbackVoiceOutputController`, Sherpa/Kokoro routing, audio focus, utterance callbacks, stop(), or the playback timeout.

## Tests run

- `:core:voice:testDebugUnitTest --tests "*AndroidTextToSpeechControllerTest*" --tests "*FallbackVoiceOutputControllerTest*"` — 22 tests, 0 failures (14 existing fallback-routing tests stay green).
- `:core:voice:testDebugUnitTest` (full module) — **234 tests, 0 failures**.
- `:app:testDebugUnitTest` — **1079 tests, 0 failures**.
- `:app:assembleDebug` — success.
- `:core:voice:lintDebug` — success.

Coverage: valid default succeeds without discovery/retry; stale default shuts down failed instance, discovers, retries explicit installed engine; selection skips the failed default package when still listed; recovered engine reused across `warmUp()`; no usable engine → `Unavailable` with clean state for later retry (no unresolved deferred); `speak()` and streaming use the recovered engine.

## Honor physical validation

**Not performed — device unreachable.** The Honor Magic 8 Pro is alive on Tailscale (100.72.7.37) but wireless debugging is inactive (no listener found on the 36000–50000 port band; last known ports 42127/38895 stale). Remaining device acceptance evidence (per #1463): confirm `com.samsung.SMT` absent + `com.google.android.tts` installed, run the Android-TTS path with `tts_default_synth = com.samsung.SMT` unchanged → spoken reply, no crash, setting unchanged; exercise a Sherpa/Kokoro-unavailable fallback to Android TTS. A single focused pass on the device is still required before this can be considered fully device-validated.

Do not merge — wait for review.