### PR TITLE
feat(#1422): spike Inflect Micro ONNX graph execution

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -49,6 +49,14 @@
                 <action android:name="com.kernel.ai.debug.action.VERIFY_WAKE_WINDOW" />
             </intent-filter>
         </receiver>
+        <receiver
+            android:name="com.kernel.ai.debug.inflect.InflectSpikeReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.kernel.ai.debug.action.RUN_INFLECT_GRAPH_PROBE" />
+                <action android:name="com.kernel.ai.debug.action.CANCEL_INFLECT_GRAPH_PROBE" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/debug/java/com/kernel/ai/debug/inflect/InflectSpikeReceiver.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/inflect/InflectSpikeReceiver.kt
@@ -46,6 +46,9 @@ class InflectSpikeReceiver : BroadcastReceiver() {
                 }
             } catch (error: CancellationException) {
                 finish(pendingResult, RESULT_CANCELLED, "cancelled")
+            } catch (error: OutOfMemoryError) {
+                Log.e(TAG, "Inflect graph probe ran out of memory", error)
+                finish(pendingResult, RESULT_FAILED, "probe_out_of_memory")
             } catch (error: Exception) {
                 Log.e(TAG, "Inflect graph probe failed", error)
                 finish(pendingResult, RESULT_FAILED, "probe_failed:${error.message}")
@@ -63,6 +66,14 @@ class InflectSpikeReceiver : BroadcastReceiver() {
         }
 
         val phonemeText = intent.getStringExtra(EXTRA_PHONEME_TEXT) ?: DEFAULT_PHONEME_TEXT
+        if (phonemeText.length > InflectMicroOnnxRunner.MAX_PHONEME_TEXT_LENGTH) {
+            finish(
+                pendingResult,
+                RESULT_REJECTED,
+                "phoneme_text_too_long:max=${InflectMicroOnnxRunner.MAX_PHONEME_TEXT_LENGTH}",
+            )
+            return
+        }
         val label = safeLabel(intent.getStringExtra(EXTRA_LABEL) ?: "graph-probe")
         val wavFile = File(context.filesDir, "$EVIDENCE_DIRECTORY/$label.wav")
         val summaryFile = File(context.filesDir, "$EVIDENCE_DIRECTORY/$label.json")
@@ -70,8 +81,8 @@ class InflectSpikeReceiver : BroadcastReceiver() {
 
         val initStarted = System.nanoTime()
         val runner = InflectMicroOnnxRunner(modelDirectory)
-        InflectSpikeRuntime.install(runner)
         try {
+            InflectSpikeRuntime.install(runner)
             val initMs = (System.nanoTime() - initStarted) / 1_000_000L
             val synthesis = runner.synthesize(
                 phonemeText = phonemeText,

--- a/app/src/debug/java/com/kernel/ai/debug/inflect/InflectSpikeReceiver.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/inflect/InflectSpikeReceiver.kt
@@ -1,0 +1,219 @@
+package com.kernel.ai.debug.inflect
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.kernel.ai.core.voice.InflectMicroOnnxRunner
+import java.io.BufferedOutputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Debug-only endpoint for proving the official Inflect Micro v2 ONNX graphs on Android.
+ *
+ * This intentionally accepts phoneme text, not user text. The existing Sherpa AAR does not expose
+ * its bundled eSpeak-ng phoneme output, so this endpoint stops at graph isolation rather than
+ * pretending that a frontend exists.
+ */
+class InflectSpikeReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val pendingResult = goAsync()
+        val appContext = context.applicationContext
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                if (!isExplicitInvocation(appContext, intent)) {
+                    finish(pendingResult, RESULT_REJECTED, "explicit_component_required")
+                    return@launch
+                }
+                when (intent.action) {
+                    ACTION_CANCEL -> {
+                        val cancelled = InflectSpikeRuntime.cancel()
+                        finish(
+                            pendingResult,
+                            if (cancelled) RESULT_OK else RESULT_REJECTED,
+                            if (cancelled) "cancel_requested" else "no_active_probe",
+                        )
+                    }
+                    ACTION_RUN_GRAPH_PROBE -> runProbe(appContext, intent, pendingResult)
+                    else -> finish(pendingResult, RESULT_REJECTED, "unknown_action")
+                }
+            } catch (error: CancellationException) {
+                finish(pendingResult, RESULT_CANCELLED, "cancelled")
+            } catch (error: Exception) {
+                Log.e(TAG, "Inflect graph probe failed", error)
+                finish(pendingResult, RESULT_FAILED, "probe_failed:${error.message}")
+            }
+        }
+    }
+
+    private fun runProbe(context: Context, intent: Intent, pendingResult: PendingResult) {
+        val modelDirectory = File(context.filesDir, MODEL_DIRECTORY)
+        if (!File(modelDirectory, InflectMicroOnnxRunner.DURATION_MODEL_FILE).isFile ||
+            !File(modelDirectory, InflectMicroOnnxRunner.DECODE_MODEL_FILE).isFile
+        ) {
+            finish(pendingResult, RESULT_FAILED, "model_files_missing:${modelDirectory.path}")
+            return
+        }
+
+        val phonemeText = intent.getStringExtra(EXTRA_PHONEME_TEXT) ?: DEFAULT_PHONEME_TEXT
+        val label = safeLabel(intent.getStringExtra(EXTRA_LABEL) ?: "graph-probe")
+        val wavFile = File(context.filesDir, "$EVIDENCE_DIRECTORY/$label.wav")
+        val summaryFile = File(context.filesDir, "$EVIDENCE_DIRECTORY/$label.json")
+        wavFile.parentFile?.mkdirs()
+
+        val initStarted = System.nanoTime()
+        val runner = InflectMicroOnnxRunner(modelDirectory)
+        InflectSpikeRuntime.install(runner)
+        try {
+            val initMs = (System.nanoTime() - initStarted) / 1_000_000L
+            val synthesis = runner.synthesize(
+                phonemeText = phonemeText,
+                speed = intent.getFloatExtra(EXTRA_SPEED, 1.0f),
+                variation = intent.getFloatExtra(EXTRA_VARIATION, 0.667f),
+                seed = intent.getLongExtra(EXTRA_SEED, 7L),
+            )
+            writeFloatWav(wavFile, synthesis.waveform)
+            val summary = buildSummary(
+                runner = runner,
+                synthesis = synthesis,
+                initMs = initMs,
+                wavFile = wavFile,
+                modelDirectory = modelDirectory,
+            )
+            summaryFile.writeText(summary)
+            Log.i(TAG, summary)
+            finish(pendingResult, RESULT_OK, summaryFile.path)
+        } finally {
+            InflectSpikeRuntime.clear(runner)
+            runner.close()
+        }
+    }
+
+    private fun buildSummary(
+        runner: InflectMicroOnnxRunner,
+        synthesis: com.kernel.ai.core.voice.InflectOnnxSynthesis,
+        initMs: Long,
+        wavFile: File,
+        modelDirectory: File,
+    ): String {
+        val audioSeconds = synthesis.audioDurationMs / 1_000.0
+        val rtf = if (audioSeconds > 0.0) synthesis.synthesisMs / 1_000.0 / audioSeconds else null
+        return """
+            {
+              "model_directory": ${json(modelDirectory.path)},
+              "duration_inputs": ${json(runner.durationInputInfo)},
+              "duration_outputs": ${json(runner.durationOutputInfo)},
+              "decode_inputs": ${json(runner.decodeInputInfo)},
+              "decode_outputs": ${json(runner.decodeOutputInfo)},
+              "phoneme_text": ${json(synthesis.phonemeText)},
+              "token_count": ${synthesis.tokenCount},
+              "duration_mean_shape": ${json(synthesis.durationMeanShape.toList())},
+              "duration_mask_shape": ${json(synthesis.durationMaskShape.toList())},
+              "waveform_shape": ${json(synthesis.waveformShape.toList())},
+              "sample_rate_hz": ${InflectMicroOnnxRunner.SAMPLE_RATE_HZ},
+              "waveform_samples": ${synthesis.waveform.size},
+              "audio_duration_ms": ${synthesis.audioDurationMs},
+              "initialization_ms": $initMs,
+              "synthesis_ms": ${synthesis.synthesisMs},
+              "real_time_factor": ${rtf ?: "null"},
+              "peak_abs": ${synthesis.peakAbs},
+              "finite": ${synthesis.finite},
+              "gain": 1.0,
+              "wav_file": ${json(wavFile.path)},
+              "playback": "not_attempted_graph_isolation_only"
+            }
+        """.trimIndent()
+    }
+
+    private fun writeFloatWav(file: File, samples: FloatArray) {
+        DataOutputStream(BufferedOutputStream(FileOutputStream(file))).use { output ->
+            val dataSize = samples.size * Float.SIZE_BYTES
+            output.writeBytes("RIFF")
+            output.writeLittleEndianInt(36 + dataSize)
+            output.writeBytes("WAVE")
+            output.writeBytes("fmt ")
+            output.writeLittleEndianInt(16)
+            output.writeLittleEndianShort(3) // IEEE float PCM
+            output.writeLittleEndianShort(1) // mono
+            output.writeLittleEndianInt(InflectMicroOnnxRunner.SAMPLE_RATE_HZ)
+            output.writeLittleEndianInt(InflectMicroOnnxRunner.SAMPLE_RATE_HZ * Float.SIZE_BYTES)
+            output.writeLittleEndianShort(Float.SIZE_BYTES)
+            output.writeLittleEndianShort(Float.SIZE_BYTES * 8)
+            output.writeBytes("data")
+            output.writeLittleEndianInt(dataSize)
+            samples.forEach { output.writeLittleEndianInt(it.toRawBits()) }
+        }
+    }
+
+    private fun isExplicitInvocation(context: Context, intent: Intent): Boolean =
+        intent.component?.packageName == context.packageName &&
+            intent.component?.className == InflectSpikeReceiver::class.java.name
+
+    private fun finish(result: PendingResult, code: Int, data: String) {
+        result.setResultCode(code)
+        result.setResultData(data)
+        result.finish()
+    }
+
+    private fun safeLabel(value: String): String =
+        value.replace(Regex("[^A-Za-z0-9._-]"), "_").take(80).ifBlank { "graph-probe" }
+
+    private fun json(value: Any?): String = when (value) {
+        null -> "null"
+        is String -> "\"${value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")}\""
+        is Iterable<*> -> value.joinToString(prefix = "[", postfix = "]") { json(it) }
+        is Number, is Boolean -> value.toString()
+        else -> json(value.toString())
+    }
+
+    private fun DataOutputStream.writeLittleEndianShort(value: Int) {
+        writeByte(value and 0xff)
+        writeByte((value ushr 8) and 0xff)
+    }
+
+    private fun DataOutputStream.writeLittleEndianInt(value: Int) {
+        writeByte(value and 0xff)
+        writeByte((value ushr 8) and 0xff)
+        writeByte((value ushr 16) and 0xff)
+        writeByte((value ushr 24) and 0xff)
+    }
+
+    companion object {
+        const val ACTION_RUN_GRAPH_PROBE = "com.kernel.ai.debug.action.RUN_INFLECT_GRAPH_PROBE"
+        const val ACTION_CANCEL = "com.kernel.ai.debug.action.CANCEL_INFLECT_GRAPH_PROBE"
+        const val EXTRA_PHONEME_TEXT = "phoneme_text"
+        const val EXTRA_LABEL = "label"
+        const val EXTRA_SEED = "seed"
+        const val EXTRA_SPEED = "speed"
+        const val EXTRA_VARIATION = "variation"
+        const val MODEL_DIRECTORY = "inflect-micro-v2-onnx"
+        const val EVIDENCE_DIRECTORY = "inflect-spike"
+        private const val DEFAULT_PHONEME_TEXT = "həlˈoʊ"
+        private const val TAG = "InflectSpike"
+        private const val RESULT_OK = 0
+        private const val RESULT_REJECTED = 2
+        private const val RESULT_FAILED = 3
+        private const val RESULT_CANCELLED = 4
+    }
+}
+
+private object InflectSpikeRuntime {
+    private val active = AtomicReference<InflectMicroOnnxRunner?>(null)
+
+    fun install(runner: InflectMicroOnnxRunner) {
+        check(active.compareAndSet(null, runner)) { "An Inflect graph probe is already active" }
+    }
+
+    fun cancel(): Boolean = active.get()?.let { it.cancel(); true } ?: false
+
+    fun clear(runner: InflectMicroOnnxRunner) {
+        active.compareAndSet(runner, null)
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/InflectMicroOnnxRunner.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/InflectMicroOnnxRunner.kt
@@ -7,6 +7,7 @@ import java.io.Closeable
 import java.nio.FloatBuffer
 import java.nio.LongBuffer
 import java.util.Random
+import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -40,9 +41,9 @@ class InflectMicroOnnxRunner(
         require(duration.isFile) { "Missing $DURATION_MODEL_FILE in ${modelDirectory.path}" }
         require(decode.isFile) { "Missing $DECODE_MODEL_FILE in ${modelDirectory.path}" }
 
-        durationSession = environment.createSession(duration.readBytes(), OrtSession.SessionOptions())
+        durationSession = createSession(duration)
         try {
-            decodeSession = environment.createSession(decode.readBytes(), OrtSession.SessionOptions())
+            decodeSession = createSession(decode)
         } catch (error: Throwable) {
             durationSession.close()
             throw error
@@ -70,7 +71,7 @@ class InflectMicroOnnxRunner(
     ): InflectOnnxSynthesis {
         require(speed in 0.5f..2.0f) { "speed must be between 0.5 and 2.0" }
         require(variation in 0.0f..1.0f) { "variation must be between 0.0 and 1.0" }
-        check(!cancelled.get()) { "Inflect synthesis cancelled" }
+        throwIfCancelled()
 
         val tokenIds = phonemesToTokenIds(phonemeText)
         val startedAt = System.nanoTime()
@@ -80,83 +81,102 @@ class InflectMicroOnnxRunner(
             LongBuffer.wrap(tokenIds),
             longArrayOf(1L, tokenIds.size.toLong()),
         )
-        val lengthsTensor = OnnxTensor.createTensor(
-            environment,
-            LongBuffer.wrap(longArrayOf(tokenIds.size.toLong())),
-            longArrayOf(1L),
-        )
-        val lengthScaleTensor = OnnxTensor.createTensor(
-            environment,
-            FloatBuffer.wrap(floatArrayOf(1.0f / speed)),
-            longArrayOf(1L),
-        )
         try {
-            val result = durationSession.run(
-                mapOf(
-                    "tokens" to tokenTensor,
-                    "lengths" to lengthsTensor,
-                    "length_scale" to lengthScaleTensor,
-                ),
-                setOf("m_p_exp", "logs_p_exp", "y_mask"),
+            val lengthsTensor = OnnxTensor.createTensor(
+                environment,
+                LongBuffer.wrap(longArrayOf(tokenIds.size.toLong())),
+                longArrayOf(1L),
             )
             try {
-                durationOutputs = InflectDurationOutputs(
-                    mean = copyTensor(result, "m_p_exp"),
-                    logScale = copyTensor(result, "logs_p_exp"),
-                    mask = copyTensor(result, "y_mask"),
+                val lengthScaleTensor = OnnxTensor.createTensor(
+                    environment,
+                    FloatBuffer.wrap(floatArrayOf(1.0f / speed)),
+                    longArrayOf(1L),
                 )
+                try {
+                    val result = durationSession.run(
+                        mapOf(
+                            "tokens" to tokenTensor,
+                            "lengths" to lengthsTensor,
+                            "length_scale" to lengthScaleTensor,
+                        ),
+                        setOf("m_p_exp", "logs_p_exp", "y_mask"),
+                    )
+                    try {
+                        durationOutputs = InflectDurationOutputs(
+                            mean = copyTensor(result, "m_p_exp"),
+                            logScale = copyTensor(result, "logs_p_exp"),
+                            mask = copyTensor(result, "y_mask"),
+                        )
+                    } finally {
+                        result.close()
+                    }
+                } finally {
+                    lengthScaleTensor.close()
+                }
             } finally {
-                result.close()
+                lengthsTensor.close()
             }
         } finally {
             tokenTensor.close()
-            lengthsTensor.close()
-            lengthScaleTensor.close()
         }
 
-        check(!cancelled.get()) { "Inflect synthesis cancelled after duration inference" }
+        throwIfCancelled()
         val latentNoise = FloatArray(durationOutputs.mean.values.size)
         val random = Random(seed)
         for (index in latentNoise.indices) latentNoise[index] = random.nextGaussian().toFloat()
-        val meanTensor = tensorFrom(durationOutputs.mean)
-        val logScaleTensor = tensorFrom(durationOutputs.logScale)
-        val maskTensor = tensorFrom(durationOutputs.mask)
-        val noiseTensor = OnnxTensor.createTensor(
-            environment,
-            FloatBuffer.wrap(latentNoise),
-            durationOutputs.mean.shape,
-        )
-        val noiseScaleTensor = OnnxTensor.createTensor(
-            environment,
-            FloatBuffer.wrap(floatArrayOf(variation)),
-            longArrayOf(1L),
-        )
         val waveform: InflectTensorData
+        val meanTensor = tensorFrom(durationOutputs.mean)
         try {
-            val result = decodeSession.run(
-                mapOf(
-                    "m_p_exp" to meanTensor,
-                    "logs_p_exp" to logScaleTensor,
-                    "y_mask" to maskTensor,
-                    "zp_noise" to noiseTensor,
-                    "noise_scale" to noiseScaleTensor,
-                ),
-                setOf("waveform"),
-            )
+            val logScaleTensor = tensorFrom(durationOutputs.logScale)
             try {
-                waveform = copyTensor(result, "waveform")
+                val maskTensor = tensorFrom(durationOutputs.mask)
+                try {
+                    val noiseTensor = OnnxTensor.createTensor(
+                        environment,
+                        FloatBuffer.wrap(latentNoise),
+                        durationOutputs.mean.shape,
+                    )
+                    try {
+                        val noiseScaleTensor = OnnxTensor.createTensor(
+                            environment,
+                            FloatBuffer.wrap(floatArrayOf(variation)),
+                            longArrayOf(1L),
+                        )
+                        try {
+                            val result = decodeSession.run(
+                                mapOf(
+                                    "m_p_exp" to meanTensor,
+                                    "logs_p_exp" to logScaleTensor,
+                                    "y_mask" to maskTensor,
+                                    "zp_noise" to noiseTensor,
+                                    "noise_scale" to noiseScaleTensor,
+                                ),
+                                setOf("waveform"),
+                            )
+                            try {
+                                waveform = copyTensor(result, "waveform")
+                            } finally {
+                                result.close()
+                            }
+                        } finally {
+                            noiseScaleTensor.close()
+                        }
+                    } finally {
+                        noiseTensor.close()
+                    }
+                } finally {
+                    maskTensor.close()
+                }
             } finally {
-                result.close()
+                logScaleTensor.close()
             }
         } finally {
             meanTensor.close()
-            logScaleTensor.close()
-            maskTensor.close()
-            noiseTensor.close()
-            noiseScaleTensor.close()
         }
+        validateWaveformShape(waveform.shape)
 
-        check(!cancelled.get()) { "Inflect synthesis cancelled after decode inference" }
+        throwIfCancelled()
         val elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L
         return InflectOnnxSynthesis(
             phonemeText = phonemeText,
@@ -176,6 +196,21 @@ class InflectMicroOnnxRunner(
     override fun close() {
         durationSession.close()
         decodeSession.close()
+    }
+
+    private fun createSession(model: java.io.File): OrtSession {
+        val options = OrtSession.SessionOptions()
+        return try {
+            environment.createSession(model.readBytes(), options)
+        } finally {
+            options.close()
+        }
+    }
+
+    private fun throwIfCancelled() {
+        if (cancelled.get()) {
+            throw CancellationException("Inflect synthesis cancelled")
+        }
     }
 
     private fun tensorFrom(data: InflectTensorData): OnnxTensor = OnnxTensor.createTensor(
@@ -217,6 +252,8 @@ class InflectMicroOnnxRunner(
 
     companion object {
         const val SAMPLE_RATE_HZ = 24_000
+        // Graph-isolation probes are intentionally bounded to keep debug broadcasts predictable.
+        const val MAX_PHONEME_TEXT_LENGTH = 1_024
         const val DURATION_MODEL_FILE = "duration.onnx"
         const val DECODE_MODEL_FILE = "decode.onnx"
 
@@ -231,6 +268,9 @@ class InflectMicroOnnxRunner(
         /** Converts already-phonemised IPA text into Inflect's blank-interleaved token IDs. */
         fun phonemesToTokenIds(phonemeText: String): LongArray {
             require(phonemeText.isNotEmpty()) { "Phoneme text must not be empty" }
+            require(phonemeText.length <= MAX_PHONEME_TEXT_LENGTH) {
+                "Phoneme text exceeds $MAX_PHONEME_TEXT_LENGTH characters"
+            }
             val symbolIds = HashMap<Char, Int>(SYMBOLS.length)
             SYMBOLS.forEachIndexed { index, symbol -> symbolIds.putIfAbsent(symbol, index) }
             val ids = LongArray(phonemeText.length * 2 + 1)
@@ -240,6 +280,16 @@ class InflectMicroOnnxRunner(
                 ids[index * 2 + 1] = id.toLong()
             }
             return ids
+        }
+        internal fun validateWaveformShape(shape: LongArray) {
+            require(
+                shape.size == 3 &&
+                    shape[0] == 1L &&
+                    shape[1] == 1L &&
+                    shape[2] > 0L,
+            ) {
+                "Expected mono waveform shape [1, 1, samples], got ${shape.contentToString()}"
+            }
         }
 
         private fun product(shape: LongArray): Int = shape.fold(1L) { total, dimension ->

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/InflectMicroOnnxRunner.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/InflectMicroOnnxRunner.kt
@@ -1,0 +1,279 @@
+package com.kernel.ai.core.voice
+
+import ai.onnxruntime.OnnxTensor
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtSession
+import java.io.Closeable
+import java.nio.FloatBuffer
+import java.nio.LongBuffer
+import java.util.Random
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Direct ONNX Runtime probe for the official Inflect Micro v2 export.
+ *
+ * This is deliberately not a [VoiceOutputController]. It proves the two official graphs can be
+ * executed with Jandal's existing ONNX Runtime before any text frontend or playback integration is
+ * attempted. The caller supplies precomputed phoneme symbols for this isolation step.
+ */
+class InflectMicroOnnxRunner(
+    modelDirectory: java.io.File,
+    private val environment: OrtEnvironment = OrtEnvironment.getEnvironment(),
+) : Closeable {
+
+    private val durationSession: OrtSession
+    private val decodeSession: OrtSession
+    private val cancelled = AtomicBoolean(false)
+
+    val durationInputNames: List<String>
+    val durationOutputNames: List<String>
+    val decodeInputNames: List<String>
+    val decodeOutputNames: List<String>
+    val durationInputInfo: Map<String, String>
+    val durationOutputInfo: Map<String, String>
+    val decodeInputInfo: Map<String, String>
+    val decodeOutputInfo: Map<String, String>
+
+    init {
+        val duration = java.io.File(modelDirectory, DURATION_MODEL_FILE)
+        val decode = java.io.File(modelDirectory, DECODE_MODEL_FILE)
+        require(duration.isFile) { "Missing $DURATION_MODEL_FILE in ${modelDirectory.path}" }
+        require(decode.isFile) { "Missing $DECODE_MODEL_FILE in ${modelDirectory.path}" }
+
+        durationSession = environment.createSession(duration.readBytes(), OrtSession.SessionOptions())
+        try {
+            decodeSession = environment.createSession(decode.readBytes(), OrtSession.SessionOptions())
+        } catch (error: Throwable) {
+            durationSession.close()
+            throw error
+        }
+
+        durationInputNames = durationSession.inputNames.toList()
+        durationOutputNames = durationSession.outputNames.toList()
+        decodeInputNames = decodeSession.inputNames.toList()
+        decodeOutputNames = decodeSession.outputNames.toList()
+        durationInputInfo = durationSession.inputInfo.mapValues { it.value.info.toString() }
+        durationOutputInfo = durationSession.outputInfo.mapValues { it.value.info.toString() }
+        decodeInputInfo = decodeSession.inputInfo.mapValues { it.value.info.toString() }
+        decodeOutputInfo = decodeSession.outputInfo.mapValues { it.value.info.toString() }
+    }
+
+    /**
+     * Runs duration then decode using the exact tensor names and sequence from the official
+     * `inference_onnx.py` wrapper. No gain, clipping, resampling, or playback processing is applied.
+     */
+    fun synthesize(
+        phonemeText: String,
+        speed: Float = 1.0f,
+        variation: Float = 0.667f,
+        seed: Long = 0L,
+    ): InflectOnnxSynthesis {
+        require(speed in 0.5f..2.0f) { "speed must be between 0.5 and 2.0" }
+        require(variation in 0.0f..1.0f) { "variation must be between 0.0 and 1.0" }
+        check(!cancelled.get()) { "Inflect synthesis cancelled" }
+
+        val tokenIds = phonemesToTokenIds(phonemeText)
+        val startedAt = System.nanoTime()
+        val durationOutputs: InflectDurationOutputs
+        val tokenTensor = OnnxTensor.createTensor(
+            environment,
+            LongBuffer.wrap(tokenIds),
+            longArrayOf(1L, tokenIds.size.toLong()),
+        )
+        val lengthsTensor = OnnxTensor.createTensor(
+            environment,
+            LongBuffer.wrap(longArrayOf(tokenIds.size.toLong())),
+            longArrayOf(1L),
+        )
+        val lengthScaleTensor = OnnxTensor.createTensor(
+            environment,
+            FloatBuffer.wrap(floatArrayOf(1.0f / speed)),
+            longArrayOf(1L),
+        )
+        try {
+            val result = durationSession.run(
+                mapOf(
+                    "tokens" to tokenTensor,
+                    "lengths" to lengthsTensor,
+                    "length_scale" to lengthScaleTensor,
+                ),
+                setOf("m_p_exp", "logs_p_exp", "y_mask"),
+            )
+            try {
+                durationOutputs = InflectDurationOutputs(
+                    mean = copyTensor(result, "m_p_exp"),
+                    logScale = copyTensor(result, "logs_p_exp"),
+                    mask = copyTensor(result, "y_mask"),
+                )
+            } finally {
+                result.close()
+            }
+        } finally {
+            tokenTensor.close()
+            lengthsTensor.close()
+            lengthScaleTensor.close()
+        }
+
+        check(!cancelled.get()) { "Inflect synthesis cancelled after duration inference" }
+        val latentNoise = FloatArray(durationOutputs.mean.values.size)
+        val random = Random(seed)
+        for (index in latentNoise.indices) latentNoise[index] = random.nextGaussian().toFloat()
+        val meanTensor = tensorFrom(durationOutputs.mean)
+        val logScaleTensor = tensorFrom(durationOutputs.logScale)
+        val maskTensor = tensorFrom(durationOutputs.mask)
+        val noiseTensor = OnnxTensor.createTensor(
+            environment,
+            FloatBuffer.wrap(latentNoise),
+            durationOutputs.mean.shape,
+        )
+        val noiseScaleTensor = OnnxTensor.createTensor(
+            environment,
+            FloatBuffer.wrap(floatArrayOf(variation)),
+            longArrayOf(1L),
+        )
+        val waveform: InflectTensorData
+        try {
+            val result = decodeSession.run(
+                mapOf(
+                    "m_p_exp" to meanTensor,
+                    "logs_p_exp" to logScaleTensor,
+                    "y_mask" to maskTensor,
+                    "zp_noise" to noiseTensor,
+                    "noise_scale" to noiseScaleTensor,
+                ),
+                setOf("waveform"),
+            )
+            try {
+                waveform = copyTensor(result, "waveform")
+            } finally {
+                result.close()
+            }
+        } finally {
+            meanTensor.close()
+            logScaleTensor.close()
+            maskTensor.close()
+            noiseTensor.close()
+            noiseScaleTensor.close()
+        }
+
+        check(!cancelled.get()) { "Inflect synthesis cancelled after decode inference" }
+        val elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L
+        return InflectOnnxSynthesis(
+            phonemeText = phonemeText,
+            tokenCount = tokenIds.size,
+            durationMeanShape = durationOutputs.mean.shape,
+            durationMaskShape = durationOutputs.mask.shape,
+            waveform = waveform.values,
+            waveformShape = waveform.shape,
+            synthesisMs = elapsedMs,
+        )
+    }
+
+    fun cancel() {
+        cancelled.set(true)
+    }
+
+    override fun close() {
+        durationSession.close()
+        decodeSession.close()
+    }
+
+    private fun tensorFrom(data: InflectTensorData): OnnxTensor = OnnxTensor.createTensor(
+        environment,
+        FloatBuffer.wrap(data.values),
+        data.shape,
+    )
+
+    private fun copyTensor(result: OrtSession.Result, name: String): InflectTensorData {
+        val tensor = result.get(name).get() as OnnxTensor
+        val shape = tensor.info.shape
+        val values = flattenFloats(tensor.value, product(shape))
+        return InflectTensorData(shape, values)
+    }
+
+    private fun flattenFloats(value: Any?, expectedSize: Int): FloatArray {
+        val output = FloatArray(expectedSize)
+        var offset = 0
+
+        fun visit(item: Any?) {
+            when (item) {
+                is FloatArray -> {
+                    item.copyInto(output, destinationOffset = offset)
+                    offset += item.size
+                }
+                is Array<*> -> item.forEach(::visit)
+                is Number -> output[offset++] = item.toFloat()
+                null -> error("ONNX tensor contained null data")
+                else -> error("Unsupported ONNX tensor value ${item::class.java.name}")
+            }
+        }
+
+        visit(value)
+        check(offset == expectedSize) {
+            "ONNX tensor size mismatch: expected $expectedSize values, copied $offset"
+        }
+        return output
+    }
+
+    companion object {
+        const val SAMPLE_RATE_HZ = 24_000
+        const val DURATION_MODEL_FILE = "duration.onnx"
+        const val DECODE_MODEL_FILE = "decode.onnx"
+
+        // The official runtime/text/symbols.py list, in order. A blank is inserted between symbols
+        // exactly as in the upstream `phonemes_to_tokens` helper. This is not a text frontend.
+        private const val SYMBOLS =
+            "_" +
+                ";:,.!?¡¿—…\"«»“” " +
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+                "ɑɐɒæɓʙβɔɕçɗɖðʤəɘɚɛɜɝɞɟʄɡɠɢʛɦɧħɥʜɨɪʝɭɬɫɮʟɱɯɰŋɳɲɴøɵɸθœɶʘɹɺɾɻʀʁɽʂʃʈʧʉʊʋⱱʌɣɤʍχʎʏʑʐʒʔʡʕʢǀǁǂǃˈˌːˑʼʴʰʱʲʷˠˤ˞↓↑→↗↘'̩ᵻ"
+
+        /** Converts already-phonemised IPA text into Inflect's blank-interleaved token IDs. */
+        fun phonemesToTokenIds(phonemeText: String): LongArray {
+            require(phonemeText.isNotEmpty()) { "Phoneme text must not be empty" }
+            val symbolIds = HashMap<Char, Int>(SYMBOLS.length)
+            SYMBOLS.forEachIndexed { index, symbol -> symbolIds.putIfAbsent(symbol, index) }
+            val ids = LongArray(phonemeText.length * 2 + 1)
+            phonemeText.forEachIndexed { index, symbol ->
+                val id = symbolIds[symbol]
+                    ?: throw IllegalArgumentException("Unsupported Inflect symbol U+${symbol.code.toString(16)}")
+                ids[index * 2 + 1] = id.toLong()
+            }
+            return ids
+        }
+
+        private fun product(shape: LongArray): Int = shape.fold(1L) { total, dimension ->
+            total * dimension
+        }.also { require(it <= Int.MAX_VALUE) }.toInt()
+    }
+}
+
+data class InflectOnnxSynthesis(
+    val phonemeText: String,
+    val tokenCount: Int,
+    val durationMeanShape: LongArray,
+    val durationMaskShape: LongArray,
+    val waveform: FloatArray,
+    val waveformShape: LongArray,
+    val synthesisMs: Long,
+) {
+    val audioDurationMs: Long
+        get() = waveform.size.toLong() * 1_000L / InflectMicroOnnxRunner.SAMPLE_RATE_HZ
+
+    val peakAbs: Float
+        get() = waveform.maxOfOrNull { kotlin.math.abs(it) } ?: 0.0f
+
+    val finite: Boolean
+        get() = waveform.all(Float::isFinite)
+}
+
+private data class InflectDurationOutputs(
+    val mean: InflectTensorData,
+    val logScale: InflectTensorData,
+    val mask: InflectTensorData,
+)
+
+private data class InflectTensorData(
+    val shape: LongArray,
+    val values: FloatArray,
+)

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/InflectMicroOnnxRunnerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/InflectMicroOnnxRunnerTest.kt
@@ -37,4 +37,24 @@ class InflectMicroOnnxRunnerTest {
             InflectMicroOnnxRunner.phonemesToTokenIds("")
         }
     }
+
+    @Test
+    fun `phoneme input is bounded before graph allocation`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            InflectMicroOnnxRunner.phonemesToTokenIds(
+                "a".repeat(InflectMicroOnnxRunner.MAX_PHONEME_TEXT_LENGTH + 1),
+            )
+        }
+
+        assertTrue(error.message.orEmpty().contains("exceeds"))
+    }
+
+    @Test
+    fun `waveform output must be positive mono audio`() {
+        InflectMicroOnnxRunner.validateWaveformShape(longArrayOf(1L, 1L, 1L))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            InflectMicroOnnxRunner.validateWaveformShape(longArrayOf(1L, 2L, 10L))
+        }
+    }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/InflectMicroOnnxRunnerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/InflectMicroOnnxRunnerTest.kt
@@ -1,0 +1,40 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class InflectMicroOnnxRunnerTest {
+    @Test
+    fun `phoneme IDs preserve upstream blank interleave contract`() {
+        val ids = InflectMicroOnnxRunner.phonemesToTokenIds("həlˈoʊ")
+
+        assertEquals(13, ids.size)
+        assertEquals(0L, ids.first())
+        assertEquals(0L, ids[2])
+        assertEquals(0L, ids[4])
+        assertEquals(0L, ids[6])
+        assertEquals(0L, ids[8])
+        assertEquals(0L, ids[10])
+        assertEquals(0L, ids.last())
+        assertTrue(ids.slice(1 until ids.lastIndex).filterIndexed { index, _ -> index % 2 == 0 }
+            .all { it > 0L })
+    }
+
+    @Test
+    fun `unsupported symbols fail closed instead of producing invalid IDs`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            InflectMicroOnnxRunner.phonemesToTokenIds("🙂")
+        }
+
+        assertTrue(error.message.orEmpty().contains("Unsupported Inflect symbol"))
+    }
+
+    @Test
+    fun `empty phoneme output is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            InflectMicroOnnxRunner.phonemesToTokenIds("")
+        }
+    }
+}


### PR DESCRIPTION
Closes #1422

## Summary
- Adds a debug-only explicit broadcast probe for the official Inflect Micro v2 ONNX export.
- Runs the duration and decode graphs through Jandal's existing ONNX Runtime.
- Captures tensor metadata, shapes, timings, RTF, finite/peak checks, and unity-gain 24 kHz mono float WAV evidence.
- Adds focused token-mapping tests; no production engine/settings wiring.

## Result
**BLOCKED** on the required runtime text frontend. The existing Sherpa AAR exposes `OfflineTts.generate(String, ...)`, but no phoneme-output API. Its bundled eSpeak-ng implementation is internal native code; it cannot provide Inflect's IPA IDs through the existing seam. Direct eSpeak-ng integration would introduce a new GPL-3-or-later licensing/distribution decision and is intentionally not added in this spike.

Precomputed IPA is therefore used only for graph isolation. The spike does not claim arbitrary runtime text, comparison-corpus parity, TTFA, resident-conversation-model memory, or subjective quality.

## Pinned upstream evidence (retrieved 2026-08-19)
- Canonical model: `owensong/Inflect-Micro-v2`, revision `3e8c567f9bce1a309eea12d38ca9fbf7050df72e`.
- Official export: `owensong/Inflect-Micro-v2-ONNX`, revision `91b1ab6432323064ec0e8e9704d92fcecd24855f`.
- `duration.onnx`: 7,322,687 bytes, SHA-256 `b728ca2564b9e5b7d6cf5e446f65e02a6fe2f1880ba281466fec93a667dd2388`.
- `decode.onnx`: 30,427,790 bytes, SHA-256 `7940923add86f76e7fa78d910b0632ca1779f8cc9a2ca2b49236381a9ca77183`.
- Both upstream repositories declare Apache-2.0. The ONNX repository describes itself as an official FP32 format export only, with no training/pruning/quantization.
- Canonical model includes `THIRD_PARTY_NOTICES.md` and `runtime/text/LICENSE`; the included Keith Ito text/frontend material is MIT. eSpeak-ng itself is GPL-3.0-or-later. Production use therefore requires exposing/reusing an existing compatible phonemisation seam or separately deciding whether to integrate a GPL-covered eSpeak-ng component.
- No upstream model/runtime code or new eSpeak dependency is copied into Jandal.

## S23 Ultra graph-isolation evidence
- Device: `SM-S918B`, Android 16, fingerprint `samsung/dm3qxxx/dm3q:16/BP4A.251205.006/S918BXXSAFZG1:user/release-keys`.
- Jandal base commit: `fc04ffe35b0a9936549c58242e5e7f914631ccdc`; spike commit: `5cbcb4d6`.
- Official graph execution succeeded with `həlˈoʊ` (13 blank-interleaved tokens).
- Duration output: `[1,192,55]`; mask: `[1,1,55]`; waveform: `[1,1,14080]`.
- Output: 14,080 samples, 586 ms, 24,000 Hz mono float PCM; finite; peak absolute amplitude `0.38958043`; gain `1.0`.
- Initialization: 582 ms on the captured run. Synthesis: 528 ms; graph-isolation RTF `0.901`. Earlier repeated run: init 792 ms, synthesis 354 ms, RTF `0.604`.
- WAV: `/data/user/0/com.kernel.ai.debug/files/inflect-spike/s23u-graph-contract.wav`; retrieved host copy `/tmp/inflect-s23u-graph-probe.wav` (RIFF IEEE-float mono 24 kHz), SHA-256 `54f06d05fd851eb707a186e8ece480a04eabf6feb6ff6a67cfe3391a8443ad9a`.
- Post-run graph-probe process PSS was 312,023 KiB after the runner closed; this is not a peak resident-conversation-model measurement.

## Verification
- `./gradlew :core:voice:test` — passed.
- `./gradlew :app:assembleDebug` — passed.
- `./gradlew :app:assembleRelease` — passed.
- `git diff --cached --check` — passed before commit.
- Release merged manifest contains no Inflect receiver; debug merged manifest contains the receiver/actions.

Do not merge. External review must resolve the frontend/licensing blocker before any listening test or production-integration issue.