### PR TITLE
fix(#1419): exclude alarm/timer warnings from TTS spoken summary

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -458,11 +458,12 @@ class NativeIntentHandler @Inject constructor(
                             "The alarm may not persist across device restarts."
                     }
                 }
+                val confirmation = "Alarm set for $formattedTime${if (label != null) " — $label" else ""}."
                 val message = buildString {
-                    append("Alarm set for $formattedTime${if (label != null) " — $label" else ""}.")
+                    append(confirmation)
                     if (warningText.isNotEmpty()) append(" $warningText")
                 }
-                SkillResult.Success(message)
+                SkillResult.Success(content = message, spokenSummary = confirmation)
             }
             is SchedulingResult.ExactAlarmBlocked ->
                 SkillResult.Failure("run_intent", "Exact alarm scheduling is unavailable right now. Please grant exact alarm permission in system settings.")
@@ -501,11 +502,12 @@ class NativeIntentHandler @Inject constructor(
                             "The timer may not persist across device restarts."
                     }
                 }
+                val confirmation = "Timer set for $durationStr."
                 val message = buildString {
-                    append("Timer set for $durationStr.")
+                    append(confirmation)
                     if (warningText.isNotEmpty()) append(" $warningText")
                 }
-                SkillResult.Success(message)
+                SkillResult.Success(content = message, spokenSummary = confirmation)
             }
             is SchedulingResult.ExactAlarmBlocked ->
                 SkillResult.Failure("run_intent", "Exact alarm scheduling is unavailable right now. Please grant exact alarm permission.")

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -19,6 +19,7 @@ import com.kernel.ai.core.memory.ImportantDateRepository
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.clock.SchedulingResult
+import com.kernel.ai.core.memory.clock.SchedulingWarning
 import com.kernel.ai.core.memory.clock.ClockStopwatch
 import com.kernel.ai.core.memory.clock.StopwatchLap
 import com.kernel.ai.core.memory.clock.StopwatchStatus
@@ -51,6 +52,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -863,7 +865,10 @@ class NativeIntentHandlerTest {
         val result = handleIntent("set_alarm", mapOf("time" to "07:00", "label" to "Wake"))
 
         assertTrue(result is SkillResult.Success)
-        assertTrue((result as SkillResult.Success).content.contains("Alarm set for"))
+        val success = result as SkillResult.Success
+        assertTrue(success.content.contains("Alarm set for"))
+        assertTrue(success.content.contains("Wake"))
+        assertEquals(success.content, success.spokenSummary)
         coVerify(exactly = 1) { clockRepository.createAlarm(any()) }
         verify(exactly = 0) { context.startActivity(any()) }
     }
