### PR TITLE
feat(#1481): make Learn entry direct and example prompts visibly tappable

### DIFF
--- a/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -56,8 +57,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import org.junit.Before
 
 @RunWith(AndroidJUnit4::class)
@@ -68,11 +67,7 @@ class ToolsHubNavTest {
 
     @Before
     fun setUp() {
-        ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences("tools_hub", Context.MODE_PRIVATE)
-            .edit()
-            .clear()
-            .apply()
+        // No per-test state to clear: ToolsHubScreen no longer persists Learn expansion.
     }
 
     @Test
@@ -184,8 +179,9 @@ class ToolsHubNavTest {
         composeTestRule.onNodeWithText("Example prompts to get started").assertIsDisplayed()
     }
 
+
     @Test
-    fun toolsHub_learnCollapseHidesExpandedRow() {
+    fun toolsHub_learnRowIsAlwaysVisibleWithoutCollapsedState() {
         composeTestRule.setContent {
             ToolsHubScreen(
                 onOpenDrawer = {},
@@ -193,64 +189,9 @@ class ToolsHubNavTest {
             )
         }
 
-        // Initially expanded — collapse button visible
-        composeTestRule.onNodeWithTag("tools_learn_collapse").assertIsDisplayed()
         composeTestRule.onNodeWithTag("tools_row_learn").assertIsDisplayed()
-
-        // Collapse
-        composeTestRule.onNodeWithTag("tools_learn_collapse", useUnmergedTree = true).performClick()
-        composeTestRule.waitForIdle()
-
-        // Expanded row hidden, collapsed row shown
-        composeTestRule.onNodeWithTag("tools_learn_collapsed").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Getting started").assertIsDisplayed()
-    }
-
-    @Test
-    fun toolsHub_learnCollapsedClickReExpands() {
-        composeTestRule.setContent {
-            ToolsHubScreen(
-                onOpenDrawer = {},
-                onNavigateToRoute = {},
-            )
-        }
-
-        // Start expanded → collapse
-        composeTestRule.onNodeWithTag("tools_learn_collapse", useUnmergedTree = true).performClick()
-        composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithTag("tools_learn_collapsed").assertIsDisplayed()
-
-        // Re-expand
-        composeTestRule.onNodeWithTag("tools_learn_collapsed", useUnmergedTree = true).performClick()
-        composeTestRule.waitForIdle()
-
-        // Expanded row back
-        composeTestRule.onNodeWithTag("tools_row_learn").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("tools_learn_collapse").assertIsDisplayed()
-        composeTestRule.onAllNodesWithTag("tools_learn_collapsed", useUnmergedTree = true)
-            .fetchSemanticsNodes().let { nodes ->
-                assertTrue("Expected no collapsed row after re-expand", nodes.isEmpty())
-            }
-    }
-
-    @Test
-    fun toolsHub_learnCollapsedStateSearchStillWorks() {
-        composeTestRule.setContent {
-            ToolsHubScreen(
-                onOpenDrawer = {},
-                onNavigateToRoute = {},
-                onNavigateToSettings = {},
-            )
-        }
-
-        // Collapse learn
-        composeTestRule.onNodeWithTag("tools_learn_collapse", useUnmergedTree = true).performClick()
-        composeTestRule.waitForIdle()
-
-        // Search still works
-        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("convert")
-        composeTestRule.onNodeWithTag("tools_search_results_header").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("tools_search_result_convert").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_learn_collapse").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("tools_learn_collapsed").assertDoesNotExist()
     }
 
     @Test
@@ -342,7 +283,9 @@ class ToolsHubNavTest {
 
         composeTestRule.onNodeWithTag("tools_learn_screen").assertIsDisplayed()
         composeTestRule.onNodeWithTag("tools_learn_helper_copy").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("tools_learn_privacy_note").assertIsDisplayed()
+        composeTestRule.onNodeWithText(
+            "Tap an example to open it in Actions, where you can review or edit it before running. Some examples may ask a follow-up question.",
+        ).assertIsDisplayed()
     }
 
     @Test
@@ -438,6 +381,36 @@ class ToolsHubNavTest {
         composeTestRule.onNodeWithTag("tools_learn_time_timer_10", useUnmergedTree = true).performClick()
 
         assertEquals("Set a timer for 10 minutes", lastPrompt)
+    }
+
+    @Test
+    fun toolsLearnScreen_exampleRowIsInteractiveWithNavigationAffordance() {
+        composeTestRule.setContent {
+            ToolsLearnScreen(
+                onBack = {},
+                onOpenPrompt = {},
+            )
+        }
+
+        val screenNode = composeTestRule.onNodeWithTag("tools_learn_screen")
+        screenNode.performScrollToNode(hasTestTag("tools_learn_time_timer_10"))
+        composeTestRule.onNodeWithTag("tools_learn_time_timer_10", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun toolsLearnScreen_tappingExampleDoesNotAutoExecute() {
+        var promptOpens = 0
+        composeTestRule.setContent {
+            ToolsLearnScreen(
+                onBack = {},
+                onOpenPrompt = { promptOpens++ },
+            )
+        }
+
+        // Rendering the Learn screen alone must never open Actions.
+        assertEquals(0, promptOpens)
     }
 
     @Test

--- a/app/src/main/java/com/kernel/ai/navigation/ToolsHubScreen.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/ToolsHubScreen.kt
@@ -40,8 +40,6 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Tune
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -56,7 +54,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import android.content.Context
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 
 
@@ -159,11 +156,6 @@ fun ToolsHubScreen(
     onToggleFavourite: (String) -> Unit = {},
 ) {
     var searchQuery by remember { mutableStateOf("") }
-    val context = LocalContext.current
-    var learnSectionExpanded by remember {
-        val prefs = context.getSharedPreferences("tools_hub", Context.MODE_PRIVATE)
-        mutableStateOf(prefs.getBoolean("tools_learn_expanded", true))
-    }
 
     Scaffold(
         topBar = {
@@ -212,82 +204,14 @@ fun ToolsHubScreen(
             )
 
             if (searchQuery.isBlank()) {
-                // ── Full grouped layout ──────────────────────────────────────
-                // Compact, collapsible Learn entry
-                if (learnSectionExpanded) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onNavigateToRoute(ROUTE_TOOLS_LEARN) }
-                            .padding(horizontal = 16.dp, vertical = 10.dp)
-                            .testTag("tools_row_learn"),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.MenuBook,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                        )
-                        Spacer(Modifier.width(16.dp))
-                        Column(Modifier.weight(1f)) {
-                            Text(
-                                "Learn what Jandal can do",
-                                style = MaterialTheme.typography.bodyLarge,
-                            )
-                            Text(
-                                "Example prompts to get started",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        IconButton(
-                            onClick = {
-                                learnSectionExpanded = false
-                                context.getSharedPreferences("tools_hub", Context.MODE_PRIVATE)
-                                    .edit()
-                                    .putBoolean("tools_learn_expanded", false)
-                                    .apply()
-                            },
-                            modifier = Modifier.testTag("tools_learn_collapse"),
-                        ) {
-                            Icon(Icons.Default.KeyboardArrowUp, contentDescription = "Collapse")
-                        }
-                    }
-                    HorizontalDivider()
-                } else {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                learnSectionExpanded = true
-                                context.getSharedPreferences("tools_hub", Context.MODE_PRIVATE)
-                                    .edit()
-                                    .putBoolean("tools_learn_expanded", true)
-                                    .apply()
-                            }
-                            .padding(horizontal = 16.dp, vertical = 10.dp)
-                            .testTag("tools_learn_collapsed"),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.MenuBook,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                        )
-                        Spacer(Modifier.width(16.dp))
-                        Text(
-                            "Getting started",
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Icon(
-                            Icons.Default.Add,
-                            contentDescription = "Show",
-                            tint = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                    HorizontalDivider()
-                }
+                // ── Learn entry: always-visible direct navigation row ────────
+                ToolsListItem(
+                    testTag = "tools_row_learn",
+                    icon = Icons.AutoMirrored.Filled.MenuBook,
+                    title = "Learn what Jandal can do",
+                    subtitle = "Example prompts to get started",
+                    onClick = { onNavigateToRoute(ROUTE_TOOLS_LEARN) },
+                )
 
                 Text(
                     text = "Productivity",

--- a/app/src/main/java/com/kernel/ai/navigation/ToolsLearnScreen.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/ToolsLearnScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
@@ -173,20 +174,12 @@ fun ToolsLearnScreen(
                 .testTag("tools_learn_screen"),
         ) {
             Text(
-                text = "Example prompts for actions, planning, weather, maps, media, and more",
+                text = "Tap an example to open it in Actions, where you can review or edit it before running. Some examples may ask a follow-up question.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier
                     .padding(horizontal = 16.dp, vertical = 8.dp)
                     .testTag("tools_learn_helper_copy"),
-            )
-            Text(
-                text = "Examples open in Actions so you can review or edit before running. Some examples may ask a follow-up question.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp, vertical = 4.dp)
-                    .testTag("tools_learn_privacy_note"),
             )
             Spacer(modifier = Modifier.height(8.dp))
             allExampleSections.forEachIndexed { index, section ->
@@ -296,8 +289,16 @@ private fun ToolsExampleRow(
             .testTag(testTag),
         headlineContent = {
             Text(
-                text = "\u2022 $label",
+                text = label,
                 style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        },
+        trailingContent = {
+            Icon(
+                Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
     )

--- a/docs/UX_PATTERNS.md
+++ b/docs/UX_PATTERNS.md
@@ -97,10 +97,9 @@ App setup
   Models
   Permissions
 
-Learn (compact, collapsible first row, opens dedicated Learn screen)
-  Expanded: "Learn what Jandal can do" / "Example prompts to get started"
-  Collapsed: "Getting started" / Add button
-  Collapsed/expanded state persists locally
+Learn (persistent direct navigation row at the top, opens dedicated Learn screen)
+  "Learn what Jandal can do" / "Example prompts to get started"
+  Not an accordion: no collapsed "Getting started" state, no persisted expansion state
 ```
 
 Each row uses the existing app visual language:
@@ -184,11 +183,11 @@ Future search should be able to produce matches such as:
 ### 1.3 Tool examples and demo prompts
 
 Example prompts live on a dedicated **Learn screen** (`ToolsLearnScreen`, route `tools/learn`).
-The Tools hub contains a compact, collapsible Learn entry at the top of the screen
-(tag `tools_row_learn` when expanded, `tools_learn_collapsed` when collapsed) that opens
-the Learn screen. The collapsed/expanded state is persisted locally via SharedPreferences
-so returning users keep their preference across app restarts. Examples are never rendered
-inline in the Tools hub.
+The Tools hub contains a persistent, direct navigation row at the top of the screen
+(tag `tools_row_learn`) that opens the Learn screen. It is not an accordion: there is no
+collapsed `Getting started` state and no persisted expansion state. Learn example prompts are
+visibly interactive/tappable rows with a trailing navigation affordance. Examples are never
+rendered inline in the Tools hub.
 
 The Learn screen uses grouped sections with a collapsed default showing two examples per
 group and a **View more** button to expand that group to show additional prompts.
@@ -307,7 +306,6 @@ Tool hub and example test tags (v2 IA):
 tools_row_learn
 tools_learn_screen
 tools_learn_helper_copy
-tools_learn_privacy_note
 tools_learn_group_lists
 tools_learn_view_more_lists
 tools_learn_lists_add_milk


### PR DESCRIPTION
Fixes #1481

## Change summary

One new-user journey, two fixes plus the copy clarification — no navigation refactoring, no new components.

### 1. Tools hub: single-item "Getting started" accordion removed
- The collapsible Learn entry (expanded row with `tools_learn_collapse` up-chevron button / collapsed `Getting started` + `+` row) is replaced by **one persistent `ToolsListItem`**: *Learn what Jandal can do* / subtitle *Example prompts to get started*, whole row tappable, trailing chevron.
- Existing wiring preserved unchanged: `tools_row_learn` test tag and `onNavigateToRoute(ROUTE_TOOLS_LEARN)`.
- Removed the now-dead plumbing: `learnSectionExpanded` state, the `tools_hub` SharedPreferences read/write, and unused imports (`Add`, `KeyboardArrowUp`, `LocalContext`). Search/filter path (`allToolSearchEntries`, `allExampleSearchEntries`) untouched; search results still render via `ToolsListItem`.

### 2. Learn screen: examples read as interactive rows
- `ToolsExampleRow` keeps its existing full-row `clickable` + ripple (Material `ListItem`) but drops the literal `"• "` bullet prefix and adds a trailing `ChevronRight`, so examples no longer look like static documentation. Theme tokens only; per-example test tags unchanged.
- Safety boundary untouched: tapping still calls the same `onOpenPrompt(example.prompt)` → Actions draft/prefill. Nothing auto-executes. Per-section **View more / View less** logic is unmodified.

### 3. Helper copy
- Merged the intro line and privacy note into one explicit instruction on `tools_learn_helper_copy`: *"Tap an example to open it in Actions, where you can review or edit it before running. Some examples may ask a follow-up question."* No extra UI element added.

## Tests (`ToolsHubNavTest.kt`)
Removed (behaviour deleted): accordion collapse/re-expand/collapsed-search tests, and the obsolete `tools_hub` prefs clear in `setUp`.
Added/updated:
- `toolsHub_learnRowIsAlwaysVisibleWithoutCollapsedState` — row always shown; `tools_learn_collapse`/`tools_learn_collapsed` must not exist.
- `toolsLearnScreen_exampleRowIsInteractiveWithNavigationAffordance` — example row displayed with click action semantics.
- `toolsLearnScreen_tappingExampleDoesNotAutoExecute` — rendering Learn never fires `onOpenPrompt`.
- helper-copy assertion updated to the new wording.
Unchanged and still passing: `toolsHub_rowLearnNavigatesToToolsLearn`, View more/less tests, draft-prefill route/encoding tests, bottom-nav state test.

## Validation

| Command | Result |
|---|---|
| `./gradlew lint --no-daemon` | BUILD SUCCESSFUL — 60 pre-existing warnings, 3 errors filtered by baseline; none in changed files |
| `./gradlew test --no-daemon` | BUILD SUCCESSFUL |
| `./gradlew assembleDebug --no-daemon` | BUILD SUCCESSFUL |

## Manual device verification — completed (S21)

Visual smoke **completed successfully** on Samsung Galaxy S21 (SM-G991B, Android 15) with the debug build from this PR head:

- Tools → Learn → example → Actions draft flow matches #1481: persistent Learn row with chevron (no `Getting started` accordion), tappable example rows, `View more`/`View less` intact, Actions opens prefilled with "Example loaded — review or edit before running." and nothing auto-executes.
- System/dynamic colours and the Jandal theme both rendered correctly.
- `ToolsHubNavTest` passes **51/51** when the physical device is awake/unlocked. The earlier `No compose hierarchies found in the app` failures were proven (A/B on the same device and build) to occur only when the device was dozing — a pre-existing environmental precondition, not caused by this PR.
- S23 Ultra screenshots were unavailable because its wireless ADB pairing had expired; this does not block #1482.

Full screenshots and the harness investigation are in the PR comments:
- [On-device visual evidence](https://github.com/NickMonrad/kernel-ai-assistant/pull/1482#issuecomment-5394027067)
- [Compose hierarchy investigation](https://github.com/NickMonrad/kernel-ai-assistant/pull/1482#issuecomment-5394248992)

Do not merge — wait for review.
