### PR TITLE
fix(voice): align Inflect Micro model UX (#1478)

### DIFF
--- a/core/model-availability/src/main/java/com/kernel/ai/core/model/availability/ModelAvailabilityState.kt
+++ b/core/model-availability/src/main/java/com/kernel/ai/core/model/availability/ModelAvailabilityState.kt
@@ -20,8 +20,8 @@ sealed class ModelAvailabilityState {
     ) : ModelAvailabilityState()
     data class ActionRequired(val reason: ActionReason) : ModelAvailabilityState()
     data class Unavailable(val reason: UnavailableReason) : ModelAvailabilityState()
-    /** Internal sentinel — the mapper returns this when no badge should be shown. */
-    internal data object NotDisplayed : ModelAvailabilityState()
+    /** Sentinel used when no availability badge should be shown. */
+    data object NotDisplayed : ModelAvailabilityState()
 }
 
 sealed class ActionReason {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -78,9 +78,6 @@ import com.kernel.ai.core.voice.VctkSpeakerMetadata
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceOutputEngine
 import com.kernel.ai.core.voice.VoicePackDownloadState
-import com.kernel.ai.core.inference.download.DownloadState
-import com.kernel.ai.core.inference.download.KernelModel
-import com.kernel.ai.core.voice.InflectMicroModelSpec
 import com.kernel.ai.core.model.availability.ModelAvailabilityState
 import com.kernel.ai.core.model.availability.ModelCardCompact
 import kotlin.math.roundToInt
@@ -792,7 +789,7 @@ private fun VoiceScreenContent(
                             Text(
                                 text = when {
                                     !engineSelectable ->
-                                        "Download both Inflect graphs and the selected Sherpa voice pack first."
+                                        "Download Inflect Micro and the selected Sherpa voice pack first."
                                     uiState.selectedOutputEngine == engine ->
                                         "Currently active"
                                     else ->
@@ -1007,15 +1004,18 @@ private fun VoiceScreenContent(
                 }
             }
 
+            val inflectModelState = uiState.inflectMicroAvailability
             if (
                 VoiceOutputEngine.InflectMicroExperimental in uiState.availableOutputEngines &&
-                (!uiState.isInflectMicroReady ||
-                    uiState.selectedOutputEngine == VoiceOutputEngine.InflectMicroExperimental)
+                (
+                    inflectModelState !is ModelAvailabilityState.Ready ||
+                        uiState.selectedOutputEngine == VoiceOutputEngine.InflectMicroExperimental
+                    )
             ) {
                 val inflectActive =
                     uiState.selectedOutputEngine == VoiceOutputEngine.InflectMicroExperimental
                 Text(
-                    text = "Inflect Micro debug models",
+                    text = "Inflect Micro debug model",
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
@@ -1027,44 +1027,53 @@ private fun VoiceScreenContent(
                         "Inflect Micro (Debug) is available"
                     },
                     message = if (inflectActive) {
-                        "This debug-only path normalizes runtime text, reuses the selected Sherpa eSpeak frontend, and runs the official Inflect Micro v2 ONNX graphs. It falls back to Android TTS until both graphs and the Sherpa voice pack are available."
+                        "This debug-only path uses the selected Sherpa eSpeak frontend and Inflect Micro model bundle. It remains available only while the model bundle and selected Sherpa voice pack are downloaded."
                     } else {
-                        "Download both Inflect graphs and a Sherpa voice pack to enable this debug-only quality path."
+                        "Download Inflect Micro and the selected Sherpa voice pack to enable this debug-only quality path."
                     },
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
-                InflectMicroModelSpec.requiredModels.forEach { required ->
-                    val model = KernelModel.entries.first { it.fileName == required.fileName }
-                    val state = uiState.inflectMicroStates[model] ?: DownloadState.NotDownloaded
-                    ListItem(
-                        headlineContent = { Text(model.displayName) },
-                        supportingContent = {
-                            Text(
-                                when (state) {
-                                    DownloadState.NotDownloaded -> "Not downloaded"
-                                    is DownloadState.Downloading -> "Downloading ${(state.progress * 100).roundToInt()}%"
-                                    is DownloadState.Downloaded -> "Downloaded"
-                                    is DownloadState.Error -> state.message
-                                },
-                            )
-                        },
-                        trailingContent = {
-                            when (state) {
-                                DownloadState.NotDownloaded,
-                                is DownloadState.Error -> {
-                                    Button(onClick = onDownloadInflectMicro) { Text("Download") }
-                                }
-                                is DownloadState.Downloading -> {
-                                    OutlinedButton(onClick = onCancelInflectMicro) { Text("Cancel") }
-                                }
-                                is DownloadState.Downloaded -> {
-                                    TextButton(onClick = onDeleteInflectMicro) { Text("Delete") }
-                                }
-                            }
-                        },
-                    )
-                    HorizontalDivider()
+                ModelCardCompact(
+                    title = "Inflect Micro (Debug)",
+                    description = "Debug-only local TTS model; uses the selected Sherpa voice pack for its frontend.",
+                    state = inflectModelState,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+                when {
+                    inflectModelState is ModelAvailabilityState.Preparing -> {
+                        OutlinedButton(
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+                            onClick = onCancelInflectMicro,
+                        ) {
+                            Text("Cancel")
+                        }
+                    }
+                    inflectModelState is ModelAvailabilityState.Ready -> {
+                        OutlinedButton(
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+                            onClick = onDeleteInflectMicro,
+                        ) {
+                            Text("Delete")
+                        }
+                    }
+                    inflectModelState is ModelAvailabilityState.ActionRequired -> {
+                        OutlinedButton(
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+                            onClick = onDownloadInflectMicro,
+                        ) {
+                            Text("Retry")
+                        }
+                    }
+                    else -> {
+                        Button(
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+                            onClick = onDownloadInflectMicro,
+                        ) {
+                            Text("Download")
+                        }
+                    }
                 }
+                HorizontalDivider()
             }
 
             if (uiState.selectedOutputEngine == VoiceOutputEngine.KokoroExperimental) {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -101,7 +101,7 @@ data class VoiceUiState(
     // ── Debug-only Inflect Micro model pair ───────────────────────────────────
     val inflectMicroStates: Map<KernelModel, DownloadState> = emptyMap(),
     val inflectMicroAvailability: ModelAvailabilityState =
-        ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
+        ModelAvailabilityState.NotDisplayed,
     /** True only when both Inflect graphs and the selected Sherpa eSpeak pack exist. */
     val isInflectMicroReady: Boolean = false,
     // ── Sherpa-ONNX STT model download states (per family) ──────────────────
@@ -182,7 +182,7 @@ internal fun aggregateInflectMicroAvailability(
         return (state as DownloadState.Error).toAvailability(model, hfAuth = false)
     }
 
-    return ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled)
+    return ModelAvailabilityState.NotDisplayed
 }
 
 /**

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.withContext
 import com.kernel.ai.core.model.availability.ActionReason
 import com.kernel.ai.core.model.availability.ModelAvailabilityState
 import com.kernel.ai.core.model.availability.UnavailableReason
+import com.kernel.ai.core.model.availability.toAvailability
 import com.kernel.ai.core.permissions.MicrophoneReadiness
 import javax.inject.Inject
 
@@ -99,6 +100,8 @@ data class VoiceUiState(
     val wakeWordThreshold: Float = WAKE_WORD_DEFAULT_THRESHOLD,
     // ── Debug-only Inflect Micro model pair ───────────────────────────────────
     val inflectMicroStates: Map<KernelModel, DownloadState> = emptyMap(),
+    val inflectMicroAvailability: ModelAvailabilityState =
+        ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
     /** True only when both Inflect graphs and the selected Sherpa eSpeak pack exist. */
     val isInflectMicroReady: Boolean = false,
     // ── Sherpa-ONNX STT model download states (per family) ──────────────────
@@ -132,6 +135,54 @@ internal fun VoicePackDownloadState.toModelAvailability(): ModelAvailabilityStat
     is VoicePackDownloadState.NotDownloaded -> ModelAvailabilityState.Unavailable(
         UnavailableReason.NotBundled
     )
+}
+
+/**
+ * Aggregates the two Inflect graph states into one logical model-management state.
+ *
+ * A partial bundle is never ready. Downloading takes precedence over an error so that the
+ * single Cancel action remains available while either graph is still in progress.
+ */
+internal fun aggregateInflectMicroAvailability(
+    requiredModels: List<KernelModel>,
+    states: Map<KernelModel, DownloadState>,
+): ModelAvailabilityState {
+    val resolvedStates = requiredModels.map { model ->
+        model to (states[model] ?: DownloadState.NotDownloaded)
+    }
+    if (
+        resolvedStates.isNotEmpty() &&
+        resolvedStates.all { (_, state) -> state is DownloadState.Downloaded }
+    ) {
+        return ModelAvailabilityState.Ready
+    }
+
+    if (resolvedStates.any { (_, state) -> state is DownloadState.Downloading }) {
+        val totalBytes = resolvedStates.sumOf { (model, _) -> model.approxSizeBytes }.toFloat()
+        val downloadedBytes = resolvedStates.fold(0f) { total, (model, state) ->
+            total + when (state) {
+                is DownloadState.Downloaded -> model.approxSizeBytes.toFloat()
+                is DownloadState.Downloading -> model.approxSizeBytes * state.progress
+                else -> 0f
+            }
+        }
+        return ModelAvailabilityState.Preparing(
+            progress = if (totalBytes > 0f) {
+                (downloadedBytes / totalBytes).coerceIn(0f, 1f)
+            } else {
+                0f
+            },
+            isAutoQueued = false,
+        )
+    }
+
+    val error = resolvedStates.firstOrNull { (_, state) -> state is DownloadState.Error }
+    if (error != null) {
+        val (model, state) = error
+        return (state as DownloadState.Error).toAvailability(model, hfAuth = false)
+    }
+
+    return ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled)
 }
 
 /**
@@ -356,6 +407,10 @@ class VoiceViewModel @Inject constructor(
                         it.isSelectedSherpaVoiceDownloaded
                     it.copy(
                         inflectMicroStates = inflectStates,
+                        inflectMicroAvailability = aggregateInflectMicroAvailability(
+                            requiredModels = inflectModels,
+                            states = states,
+                        ),
                         isInflectMicroReady = inflectReady,
                         sherpaSttStates = perFamilyStates,
                         sherpaSttAvailability = perFamilyStates.mapValues { (_, state) ->

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -21,7 +21,6 @@ import com.kernel.ai.core.voice.VoicePackDownloadState
 import com.kernel.ai.core.permissions.MicrophoneReadiness
 import com.kernel.ai.core.model.availability.ActionReason
 import com.kernel.ai.core.model.availability.ModelAvailabilityState
-import com.kernel.ai.core.model.availability.UnavailableReason
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -417,7 +416,7 @@ class VoiceViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
-            ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
+            ModelAvailabilityState.NotDisplayed,
             viewModel.uiState.value.inflectMicroAvailability,
         )
     }
@@ -486,7 +485,7 @@ class VoiceViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
-            ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
+            ModelAvailabilityState.NotDisplayed,
             viewModel.uiState.value.inflectMicroAvailability,
         )
         assertFalse(viewModel.uiState.value.isInflectMicroReady)

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -19,6 +19,9 @@ import com.kernel.ai.core.voice.VoiceOutputEngine
 import com.kernel.ai.core.voice.VoiceOutputPreferences
 import com.kernel.ai.core.voice.VoicePackDownloadState
 import com.kernel.ai.core.permissions.MicrophoneReadiness
+import com.kernel.ai.core.model.availability.ActionReason
+import com.kernel.ai.core.model.availability.ModelAvailabilityState
+import com.kernel.ai.core.model.availability.UnavailableReason
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -34,6 +37,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -377,6 +381,117 @@ class VoiceViewModelTest {
             }
         )
     }
+    @Test
+    fun `debug builds expose Inflect while release builds hide it`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(
+            viewModel.uiState.value.availableOutputEngines.contains(
+                VoiceOutputEngine.InflectMicroExperimental,
+            ),
+        )
+
+        val releaseContext: Context = mockk(relaxed = true)
+        every { releaseContext.applicationInfo } returns ApplicationInfo().apply { flags = 0 }
+        val releaseViewModel = VoiceViewModel(
+            androidNativeRecognitionSupport,
+            voiceInputPreferences,
+            voiceOutputPreferences,
+            sherpaVoicePackDownloadManager,
+            wakeWordPreferences,
+            wakeWordDetector,
+            modelDownloadManager,
+            releaseContext,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(
+            releaseViewModel.uiState.value.availableOutputEngines.contains(
+                VoiceOutputEngine.InflectMicroExperimental,
+            ),
+        )
+    }
+
+    @Test
+    fun `both Inflect graphs missing map to one downloadable logical model`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
+            viewModel.uiState.value.inflectMicroAvailability,
+        )
+    }
+
+    @Test
+    fun `either Inflect graph downloading maps to Preparing`() = runTest {
+        modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
+            put(KernelModel.INFLECT_MICRO_DURATION, DownloadState.Downloading(progress = 0.4f))
+            put(KernelModel.INFLECT_MICRO_DECODE, DownloadState.Error("stale partial file"))
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(
+            viewModel.uiState.value.inflectMicroAvailability
+                is ModelAvailabilityState.Preparing,
+        )
+    }
+
+    @Test
+    fun `either Inflect graph error maps to retryable logical model`() = runTest {
+        modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
+            put(KernelModel.INFLECT_MICRO_DURATION, DownloadState.Error("network timeout"))
+            put(KernelModel.INFLECT_MICRO_DECODE, DownloadState.Downloaded("/models/decode.onnx"))
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            ModelAvailabilityState.ActionRequired(
+                ActionReason.DownloadFailed("network timeout"),
+            ),
+            viewModel.uiState.value.inflectMicroAvailability,
+        )
+    }
+
+    @Test
+    fun `both Inflect graphs downloaded map to available but readiness still requires Sherpa`() =
+        runTest {
+            modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
+                put(
+                    KernelModel.INFLECT_MICRO_DURATION,
+                    DownloadState.Downloaded("/models/duration.onnx"),
+                )
+                put(
+                    KernelModel.INFLECT_MICRO_DECODE,
+                    DownloadState.Downloaded("/models/decode.onnx"),
+                )
+            }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(
+                ModelAvailabilityState.Ready,
+                viewModel.uiState.value.inflectMicroAvailability,
+            )
+            assertFalse(viewModel.uiState.value.isInflectMicroReady)
+        }
+
+    @Test
+    fun `partial Inflect graph availability never maps to ready`() = runTest {
+        modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
+            put(
+                KernelModel.INFLECT_MICRO_DURATION,
+                DownloadState.Downloaded("/models/duration.onnx"),
+            )
+            put(KernelModel.INFLECT_MICRO_DECODE, DownloadState.NotDownloaded)
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
+            viewModel.uiState.value.inflectMicroAvailability,
+        )
+        assertFalse(viewModel.uiState.value.isInflectMicroReady)
+    }
+
 
     @Test
     fun `setVoiceOutputEngine updates ui state immediately`() = runTest {


### PR DESCRIPTION
Closes #1478

## Summary

- Presents Inflect Micro (Debug) as one logical `ModelCardCompact` with the standard action beneath it.
- Aggregates the two existing graph download states: both downloaded → available/Delete, either downloading → Preparing/Cancel, either error → Action Required/Retry, otherwise → incomplete/Download.
- Keeps the existing two-file download, cancellation, deletion, runtime, and readiness handlers unchanged.
- Preserves readiness gating on both Inflect graphs plus the selected Sherpa voice pack.
- Preserves debug-only visibility; release builds continue to hide Inflect. Existing Android TTS, Piper, Kokoro, and Sherpa STT UX is unchanged.

## Verification

- `./gradlew :feature:settings:testDebugUnitTest` — passed.
- `./gradlew assembleDebug` — passed.
- `./gradlew assembleRelease` — passed.
- Manual debug-device smoke test: Voice settings showed one Inflect Micro (Debug) card with no `duration.onnx` / `decode.onnx` rows; Download and Cancel rendered in the standard card/action placement.
- Focused settings tests cover missing, downloading, error, complete, partial, readiness, and debug/release visibility states.

Do not merge — wait for review.