@@ -1014,7 +1019,185 @@ class NativeIntentHandlerTest {
         val result = handleIntent("set_timer", mapOf("duration_seconds" to "90", "label" to "Tea"))
 
         assertTrue(result is SkillResult.Success)
-        assertEquals("Timer set for 1 min 30 sec.", (result as SkillResult.Success).content)
+        val success = result as SkillResult.Success
+        assertEquals("Timer set for 1 min 30 sec.", success.content)
+        assertEquals("Timer set for 1 min 30 sec.", success.spokenSummary)
+    }
+
+    @Test
+    fun `set_alarm keeps full-screen warning visible but excludes it from spoken summary`() {
+        val alarm = ClockAlarm(
+            id = "alarm-1",
+            label = "Wake",
+            createdAtMillis = 1_699_000_000_000L,
+            enabled = true,
+            hour = 7,
+            minute = 0,
+            repeatRule = com.kernel.ai.core.memory.clock.AlarmRepeatRule.OneOff(19_000L),
+            timeZoneId = java.time.ZoneId.systemDefault().id,
+            triggerAtMillis = 1_700_000_000_000L,
+        )
+        coEvery { clockRepository.createAlarm(any()) } returns SchedulingResult.Success(
+            alarm,
+            warnings = listOf(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE),
+        )
+
+        val result = handleIntent("set_alarm", mapOf("time" to "07:00", "label" to "Wake"))
+
+        assertTrue(result is SkillResult.Success)
+        val success = result as SkillResult.Success
+        val spoken = requireNotNull(success.spokenSummary) { "spokenSummary must be populated" }
+        assertTrue(success.content.contains("Alarm set for"))
+        assertTrue(success.content.contains("Full-screen alerts are unavailable for this alarm."))
+        assertFalse(spoken.contains("Full-screen alerts are unavailable for this alarm."))
+        assertEquals(
+            success.content.replace(" Full-screen alerts are unavailable for this alarm.", ""),
+            spoken,
+        )
+    }
+
+    @Test
+    fun `set_alarm keeps boot-restore warning visible but excludes it from spoken summary`() {
+        val alarm = ClockAlarm(
+            id = "alarm-1",
+            label = "Wake",
+            createdAtMillis = 1_699_000_000_000L,
+            enabled = true,
+            hour = 7,
+            minute = 0,
+            repeatRule = com.kernel.ai.core.memory.clock.AlarmRepeatRule.OneOff(19_000L),
+            timeZoneId = java.time.ZoneId.systemDefault().id,
+            triggerAtMillis = 1_700_000_000_000L,
+        )
+        coEvery { clockRepository.createAlarm(any()) } returns SchedulingResult.Success(
+            alarm,
+            warnings = listOf(SchedulingWarning.BOOT_RESTORE_LIMITED),
+        )
+
+        val result = handleIntent("set_alarm", mapOf("time" to "07:00", "label" to "Wake"))
+
+        val success = result as SkillResult.Success
+        val spoken = requireNotNull(success.spokenSummary) { "spokenSummary must be populated" }
+        assertTrue(success.content.contains("Alarm set for"))
+        assertTrue(success.content.contains("The alarm may not persist across device restarts."))
+        assertFalse(spoken.contains("The alarm may not persist across device restarts."))
+        assertEquals(
+            success.content.replace(" The alarm may not persist across device restarts.", ""),
+            spoken,
+        )
+    }
+
+    @Test
+    fun `set_alarm keeps multiple warnings visible but none are spoken`() {
+        val alarm = ClockAlarm(
+            id = "alarm-1",
+            label = "Wake",
+            createdAtMillis = 1_699_000_000_000L,
+            enabled = true,
+            hour = 7,
+            minute = 0,
+            repeatRule = com.kernel.ai.core.memory.clock.AlarmRepeatRule.OneOff(19_000L),
+            timeZoneId = java.time.ZoneId.systemDefault().id,
+            triggerAtMillis = 1_700_000_000_000L,
+        )
+        coEvery { clockRepository.createAlarm(any()) } returns SchedulingResult.Success(
+            alarm,
+            warnings = listOf(
+                SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE,
+                SchedulingWarning.BOOT_RESTORE_LIMITED,
+            ),
+        )
+
+        val result = handleIntent("set_alarm", mapOf("time" to "07:00", "label" to "Wake"))
+        val success = result as SkillResult.Success
+        val spoken = requireNotNull(success.spokenSummary) { "spokenSummary must be populated" }
+        assertTrue(success.content.contains("Full-screen alerts are unavailable for this alarm."))
+        assertTrue(success.content.contains("The alarm may not persist across device restarts."))
+        assertFalse(spoken.contains("Full-screen alerts are unavailable for this alarm."))
+        assertFalse(spoken.contains("The alarm may not persist across device restarts."))
+        val expected = success.content
+            .replace(" Full-screen alerts are unavailable for this alarm.", "")
+            .replace(" The alarm may not persist across device restarts.", "")
+        assertEquals(expected, spoken)
+
+    }
+
+    @Test
+    fun `set_timer keeps full-screen warning visible but excludes it from spoken summary`() {
+        coEvery { clockRepository.scheduleTimer(90_000L, "Tea") } returns SchedulingResult.Success(
+            com.kernel.ai.core.memory.clock.ClockTimer(
+                id = "timer-1",
+                triggerAtMillis = 5_000L,
+                label = "Tea",
+                createdAtMillis = 1_000L,
+                durationMs = 90_000L,
+                startedAtMillis = 2_000L,
+            ),
+            warnings = listOf(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE),
+        )
+
+        val result = handleIntent("set_timer", mapOf("duration_seconds" to "90", "label" to "Tea"))
+
+        assertTrue(result is SkillResult.Success)
+        val success = result as SkillResult.Success
+        val spoken = requireNotNull(success.spokenSummary) { "spokenSummary must be populated" }
+        assertTrue(success.content.contains("Full-screen alerts are unavailable for this timer."))
+        assertFalse(spoken.contains("Full-screen alerts are unavailable for this timer."))
+        assertEquals("Timer set for 1 min 30 sec.", spoken)
+        assertEquals("Timer set for 1 min 30 sec. Full-screen alerts are unavailable for this timer.", success.content)
+    }
+
+    @Test
+    fun `set_timer keeps boot-restore warning visible but excludes it from spoken summary`() {
+        coEvery { clockRepository.scheduleTimer(60_000L, null) } returns SchedulingResult.Success(
+            com.kernel.ai.core.memory.clock.ClockTimer(
+                id = "timer-1",
+                triggerAtMillis = 5_000L,
+                label = null,
+                createdAtMillis = 1_000L,
+                durationMs = 60_000L,
+                startedAtMillis = 2_000L,
+            ),
+            warnings = listOf(SchedulingWarning.BOOT_RESTORE_LIMITED),
+        )
+
+        val result = handleIntent("set_timer", mapOf("duration_seconds" to "60"))
+        assertTrue(result is SkillResult.Success)
+        val success = result as SkillResult.Success
+        val spoken = requireNotNull(success.spokenSummary) { "spokenSummary must be populated" }
+        assertTrue(success.content.contains("The timer may not persist across device restarts."))
+        assertFalse(spoken.contains("The timer may not persist across device restarts."))
+        assertEquals("Timer set for 1 minute.", spoken)
+        assertEquals("Timer set for 1 minute. The timer may not persist across device restarts.", success.content)
+    }
+
+    @Test
+    fun `set_timer keeps multiple warnings visible but none are spoken`() {
+        coEvery { clockRepository.scheduleTimer(90_000L, "Tea") } returns SchedulingResult.Success(
+            com.kernel.ai.core.memory.clock.ClockTimer(
+                id = "timer-1",
+                triggerAtMillis = 5_000L,
+                label = "Tea",
+                createdAtMillis = 1_000L,
+                durationMs = 90_000L,
+                startedAtMillis = 2_000L,
+            ),
+            warnings = listOf(
+                SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE,
+                SchedulingWarning.BOOT_RESTORE_LIMITED,
+            ),
+        )
+
+        val result = handleIntent("set_timer", mapOf("duration_seconds" to "90", "label" to "Tea"))
+
+        assertTrue(result is SkillResult.Success)
+        val success = result as SkillResult.Success
+        val spoken = requireNotNull(success.spokenSummary) { "spokenSummary must be populated" }
+        assertTrue(success.content.contains("Full-screen alerts are unavailable for this timer."))
+        assertTrue(success.content.contains("The timer may not persist across device restarts."))
+        assertFalse(spoken.contains("Full-screen alerts are unavailable for this timer."))
+        assertFalse(spoken.contains("The timer may not persist across device restarts."))
+        assertEquals("Timer set for 1 min 30 sec.", spoken)
     }
 
     @Test


