### PR TITLE
fix(#1468): preserve debug-latest during release cleanup

### DIFF
--- a/.github/workflows/cleanup-old-releases.yml
+++ b/.github/workflows/cleanup-old-releases.yml
@@ -31,7 +31,7 @@ jobs:
             --limit 100 \
             --json tagName,publishedAt,isPrerelease \
             --jq --arg cutoff "$CUTOFF" \
-              '.[] | select(.isPrerelease == true and .publishedAt < $cutoff) | .tagName' \
+              '.[] | select(.isPrerelease == true and .tagName != "debug-latest" and .publishedAt < $cutoff) | .tagName' \
           | while read -r TAG; do
               echo "Deleting release + tag: $TAG"
               gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag 2>/dev/null || true


### PR DESCRIPTION
Closes #1468

## Summary

Exclude the reserved `debug-latest` prerelease from the manual age-based cleanup workflow.

## Change

The existing `gh release list` jq filter now requires:

```text
.tagName != "debug-latest"
```

Everything else is unchanged: old prereleases beyond the configured cutoff are still deleted as before.

## Why

`ci.yml` publishes the canonical main debug APK as the `debug-latest` prerelease. The cleanup workflow previously treated it like any other prerelease, so after a quiet period it could delete the main install artifact.

## Validation

This is a single-condition workflow change with no application/runtime code impact. On merge, the resulting push to `main` will also run CI and recreate/update the `debug-latest` release if CI succeeds.