### PR TITLE
docs(#1483): document awake/unlocked device prerequisite for connected Compose tests

### DIFF
--- a/.docs/agents/validation.md
+++ b/.docs/agents/validation.md
@@ -28,6 +28,32 @@ Load this when deciding how to verify a change.
 - Inference tests use mocked `InferenceEngine` — never download models in CI
 - Compose UI tests run via Android Emulator (API 35 system image)
 
+## Connected Compose/UI tests on a physical device
+
+Before running connected Compose/UI instrumentation tests on a physical device,
+verify the device is:
+
+- visible and authorised in `adb devices`
+- awake
+- unlocked / keyguard dismissed
+
+For longer runs, keep the device awake:
+
+```bash
+adb shell svc power stayon usb
+```
+
+If you temporarily change the device keep-awake setting for validation, restore
+the prior/default state after the run unless the operator explicitly asks to
+leave it enabled.
+
+**Troubleshooting:** `IllegalStateException: No compose hierarchies found in the app`
+can occur when the physical device is dozing or the screen is off — the Compose
+test host cannot stay resumed long enough to register a test root. Check the
+device's wake/unlock state before classifying this error as a product or
+Compose test-harness defect. This failure mode was observed during #1482
+validation.
+
 ## Pre-PR checklist
 
 1. `./gradlew test` passes


### PR DESCRIPTION
Closes #1483.

## What

Adds a concise "Connected Compose/UI tests on a physical device" section to `.docs/agents/validation.md`, placed between the CI constraints and the pre-PR checklist. It documents that before running connected Compose/UI instrumentation tests the device should be:

- visible and authorised in `adb devices`
- awake
- unlocked / keyguard dismissed
- kept awake for longer runs where needed (`adb shell svc power stayon usb`)

It also states that an agent temporarily changing the keep-awake setting for validation must restore the prior/default state afterwards unless the operator explicitly asks to leave it enabled, and adds a troubleshooting note: `IllegalStateException: No compose hierarchies found in the app` can occur when the device is dozing/screen-off because the Compose test host cannot remain resumed long enough to register a test root — check wake/unlock state before classifying it as a product or harness defect.

## Provenance

The failure mode was proven during #1482 validation, where connected Compose tests failed with exactly this error while the physical device was dozing.

## Scope

Documentation-only. No production code, Compose dependencies, `createComposeRule()` usage, instrumentation runner, or validation policy changed.

## Validation performed

- Diff inspected: only `.docs/agents/validation.md` changed (26 insertions, 0 deletions)
- `git diff --check`: clean
- No repository docs/static checks apply to markdown; Android lint/CI unaffected by this change
- No Android build or connected-device run required (docs-only change)

Do not merge — wait for review.