### PR DESCRIPTION
Closes #1419

## Summary

Alarm/timer operational warnings (full-screen-intent unavailable, boot-restore/persistence) remain in the visible chat `content`, but are no longer read aloud through TTS. The concise success confirmation is now routed to voice surfaces via `SkillResult.Success.spokenSummary`.

## Visible vs spoken split

- **Visible (`content`)** is unchanged: still `Alarm set for <time> — <label>. <warning>` / `Timer set for <duration>. <warning>`.
- **Spoken (`spokenSummary`)** carries only the concise confirmation: `Alarm set for <time> — <label>.` / `Timer set for <duration>.` — warnings excluded.

## Files changed

- `core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt`
  - `setAlarm()` / `setTimer()`: extract the concise confirmation string before warnings are appended; pass it as `spokenSummary`. Warning-generation logic and visible `content` are untouched.

## Tests

- `core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt`
  - Strengthened `set_alarm without explicit date` and `set_timer mixed duration formats` to assert `spokenSummary` equals the concise confirmation (label/time preserved).
  - Added: alarm full-screen warning, alarm boot-restore warning, alarm multiple warnings, timer full-screen warning, timer boot-restore warning, timer multiple warnings — each verifies the warning stays in `content` and is absent from `spokenSummary`, and that duration/label formatting is unchanged.

## Validation

- `./gradlew :core:skills:testDebugUnitTest` → 120 tests, 0 failures, 0 skipped.
- `./gradlew assembleDebug` → BUILD SUCCESSFUL.

## Invariants preserved

Alarm/timer scheduling, exact-alarm behaviour, notification behaviour, full-screen-intent checks, boot-restore checks, warning wording in the visible response, permission handling, alert lifecycle, TTS architecture, and `SkillResult` structure are all unchanged.

Do not merge — wait for review.