### PR TITLE
feat: add Lists home-screen widget and shortcut (#1489)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.io.File
 import java.time.Instant
 import java.util.zip.ZipFile
 
@@ -96,6 +97,93 @@ android {
             )
         }
     }
+}
+
+/**
+ * Verifies the packaged shortcut target rather than only checking the source XML. The debug
+ * application id has an applicationIdSuffix, so its static shortcut must resolve independently
+ * from the release resource value.
+ */
+tasks.register("verifyListsShortcutVariants") {
+    dependsOn("assembleDebug", "assembleRelease")
+    doLast {
+        val sdkDirectory = sequenceOf(
+            System.getenv("ANDROID_HOME"),
+            System.getenv("ANDROID_SDK_ROOT"),
+        ).filterNotNull()
+            .map(::File)
+            .firstOrNull { it.isDirectory }
+            ?: rootProject.file("local.properties").readLines()
+                .firstOrNull { it.startsWith("sdk.dir=") }
+                ?.substringAfter("sdk.dir=")
+                ?.let(::File)
+            ?: error("Unable to locate the Android SDK")
+        val buildToolsDirectory = sdkDirectory.resolve("build-tools")
+        val aapt2 = buildToolsDirectory
+            .listFiles()
+            ?.filter { it.isDirectory }
+            ?.maxByOrNull { it.name }
+            ?.resolve("aapt2")
+            ?.takeIf { it.isFile }
+            ?: error("Unable to locate aapt2 under ${buildToolsDirectory.path}")
+
+        fun dumpResources(artifact: File): String {
+            check(artifact.isFile) { "Missing artifact: ${artifact.path}" }
+            return providers.exec {
+                commandLine(aapt2.absolutePath, "dump", "resources", artifact.absolutePath)
+            }.standardOutput.asText.get()
+        }
+
+        fun dumpShortcutXml(artifact: File, resources: String): String {
+            val packagedPath = Regex(
+                """resource \S+ xml/shortcuts\s+\(\) \(file\) (res/\S+) type=XML""",
+            ).find(resources)?.groupValues?.get(1)
+                ?: error("Packaged shortcuts.xml missing from ${artifact.path}")
+            return providers.exec {
+                commandLine(
+                    aapt2.absolutePath,
+                    "dump",
+                    "xmltree",
+                    artifact.absolutePath,
+                    "--file",
+                    packagedPath,
+                )
+            }.standardOutput.asText.get()
+        }
+
+        fun verifyShortcut(artifact: File, expectedTarget: String) {
+            val resources = dumpResources(artifact)
+            val shortcutXml = dumpShortcutXml(artifact, resources)
+            val targetResource = Regex(
+                """resource (0x[0-9a-f]+) string/shortcut_target_package\s+\(\) "([^"]+)"""",
+            ).find(resources)
+                ?: error("Packaged shortcut_target_package missing from ${artifact.path}")
+            val targetAttribute = Regex(
+                """targetPackage\([^)]*\)=@(0x[0-9a-f]+)""",
+            ).find(shortcutXml)
+                ?: error("Packaged Lists shortcut targetPackage missing from ${artifact.path}")
+
+            check(targetResource.groupValues[2] == expectedTarget) {
+                "Packaged Lists shortcut resource must target $expectedTarget"
+            }
+            check(targetAttribute.groupValues[1] == targetResource.groupValues[1]) {
+                "Packaged Lists shortcut must use shortcut_target_package"
+            }
+            check("""shortcutId(0x01010528)="lists" (Raw: "lists")""" in shortcutXml)
+            check("""targetClass(0x0101002f)="com.kernel.ai.MainActivity" (Raw: "com.kernel.ai.MainActivity")""" in shortcutXml)
+            check("""name(0x01010003)="navigation_route" (Raw: "navigation_route")""" in shortcutXml)
+            check("""value(0x01010024)="lists" (Raw: "lists")""" in shortcutXml)
+        }
+
+        verifyShortcut(
+            layout.buildDirectory.file("outputs/apk/debug/app-debug.apk").get().asFile,
+            "com.kernel.ai.debug",
+        )
+        verifyShortcut(
+            layout.buildDirectory.file("outputs/apk/release/app-release-unsigned.apk").get().asFile,
+            "com.kernel.ai",
+        )
+}
 }
 
 tasks.register("verifyAcousticStimulusReleaseIsolation") {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,9 +100,7 @@ android {
 }
 
 /**
- * Verifies the packaged shortcut target rather than only checking the source XML. The debug
- * application id has an applicationIdSuffix, so its static shortcut must resolve independently
- * from the release resource value.
+ * Verifies literal variant-specific shortcut metadata in the packaged APKs.
  */
 tasks.register("verifyListsShortcutVariants") {
     dependsOn("assembleDebug", "assembleRelease")
@@ -118,72 +116,47 @@ tasks.register("verifyListsShortcutVariants") {
                 ?.substringAfter("sdk.dir=")
                 ?.let(::File)
             ?: error("Unable to locate the Android SDK")
-        val buildToolsDirectory = sdkDirectory.resolve("build-tools")
-        val aapt2 = buildToolsDirectory
+        val aapt2 = sdkDirectory.resolve("build-tools")
             .listFiles()
             ?.filter { it.isDirectory }
             ?.maxByOrNull { it.name }
             ?.resolve("aapt2")
             ?.takeIf { it.isFile }
-            ?: error("Unable to locate aapt2 under ${buildToolsDirectory.path}")
+            ?: error("Unable to locate aapt2")
 
-        fun dumpResources(artifact: File): String {
+        fun packagedShortcut(artifact: File): String {
             check(artifact.isFile) { "Missing artifact: ${artifact.path}" }
-            return providers.exec {
+            val resources = providers.exec {
                 commandLine(aapt2.absolutePath, "dump", "resources", artifact.absolutePath)
             }.standardOutput.asText.get()
-        }
-
-        fun dumpShortcutXml(artifact: File, resources: String): String {
             val packagedPath = Regex(
                 """resource \S+ xml/shortcuts\s+\(\) \(file\) (res/\S+) type=XML""",
             ).find(resources)?.groupValues?.get(1)
                 ?: error("Packaged shortcuts.xml missing from ${artifact.path}")
             return providers.exec {
-                commandLine(
-                    aapt2.absolutePath,
-                    "dump",
-                    "xmltree",
-                    artifact.absolutePath,
-                    "--file",
-                    packagedPath,
-                )
+                commandLine(aapt2.absolutePath, "dump", "xmltree", artifact.absolutePath, "--file", packagedPath)
             }.standardOutput.asText.get()
         }
 
-        fun verifyShortcut(artifact: File, expectedTarget: String) {
-            val resources = dumpResources(artifact)
-            val shortcutXml = dumpShortcutXml(artifact, resources)
-            val targetResource = Regex(
-                """resource (0x[0-9a-f]+) string/shortcut_target_package\s+\(\) "([^"]+)"""",
-            ).find(resources)
-                ?: error("Packaged shortcut_target_package missing from ${artifact.path}")
-            val targetAttribute = Regex(
-                """targetPackage\([^)]*\)=@(0x[0-9a-f]+)""",
-            ).find(shortcutXml)
-                ?: error("Packaged Lists shortcut targetPackage missing from ${artifact.path}")
-
-            check(targetResource.groupValues[2] == expectedTarget) {
-                "Packaged Lists shortcut resource must target $expectedTarget"
+        fun verify(artifact: File, expectedTarget: String) {
+            val xml = packagedShortcut(artifact)
+            val target = xml.lineSequence().firstOrNull { "targetPackage(" in it }
+                ?: error("Packaged targetPackage missing from ${artifact.path}")
+            check("""="$expectedTarget" (Raw: "$expectedTarget")""" in target && "=@" !in target) {
+                "Packaged targetPackage must be literal $expectedTarget in ${artifact.path}"
             }
-            check(targetAttribute.groupValues[1] == targetResource.groupValues[1]) {
-                "Packaged Lists shortcut must use shortcut_target_package"
-            }
-            check("""shortcutId(0x01010528)="lists" (Raw: "lists")""" in shortcutXml)
-            check("""targetClass(0x0101002f)="com.kernel.ai.MainActivity" (Raw: "com.kernel.ai.MainActivity")""" in shortcutXml)
-            check("""name(0x01010003)="navigation_route" (Raw: "navigation_route")""" in shortcutXml)
-            check("""value(0x01010024)="lists" (Raw: "lists")""" in shortcutXml)
+            check(Regex("""shortcutId\([^)]*\)="lists" \(Raw: "lists"\)""").containsMatchIn(xml))
+            check(Regex("""targetClass\([^)]*\)="com\.kernel\.ai\.MainActivity" """).containsMatchIn(xml))
+            check(Regex("""name\([^)]*\)="navigation_route" """).containsMatchIn(xml))
+            check(Regex("""value\([^)]*\)="lists" """).containsMatchIn(xml))
         }
 
-        verifyShortcut(
-            layout.buildDirectory.file("outputs/apk/debug/app-debug.apk").get().asFile,
-            "com.kernel.ai.debug",
-        )
-        verifyShortcut(
+        verify(layout.buildDirectory.file("outputs/apk/debug/app-debug.apk").get().asFile, "com.kernel.ai.debug")
+        verify(
             layout.buildDirectory.file("outputs/apk/release/app-release-unsigned.apk").get().asFile,
             "com.kernel.ai",
         )
-}
+    }
 }
 
 tasks.register("verifyAcousticStimulusReleaseIsolation") {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -9,3 +9,8 @@
 
 # Keep Chicory Wasm runtime (Phase 4)
 -keep class com.dylibso.chicory.** { *; }
+
+# Glance instantiates ActionCallbacks reflectively from their serialized class name.
+-keep class com.kernel.ai.feature.widget.ListsWidgetLaunchCallback {
+    public <init>();
+}

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="shortcut_target_package" translatable="false">com.kernel.ai.debug</string>
-</resources>

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="shortcut_target_package" translatable="false">com.kernel.ai.debug</string>
+</resources>

--- a/app/src/debug/res/xml/shortcuts.xml
+++ b/app/src/debug/res/xml/shortcuts.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Canonical launcher shortcut for Lists. Mirrors the in-app pin action built in
-         com.kernel.ai.feature.settings.ListsShortcut — same id, label, icon, and route.
-         Tapping deep-links into the app via the "navigation_route" extra that MainActivity
-         / KernelNavHost already consume. -->
+    <!-- Debug variant mirrors the release Lists shortcut with its own literal application id. -->
     <shortcut
         android:shortcutId="lists"
         android:enabled="true"
@@ -11,7 +8,7 @@
         android:shortcutShortLabel="@string/shortcut_lists_label">
         <intent
             android:action="android.intent.action.VIEW"
-            android:targetPackage="com.kernel.ai"
+            android:targetPackage="com.kernel.ai.debug"
             android:targetClass="com.kernel.ai.MainActivity">
             <extra
                 android:name="navigation_route"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -337,7 +337,11 @@
         <activity
             android:name="com.kernel.ai.feature.widget.ListsWidgetConfigureActivity"
             android:exported="true"
-            android:theme="@style/Theme.KernelAI" />
+            android:theme="@style/Theme.KernelAI">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -213,16 +213,24 @@
                 android:resource="@xml/kernel_widget_info" />
         </receiver>
         <!-- Lists home-screen widget -->
+        <!-- Lists home-screen widget (lifecycle only; refresh signal handled by ListsDataChangedReceiver) -->
         <receiver
             android:name="com.kernel.ai.feature.widget.ListsWidgetReceiver"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-                <action android:name="com.kernel.ai.action.LISTS_DATA_CHANGED" />
             </intent-filter>
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/lists_widget_info" />
+        </receiver>
+        <!-- Internal, non-exported receiver for the lists-changed widget refresh signal -->
+        <receiver
+            android:name="com.kernel.ai.feature.widget.ListsDataChangedReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.kernel.ai.action.LISTS_DATA_CHANGED" />
+            </intent-filter>
         </receiver>
 
         <!--

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -216,6 +216,7 @@
         <!-- Lists home-screen widget (lifecycle only; refresh signal handled by ListsDataChangedReceiver) -->
         <receiver
             android:name="com.kernel.ai.feature.widget.ListsWidgetReceiver"
+            android:label="@string/lists_widget_label"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,6 +81,9 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
 
         <!-- WorkManager foreground service for model downloads -->
@@ -209,6 +212,18 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/kernel_widget_info" />
         </receiver>
+        <!-- Lists home-screen widget -->
+        <receiver
+            android:name="com.kernel.ai.feature.widget.ListsWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="com.kernel.ai.action.LISTS_DATA_CHANGED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/lists_widget_info" />
+        </receiver>
 
         <!--
             Jandal as Android Default Digital Assistant.
@@ -310,6 +325,11 @@
             android:noHistory="true"
             android:taskAffinity=""
             android:excludeFromRecents="true" />
+        <!-- Lists widget configuration screen -->
+        <activity
+            android:name="com.kernel.ai.feature.widget.ListsWidgetConfigureActivity"
+            android:exported="true"
+            android:theme="@style/Theme.KernelAI" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/kernel/ai/MainActivity.kt
+++ b/app/src/main/java/com/kernel/ai/MainActivity.kt
@@ -19,7 +19,7 @@ import com.kernel.ai.core.memory.repository.UserProfileRepository
 import com.kernel.ai.core.memory.prefs.ChatPreferences
 import com.kernel.ai.core.ui.theme.KernelAITheme
 import com.kernel.ai.navigation.KernelNavHost
-import dagger.hilt.android.AndroidEntryPoint
+import com.kernel.ai.feature.widget.ListsWidgetConfig
 import com.kernel.ai.assistant.WakeWordService
 import com.kernel.ai.core.voice.WakeWordPreferences
 import kotlinx.coroutines.flow.first
@@ -27,6 +27,7 @@ import kotlinx.coroutines.launch
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationResponse
 import javax.inject.Inject
+import dagger.hilt.android.AndroidEntryPoint
 /**
     * Build the list of runtime permissions that should be requested at startup.
     * Currently only POST_NOTIFICATIONS is included (needed for alarms, timers,
@@ -85,6 +86,9 @@ class MainActivity : ComponentActivity() {
 
     /** Bridges ADB `--es slot_reply_input` extras into ActionsViewModel.onSlotReply(). */
     private val adbSlotReplyInput = mutableStateOf<String?>(null)
+    /** Bridges launcher shortcut / widget deep-link into the nav graph via the "navigation_route" extra. */
+    private val adbNavigationRoute = mutableStateOf<String?>(null)
+    private var navigationRouteSerial = 0
 
     private val requestOnboardingPermissions =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { /* no-op */ }
@@ -103,6 +107,11 @@ class MainActivity : ComponentActivity() {
                 adbQuickActionInput.value = QuickActionRequest(it, voice, ++quickActionSerial)
                 adbQuickActionIsVoice.value = voice
             }
+            intent.getStringExtra("navigation_route")?.takeIf { it.isNotBlank() }?.let {
+                adbNavigationRoute.value = it
+                navigationRouteSerial++
+            }
+            consumeWidgetRoute()
         }
         adbSlotReplyInput.value = intent.getStringExtra("slot_reply_input")
         handleAdbProfileText(intent)
@@ -116,6 +125,8 @@ class MainActivity : ComponentActivity() {
                     initialQuickActionQuery = adbQuickActionInput.value?.query,
                     initialQuickActionIsVoice = adbQuickActionInput.value?.isVoice ?: false,
                     quickActionSerial = adbQuickActionInput.value?.serial ?: 0,
+                    initialNavigationRoute = adbNavigationRoute.value,
+                    navigationRouteSerial = navigationRouteSerial,
                     initialSlotReply = adbSlotReplyInput.value,
                     favouriteShortcutRepository = favouriteShortcutRepository,
                     recentShortcutTracker = recentShortcutTracker,
@@ -156,6 +167,11 @@ class MainActivity : ComponentActivity() {
         // if the composable re-enters between independent commands, causing the previous
         // case's slot reply to overwrite the newly primed pending slot.
         adbSlotReplyInput.value = null
+        intent.getStringExtra("navigation_route")?.takeIf { it.isNotBlank() }?.let {
+            adbNavigationRoute.value = it
+            navigationRouteSerial++
+        }
+        consumeWidgetRoute()
         intent.getStringExtra("chat_input")?.let { adbChatInput.value = it }
         readQuickActionInput(intent)?.let {
             val voice = intent.getBooleanExtra("quick_action_is_voice", false)
@@ -212,5 +228,17 @@ class MainActivity : ComponentActivity() {
             prefs.edit().putBoolean(KEY_ONBOARDING_PERMISSIONS_REQUESTED, true).apply()
         }
         requestOnboardingPermissions.launch(missingPermissions.toTypedArray())
+    }
+    /**
+     * If the Lists widget rendered a deep-link route on its most recent render, navigate there.
+     *
+     * Glance 1.1.1 widget clicks can only launch an Activity by class (no intent extras), so the
+     * route is handed off through [ListsWidgetConfig] and read here. This also fires on a plain
+     * launcher cold start while a widget exists, which is acceptable for a Lists-widget user.
+     */
+    private fun consumeWidgetRoute() {
+        val route = ListsWidgetConfig.from(this).getLastRoute() ?: return
+        adbNavigationRoute.value = route
+        navigationRouteSerial++
     }
 }

--- a/app/src/main/java/com/kernel/ai/MainActivity.kt
+++ b/app/src/main/java/com/kernel/ai/MainActivity.kt
@@ -86,9 +86,11 @@ class MainActivity : ComponentActivity() {
 
     /** Bridges ADB `--es slot_reply_input` extras into ActionsViewModel.onSlotReply(). */
     private val adbSlotReplyInput = mutableStateOf<String?>(null)
-    /** Bridges launcher shortcut / widget deep-link into the nav graph via the "navigation_route" extra. */
-    private val adbNavigationRoute = mutableStateOf<String?>(null)
-    private var navigationRouteSerial = 0
+    /** Bridges launcher shortcut / widget deep-link into the nav graph via the "navigation_route" extra.
+     *  Wrapped in [NavRouteRequest] so every delivery — even of the same route string — produces a
+     *  distinct observable value and re-fires KernelNavHost's LaunchedEffect. */
+    private data class NavRouteRequest(val route: String, val serial: Int)
+    private val adbNavigationRoute = mutableStateOf<NavRouteRequest?>(null)
 
     private val requestOnboardingPermissions =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { /* no-op */ }
@@ -107,11 +109,10 @@ class MainActivity : ComponentActivity() {
                 adbQuickActionInput.value = QuickActionRequest(it, voice, ++quickActionSerial)
                 adbQuickActionIsVoice.value = voice
             }
-            intent.getStringExtra("navigation_route")?.takeIf { it.isNotBlank() }?.let {
-                adbNavigationRoute.value = it
-                navigationRouteSerial++
+            intent.getStringExtra("navigation_route")?.takeIf { it.isNotBlank() }?.let { route ->
+                val prev = adbNavigationRoute.value
+                adbNavigationRoute.value = NavRouteRequest(route, (prev?.serial ?: 0) + 1)
             }
-            consumeWidgetRoute()
         }
         adbSlotReplyInput.value = intent.getStringExtra("slot_reply_input")
         handleAdbProfileText(intent)
@@ -125,8 +126,8 @@ class MainActivity : ComponentActivity() {
                     initialQuickActionQuery = adbQuickActionInput.value?.query,
                     initialQuickActionIsVoice = adbQuickActionInput.value?.isVoice ?: false,
                     quickActionSerial = adbQuickActionInput.value?.serial ?: 0,
-                    initialNavigationRoute = adbNavigationRoute.value,
-                    navigationRouteSerial = navigationRouteSerial,
+                    initialNavigationRoute = adbNavigationRoute.value?.route,
+                    navigationRouteSerial = adbNavigationRoute.value?.serial ?: 0,
                     initialSlotReply = adbSlotReplyInput.value,
                     favouriteShortcutRepository = favouriteShortcutRepository,
                     recentShortcutTracker = recentShortcutTracker,
@@ -167,11 +168,10 @@ class MainActivity : ComponentActivity() {
         // if the composable re-enters between independent commands, causing the previous
         // case's slot reply to overwrite the newly primed pending slot.
         adbSlotReplyInput.value = null
-        intent.getStringExtra("navigation_route")?.takeIf { it.isNotBlank() }?.let {
-            adbNavigationRoute.value = it
-            navigationRouteSerial++
+        intent.getStringExtra("navigation_route")?.takeIf { it.isNotBlank() }?.let { route ->
+            val prev = adbNavigationRoute.value
+            adbNavigationRoute.value = NavRouteRequest(route, (prev?.serial ?: 0) + 1)
         }
-        consumeWidgetRoute()
         intent.getStringExtra("chat_input")?.let { adbChatInput.value = it }
         readQuickActionInput(intent)?.let {
             val voice = intent.getBooleanExtra("quick_action_is_voice", false)
@@ -228,17 +228,5 @@ class MainActivity : ComponentActivity() {
             prefs.edit().putBoolean(KEY_ONBOARDING_PERMISSIONS_REQUESTED, true).apply()
         }
         requestOnboardingPermissions.launch(missingPermissions.toTypedArray())
-    }
-    /**
-     * If the Lists widget rendered a deep-link route on its most recent render, navigate there.
-     *
-     * Glance 1.1.1 widget clicks can only launch an Activity by class (no intent extras), so the
-     * route is handed off through [ListsWidgetConfig] and read here. This also fires on a plain
-     * launcher cold start while a widget exists, which is acceptable for a Lists-widget user.
-     */
-    private fun consumeWidgetRoute() {
-        val route = ListsWidgetConfig.from(this).getLastRoute() ?: return
-        adbNavigationRoute.value = route
-        navigationRouteSerial++
     }
 }

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -121,6 +121,7 @@ private const val ARG_INITIAL_QUERY = "initialQuery"
 private const val ARG_MINIMAL_CONTEXT = "minimalContext"
 private const val ARG_SPEAK_RESPONSE = "speakResponse"
 private const val ARG_START_VOICE = "startVoice"
+private val LISTS_WIDGET_DEEP_LINK = Regex("^lists/\\d+$")
 private const val ARG_WIDGET_QUERY = "widgetQuery"
 private const val ARG_WIDGET_VOICE = "widgetVoice"
 private const val ARG_DRAFT_QUERY = "draftQuery"
@@ -384,8 +385,11 @@ fun KernelNavHost(
     // ("lists" overview, or "lists/{listId}" detail). Reuses the same external-entry
     // seam as the ADB chat/quick-action hooks — no new routing concept.
     LaunchedEffect(initialNavigationRoute, navigationRouteSerial) {
-        if (!initialNavigationRoute.isNullOrBlank()) {
-            navController.navigate(initialNavigationRoute) {
+        val route = initialNavigationRoute
+        // Only accept the Lists deep-link seam; external/garbage routes must never reach
+        // navController.navigate (which would throw on an unknown route).
+        if (route != null && (route == ROUTE_LISTS || route.matches(LISTS_WIDGET_DEEP_LINK))) {
+            navController.navigate(route) {
                 popUpTo(ROUTE_LIST)
                 launchSingleTop = true
             }

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -344,6 +344,10 @@ fun KernelNavHost(
     initialSlotReply: String? = null,
     favouriteShortcutRepository: FavouriteShortcutRepository? = null,
     recentShortcutTracker: RecentShortcutTracker? = null,
+    initialNavigationRoute: String? = null,
+    /** Monotonic counter incremented by MainActivity on every delivery — ensures the
+     *  [LaunchedEffect] re-fires even when the route is identical to the prior one. */
+    navigationRouteSerial: Int = 0,
 ) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -373,6 +377,17 @@ fun KernelNavHost(
                 "$ROUTE_ACTIONS?$ARG_WIDGET_QUERY=$encoded&$ARG_WIDGET_VOICE=$initialQuickActionIsVoice"
             ) {
                 popUpTo(ROUTE_LIST)
+            }
+        }
+    }
+    // Launcher shortcut / Lists widget: deep-link to a top-level list route
+    // ("lists" overview, or "lists/{listId}" detail). Reuses the same external-entry
+    // seam as the ADB chat/quick-action hooks — no new routing concept.
+    LaunchedEffect(initialNavigationRoute, navigationRouteSerial) {
+        if (!initialNavigationRoute.isNullOrBlank()) {
+            navController.navigate(initialNavigationRoute) {
+                popUpTo(ROUTE_LIST)
+                launchSingleTop = true
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Jandal AI</string>
+    <string name="shortcut_target_package" translatable="false">com.kernel.ai</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Jandal AI</string>
-    <string name="shortcut_target_package" translatable="false">com.kernel.ai</string>
 </resources>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -11,7 +11,7 @@
         android:shortcutShortLabel="@string/shortcut_lists_label">
         <intent
             android:action="android.intent.action.VIEW"
-            android:targetPackage="com.kernel.ai"
+            android:targetPackage="@string/shortcut_target_package"
             android:targetClass="com.kernel.ai.MainActivity">
             <extra
                 android:name="navigation_route"

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Canonical launcher shortcut for Lists. Mirrors the in-app pin action built in
+         com.kernel.ai.feature.settings.ListsShortcut — same id, label, icon, and route.
+         Tapping deep-links into the app via the "navigation_route" extra that MainActivity
+         / KernelNavHost already consume. -->
+    <shortcut
+        android:shortcutId="lists"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_lists"
+        android:shortcutShortLabel="@string/shortcut_lists_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.kernel.ai"
+            android:targetClass="com.kernel.ai.MainActivity" />
+        <extra
+            android:name="navigation_route"
+            android:value="lists" />
+    </shortcut>
+</shortcuts>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -12,9 +12,10 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetPackage="com.kernel.ai"
-            android:targetClass="com.kernel.ai.MainActivity" />
-        <extra
-            android:name="navigation_route"
-            android:value="lists" />
+            android:targetClass="com.kernel.ai.MainActivity">
+            <extra
+                android:name="navigation_route"
+                android:value="lists" />
+        </intent>
     </shortcut>
 </shortcuts>

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/lists/ListsDataChanged.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/lists/ListsDataChanged.kt
@@ -31,7 +31,7 @@ object ListsDataChanged {
      */
     fun broadcast(context: Context) {
         try {
-            context.sendBroadcast(Intent(ACTION))
+            context.sendBroadcast(Intent(ACTION).apply { setPackage(context.packageName) })
         } catch (_: Throwable) {
             // A failed/unsupported broadcast must never roll back a successful list mutation.
         }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/lists/ListsDataChanged.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/lists/ListsDataChanged.kt
@@ -1,0 +1,39 @@
+package com.kernel.ai.core.memory.lists
+
+import android.content.Context
+import android.content.Intent
+
+/**
+ * Dependency-safe invalidation signal for the Lists home-screen widget.
+ *
+ * List mutations happen in two places that the widget cannot observe directly:
+ *  - [com.kernel.ai.core.skills.natives.NativeIntentHandler] (voice / chat `add_to_list`, etc.)
+ *  - [com.kernel.ai.feature.settings.ListsViewModel] (in-app Lists UI)
+ *
+ * Both live in modules that depend on `:core:memory`, but neither should depend on
+ * `:feature:widget`. To keep module boundaries intact, list mutations broadcast this
+ * plain intent; [com.kernel.ai.feature.widget.ListsWidgetReceiver] listens for it and
+ * refreshes the Glance widget without polling or a shared event bus.
+ *
+ * Broadcasting is the only cross-module coupling and is intentionally fire-and-forget:
+ * the local list mutation remains authoritative even if the broadcast or a widget update
+ * fails.
+ */
+object ListsDataChanged {
+    /** Action carried by the lists-changed broadcast. */
+    const val ACTION = "com.kernel.ai.action.LISTS_DATA_CHANGED"
+
+    /**
+     * Notify listeners (the Lists widget) that list data may have changed.
+     *
+     * Wrapped in try/catch so a failed/unsupported broadcast can never make an otherwise
+     * successful local list mutation fail.
+     */
+    fun broadcast(context: Context) {
+        try {
+            context.sendBroadcast(Intent(ACTION))
+        } catch (_: Throwable) {
+            // A failed/unsupported broadcast must never roll back a successful list mutation.
+        }
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -34,6 +34,7 @@ import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.entity.ListItemEntity
+import com.kernel.ai.core.memory.lists.ListsDataChanged
 import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.memory.dao.NoteDao
 import com.kernel.ai.core.memory.entity.NoteEntity
@@ -1918,6 +1919,7 @@ class NativeIntentHandler @Inject constructor(
             )
             listItemDao.getByList(listId)
         }
+        ListsDataChanged.broadcast(context)
         return SkillResult.DirectReply(
             "Added \"$item\" to your $listName.",
             presentation = buildListPreview(listName, items),
@@ -1947,6 +1949,7 @@ class NativeIntentHandler @Inject constructor(
             }
             listItemDao.getByList(listId)
         }
+        ListsDataChanged.broadcast(context)
         return SkillResult.DirectReply(
             "Added ${items.size} item${if (items.size == 1) "" else "s"} to your $listName:\n" +
                 items.joinToString(", "),
@@ -1959,6 +1962,7 @@ class NativeIntentHandler @Inject constructor(
         val name = normalizeListName(raw)
         val now = System.currentTimeMillis()
         runBlocking { listNameDao.insert(ListNameEntity(name = name, createdAt = now, updatedAt = now)) }
+        ListsDataChanged.broadcast(context)
         return SkillResult.DirectReply(
             "Created list \"$name\".",
             presentation = buildListPreview(name, emptyList(), "No items yet."),
@@ -2002,6 +2006,7 @@ class NativeIntentHandler @Inject constructor(
             val list = listNameDao.getByName(listName) ?: return@runBlocking emptyList<ListItemEntity>()
             listItemDao.getByList(list.id)
         }
+        ListsDataChanged.broadcast(context)
         return SkillResult.DirectReply(
             "Removed \"${match.text}\" from $listName.",
             presentation = buildListPreview(listName, remaining, "No items left."),
@@ -2121,6 +2126,7 @@ class NativeIntentHandler @Inject constructor(
 
         val dayDisplay = dayRaw.replaceFirstChar { it.uppercase() }
         val timeDisplay = targetTime.format(DateTimeFormatter.ofPattern("h:mm a", Locale.ENGLISH))
+        ListsDataChanged.broadcast(context)
         return SkillResult.DirectReply(
             "Reminder set: \"$item\" on $dayDisplay at $timeDisplay.",
             presentation = buildListPreview(persistedListName, allItems),

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -26,6 +26,7 @@ import com.kernel.ai.core.memory.clock.StopwatchStatus
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.NoteDao
 import com.kernel.ai.core.memory.dao.ListNameDao
+import com.kernel.ai.core.memory.lists.ListsDataChanged
 import com.kernel.ai.core.memory.entity.ContactAliasEntity
 import com.kernel.ai.core.memory.entity.ImportantDateEntity
 import com.kernel.ai.core.memory.entity.ListItemEntity
@@ -786,6 +787,29 @@ class NativeIntentHandlerTest {
             readResult,
         )
         coVerify(exactly = 2) { listItemDao.getByList(1L) }
+    }
+    @Test
+    fun `add_to_list broadcasts lists data changed after a successful insertion`() {
+        val shoppingList = com.kernel.ai.core.memory.entity.ListNameEntity(
+            id = 1L, name = "shopping list", createdAt = 0L, updatedAt = 0L,
+        )
+        coEvery { listNameDao.getByName("shopping list") } returns shoppingList
+        coEvery { listItemDao.getByList(1L) } returns emptyList()
+        coEvery { listItemDao.insert(any()) } just Runs
+
+        handleIntent("add_to_list", mapOf("item" to "milk", "list_name" to "shopping list"))
+
+        verify(exactly = 1) { context.sendBroadcast(any()) }
+    }
+
+    @Test
+    fun `add_to_list does not broadcast when it fails fast before any write`() {
+        // No list_name -> addToList returns Failure at the guard, before touching the DAOs.
+        handleIntent("add_to_list", mapOf("item" to "milk"))
+
+        verify(exactly = 0) {
+            context.sendBroadcast(any())
+        }
     }
 
     @Test

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Archive
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Checklist
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DragHandle
@@ -69,6 +70,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -105,6 +107,18 @@ fun ListsScreen(
     var showSortMenu by remember { mutableStateOf(false) }
     var showBulkDeleteDialog by remember { mutableStateOf(false) }
     var showBulkArchiveDialog by remember { mutableStateOf(false) }
+    val handleAddShortcut: () -> Unit = {
+        val result = ListsShortcut.requestPin(context)
+        scope.launch {
+            snackbarHostState.showSnackbar(
+                when (result) {
+                    ListsShortcut.PinResult.Requested -> "Lists shortcut request sent"
+                    ListsShortcut.PinResult.Unsupported ->
+                        "Home-screen shortcuts aren't supported on this device"
+                },
+            )
+        }
+    }
 
     // Active view: apply search on top of already sort/filter-applied displayedLists
     // Archived view: show archivedLists (no search/sort/filter applied)
@@ -224,6 +238,7 @@ fun ListsScreen(
                                 onSortSelected = { viewModel.listSort = it },
                                 onFilterSelected = { viewModel.listFilter = it },
                                 onDismiss = { showSortMenu = false },
+                                onAddShortcut = { handleAddShortcut() },
                             )
                         }
                     },
@@ -708,6 +723,7 @@ private fun SortFilterMenu(
     onFilterSelected: (ListFilter) -> Unit,
     onToggleArchived: () -> Unit,
     onDismiss: () -> Unit,
+    onAddShortcut: () -> Unit,
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
         // ── Archive toggle ──────────────────────────────────────────────────
@@ -790,6 +806,14 @@ private fun SortFilterMenu(
             label = "Pinned only",
             selected = currentFilter == ListFilter.PINNED_ONLY,
             onClick = { onFilterSelected(ListFilter.PINNED_ONLY); onDismiss() },
+        )
+        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+        DropdownMenuItem(
+            text = { Text("Add Lists shortcut to Home screen") },
+            leadingIcon = { Icon(Icons.Filled.Home, contentDescription = null) },
+            onClick = { onDismiss(); onAddShortcut() },
+            modifier = Modifier.testTag("lists_add_home_shortcut"),
         )
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
@@ -113,9 +113,11 @@ fun ListsScreen(
             snackbarHostState.showSnackbar(
                 when (result) {
                     ListsShortcut.PinResult.Requested -> "Lists shortcut request sent"
+                    ListsShortcut.PinResult.Rejected ->
+                        "Couldn't add the shortcut — check your launcher's home-screen settings"
                     ListsShortcut.PinResult.Unsupported ->
                         "Home-screen shortcuts aren't supported on this device"
-                },
+                }
             )
         }
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsShortcut.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsShortcut.kt
@@ -1,0 +1,67 @@
+package com.kernel.ai.feature.settings
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ShortcutInfo
+import android.content.pm.ShortcutManager
+import android.graphics.drawable.Icon
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import com.kernel.ai.feature.settings.R
+
+/**
+ * Canonical launcher shortcut for the Lists feature.
+ *
+ * Both the static launcher shortcut (declared in `app/src/main/res/xml/shortcuts.xml`) and the
+ * in-app "Add Lists shortcut to Home screen" pin action build from this single contract, so they
+ * always share the same id, label, icon, and destination route. The destination is expressed via
+ * the `navigation_route` extra that [com.kernel.ai.MainActivity] / `KernelNavHost` already consume
+ * for the widget and assistant deep-links — no new routing concept.
+ */
+object ListsShortcut {
+    const val ID = "lists"
+    const val NAV_ROUTE = "lists"
+
+    /** Destination route extra name shared with MainActivity / KernelNavHost. */
+    const val NAV_ROUTE_EXTRA = "navigation_route"
+
+    @StringRes
+    val LABEL_RES: Int = R.string.shortcut_lists_label
+
+    @DrawableRes
+    val ICON_RES: Int = R.drawable.ic_shortcut_lists
+
+    fun buildIntent(context: Context): Intent =
+        Intent(Intent.ACTION_VIEW).apply {
+            setClassName(context, "com.kernel.ai.MainActivity")
+            putExtra(NAV_ROUTE_EXTRA, NAV_ROUTE)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+
+    fun buildShortcutInfo(context: Context): ShortcutInfo =
+        ShortcutInfo.Builder(context, ID)
+            .setShortLabel(context.getString(LABEL_RES))
+            .setIcon(Icon.createWithResource(context, ICON_RES))
+            .setIntent(buildIntent(context))
+            .build()
+
+    /**
+     * Pin the canonical Lists shortcut to the home screen.
+     *
+     * Returns [PinResult.Requested] only when the device supports pinning AND the pin request was
+     * accepted; otherwise [PinResult.Unsupported]. The caller must NOT report success when the
+     * result is [PinResult.Unsupported] — pinning is a user-confirmed, asynchronous system flow and
+     * we never claim the shortcut is placed.
+     */
+    fun requestPin(context: Context): PinResult {
+        val manager = context.getSystemService(ShortcutManager::class.java) ?: return PinResult.Unsupported
+        if (!manager.isRequestPinShortcutSupported) {
+            return PinResult.Unsupported
+        }
+        val ok = runCatching { manager.requestPinShortcut(buildShortcutInfo(context), null) }
+            .getOrDefault(false)
+        return if (ok) PinResult.Requested else PinResult.Unsupported
+    }
+
+    enum class PinResult { Requested, Unsupported }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsShortcut.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsShortcut.kt
@@ -49,9 +49,8 @@ object ListsShortcut {
      * Pin the canonical Lists shortcut to the home screen.
      *
      * Returns [PinResult.Requested] only when the device supports pinning AND the pin request was
-     * accepted; otherwise [PinResult.Unsupported]. The caller must NOT report success when the
-     * result is [PinResult.Unsupported] — pinning is a user-confirmed, asynchronous system flow and
-     * we never claim the shortcut is placed.
+     * accepted; [PinResult.Rejected] when the device supports pinning but the request was declined
+     * or threw (we must NOT report success in that case); otherwise [PinResult.Unsupported].
      */
     fun requestPin(context: Context): PinResult {
         val manager = context.getSystemService(ShortcutManager::class.java) ?: return PinResult.Unsupported
@@ -60,8 +59,8 @@ object ListsShortcut {
         }
         val ok = runCatching { manager.requestPinShortcut(buildShortcutInfo(context), null) }
             .getOrDefault(false)
-        return if (ok) PinResult.Requested else PinResult.Unsupported
+        return if (ok) PinResult.Requested else PinResult.Rejected
     }
 
-    enum class PinResult { Requested, Unsupported }
+    enum class PinResult { Requested, Rejected, Unsupported }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -6,11 +6,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import android.content.Context
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.memory.notification.ListNotificationScheduler
+import com.kernel.ai.core.memory.lists.ListsDataChanged
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -22,6 +24,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 data class ListItemCounts(val active: Int, val completed: Int) {
@@ -49,7 +52,16 @@ class ListsViewModel @Inject constructor(
     private val dao: ListItemDao,
     private val listNameDao: ListNameDao,
     private val scheduler: ListNotificationScheduler,
+    @ApplicationContext private val appContext: Context,
 ) : ViewModel() {
+    init {
+        // Keep the Lists home-screen widget in sync with in-app list mutations. Emitted only on a
+        // real Room change (i.e. after a successful write), so a failed persistence never triggers
+        // a widget refresh.
+        viewModelScope.launch {
+            dao.observeAll().collect { ListsDataChanged.broadcast(appContext) }
+        }
+    }
 
     /** Full list entities — exposes id, name, pinned, updatedAt for the overview screen. */
     val listEntities: StateFlow<List<ListNameEntity>> =

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -55,11 +56,21 @@ class ListsViewModel @Inject constructor(
     @ApplicationContext private val appContext: Context,
 ) : ViewModel() {
     init {
-        // Keep the Lists home-screen widget in sync with in-app list mutations. Emitted only on a
-        // real Room change (i.e. after a successful write), so a failed persistence never triggers
-        // a widget refresh.
+        // Keep the Lists home-screen widget in sync with in-app list mutations. A single combined
+        // flow over the item DAO and the list-name DAO emits once on subscription (the initial Room
+        // replay); we skip that first emission explicitly so a cold-start VM never broadcasts. Every
+        // subsequent real write (item OR list metadata: rename, archive, pin, reorder, delete) emits
+        // exactly one widget-refresh broadcast, and a failed persistence never triggers one.
         viewModelScope.launch {
-            dao.observeAll().collect { ListsDataChanged.broadcast(appContext) }
+            var isFirst = true
+            combine(dao.observeAll(), listNameDao.observeActiveLists()) { _, _ -> }
+                .collect {
+                    if (isFirst) {
+                        isFirst = false
+                        return@collect
+                    }
+                    ListsDataChanged.broadcast(appContext)
+                }
         }
     }
 

--- a/feature/settings/src/main/res/drawable/ic_shortcut_lists.xml
+++ b/feature/settings/src/main/res/drawable/ic_shortcut_lists.xml
@@ -8,20 +8,30 @@
         android:fillColor="#1F6F4A"
         android:pathData="M4,2h16a2,2 0 0 1 2,2v16a2,2 0 0 1 -2,2H4a2,2 0 0 1 -2,-2V4a2,2 0 0 1 2,-2Z" />
     <!-- Checklist: a tick then list rows -->
+    <!-- Checklist: stroked check marks + filled list rows -->
     <path
-        android:fillColor="#FFFFFF"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.6"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
         android:pathData="M5.5,7L7,8.5L10,5.5" />
     <path
         android:fillColor="#FFFFFF"
         android:pathData="M11.5,5.5h6v1.8h-6z" />
     <path
-        android:fillColor="#FFFFFF"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.6"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
         android:pathData="M5.5,12L7,13.5L10,10.5" />
     <path
         android:fillColor="#FFFFFF"
         android:pathData="M11.5,10.5h6v1.8h-6z" />
     <path
-        android:fillColor="#FFFFFF"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.6"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
         android:pathData="M5.5,17L7,18.5L10,15.5" />
     <path
         android:fillColor="#FFFFFF"

--- a/feature/settings/src/main/res/drawable/ic_shortcut_lists.xml
+++ b/feature/settings/src/main/res/drawable/ic_shortcut_lists.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Jandal green panel (related to the app icon family) -->
+    <path
+        android:fillColor="#1F6F4A"
+        android:pathData="M4,2h16a2,2 0 0 1 2,2v16a2,2 0 0 1 -2,2H4a2,2 0 0 1 -2,-2V4a2,2 0 0 1 2,-2Z" />
+    <!-- Checklist: a tick then list rows -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M5.5,7L7,8.5L10,5.5" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M11.5,5.5h6v1.8h-6z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M5.5,12L7,13.5L10,10.5" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M11.5,10.5h6v1.8h-6z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M5.5,17L7,18.5L10,15.5" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M11.5,15.5h6v1.8h-6z" />
+</vector>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="shortcut_lists_label">Lists</string>
+</resources>

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ListsShortcutTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ListsShortcutTest.kt
@@ -52,9 +52,9 @@ class ListsShortcutTest {
     }
 
     @Test
-    fun `requestPin reports Unsupported when the system rejects the pin`() {
+    fun `reports rejected when the pin request is declined`() {
         every { manager.isRequestPinShortcutSupported } returns true
         every { manager.requestPinShortcut(any(), any()) } returns false
-        assertEquals(ListsShortcut.PinResult.Unsupported, ListsShortcut.requestPin(context))
+        assertEquals(ListsShortcut.PinResult.Rejected, ListsShortcut.requestPin(context))
     }
 }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ListsShortcutTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ListsShortcutTest.kt
@@ -1,0 +1,60 @@
+package com.kernel.ai.feature.settings
+
+import android.content.Context
+import android.content.pm.ShortcutManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ListsShortcutTest {
+
+    private val context = mockk<Context>(relaxed = true)
+    private val manager = mockk<ShortcutManager>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(ListsShortcut)
+        every { ListsShortcut.buildShortcutInfo(any()) } returns mockk(relaxed = true)
+        every { context.getSystemService(ShortcutManager::class.java) } returns manager
+    }
+
+    @AfterEach
+    fun tearDown() { unmockkObject(ListsShortcut) }
+
+    @Test
+    fun `canonical constants match the static shortcut definition`() {
+        assertEquals("lists", ListsShortcut.ID)
+        assertEquals("lists", ListsShortcut.NAV_ROUTE)
+        assertEquals("navigation_route", ListsShortcut.NAV_ROUTE_EXTRA)
+        assertEquals(R.string.shortcut_lists_label, ListsShortcut.LABEL_RES)
+        assertEquals(R.drawable.ic_shortcut_lists, ListsShortcut.ICON_RES)
+    }
+
+    @Test
+    fun `requestPin reports Unsupported when pinning is not supported`() {
+        every { manager.isRequestPinShortcutSupported } returns false
+        assertEquals(ListsShortcut.PinResult.Unsupported, ListsShortcut.requestPin(context))
+        verify(exactly = 0) { manager.requestPinShortcut(any(), any()) }
+    }
+
+    @Test
+    fun `requestPin reports Requested when supported and accepted`() {
+        every { manager.isRequestPinShortcutSupported } returns true
+        every { manager.requestPinShortcut(any(), any()) } returns true
+        assertEquals(ListsShortcut.PinResult.Requested, ListsShortcut.requestPin(context))
+        verify { manager.requestPinShortcut(any(), any()) }
+    }
+
+    @Test
+    fun `requestPin reports Unsupported when the system rejects the pin`() {
+        every { manager.isRequestPinShortcutSupported } returns true
+        every { manager.requestPinShortcut(any(), any()) } returns false
+        assertEquals(ListsShortcut.PinResult.Unsupported, ListsShortcut.requestPin(context))
+    }
+}

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ListsViewModelBroadcastTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ListsViewModelBroadcastTest.kt
@@ -1,0 +1,52 @@
+package com.kernel.ai.feature.settings
+
+import android.content.Context
+import com.kernel.ai.core.memory.dao.ListItemDao
+import com.kernel.ai.core.memory.entity.ListItemEntity
+import com.kernel.ai.core.memory.notification.ListNotificationScheduler
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ListsViewModelBroadcastTest {
+
+    private val dao = mockk<ListItemDao>(relaxed = true)
+    private val listNameDao = mockk<com.kernel.ai.core.memory.dao.ListNameDao>(relaxed = true)
+    private val scheduler = mockk<ListNotificationScheduler>(relaxed = true)
+    private val context = mockk<Context>(relaxed = true)
+    private val flow = MutableSharedFlow<List<ListItemEntity>>(extraBufferCapacity = 1)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        every { dao.observeAll() } returns flow
+    }
+
+    @AfterEach
+    fun tearDown() { Dispatchers.resetMain() }
+
+    @Test
+    fun `broadcasts lists data changed whenever the list store emits`() {
+        ListsViewModel(dao, listNameDao, scheduler, context)
+
+        flow.tryEmit(emptyList())
+        verify(exactly = 1) { context.sendBroadcast(any()) }
+
+        flow.tryEmit(
+            listOf(
+                ListItemEntity(id = 1L, listId = 1L, text = "milk", createdAt = 1L, updatedAt = 1L),
+            ),
+        )
+        verify(exactly = 2) { context.sendBroadcast(any()) }
+    }
+}

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ListsViewModelBroadcastTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ListsViewModelBroadcastTest.kt
@@ -2,7 +2,9 @@ package com.kernel.ai.feature.settings
 
 import android.content.Context
 import com.kernel.ai.core.memory.dao.ListItemDao
+import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.entity.ListItemEntity
+import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.memory.notification.ListNotificationScheduler
 import io.mockk.every
 import io.mockk.mockk
@@ -14,6 +16,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -21,32 +24,38 @@ import org.junit.jupiter.api.Test
 class ListsViewModelBroadcastTest {
 
     private val dao = mockk<ListItemDao>(relaxed = true)
-    private val listNameDao = mockk<com.kernel.ai.core.memory.dao.ListNameDao>(relaxed = true)
+    private val listNameDao = mockk<ListNameDao>(relaxed = true)
     private val scheduler = mockk<ListNotificationScheduler>(relaxed = true)
     private val context = mockk<Context>(relaxed = true)
-    private val flow = MutableSharedFlow<List<ListItemEntity>>(extraBufferCapacity = 1)
+    private val itemFlow = MutableSharedFlow<List<ListItemEntity>>(extraBufferCapacity = 1)
+    private val nameFlow = MutableSharedFlow<List<ListNameEntity>>(extraBufferCapacity = 1)
+    private val broadcastCalls = mutableListOf<Int>()
 
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
-        every { dao.observeAll() } returns flow
+        every { dao.observeAll() } returns itemFlow
+        every { listNameDao.observeActiveLists() } returns nameFlow
+        every { context.sendBroadcast(any()) } answers { broadcastCalls.add(0); Unit }
     }
 
     @AfterEach
     fun tearDown() { Dispatchers.resetMain() }
 
     @Test
-    fun `broadcasts lists data changed whenever the list store emits`() {
+    fun `broadcasts on item and name mutations, never on initial replay`() {
         ListsViewModel(dao, listNameDao, scheduler, context)
 
-        flow.tryEmit(emptyList())
-        verify(exactly = 1) { context.sendBroadcast(any()) }
+        itemFlow.tryEmit(emptyList())
+        nameFlow.tryEmit(emptyList())
+        assertEquals(0, broadcastCalls.size, "no broadcast on initial replay (got ${broadcastCalls.size})")
 
-        flow.tryEmit(
-            listOf(
-                ListItemEntity(id = 1L, listId = 1L, text = "milk", createdAt = 1L, updatedAt = 1L),
-            ),
+        itemFlow.tryEmit(
+            listOf(ListItemEntity(id = 1L, listId = 1L, text = "milk", createdAt = 1L, updatedAt = 1L)),
         )
-        verify(exactly = 2) { context.sendBroadcast(any()) }
+        assertEquals(1, broadcastCalls.size, "one broadcast on item mutation (got ${broadcastCalls.size})")
+
+        nameFlow.tryEmit(emptyList())
+        assertEquals(2, broadcastCalls.size, "one broadcast on name mutation (got ${broadcastCalls.size})")
     }
 }

--- a/feature/widget/build.gradle.kts
+++ b/feature/widget/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation(libs.compose.material3)
     implementation(libs.compose.material.icons)
     implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.foundation)
     implementation(libs.lifecycle.runtime.compose)
     implementation(libs.activity.compose)
 

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsDataChangedReceiver.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsDataChangedReceiver.kt
@@ -1,0 +1,22 @@
+package com.kernel.ai.feature.widget
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.kernel.ai.core.memory.lists.ListsDataChanged
+
+/**
+ * Non-exported receiver for the internal [ListsDataChanged.ACTION] signal.
+ *
+ * It is deliberately NOT exported: only broadcasts from within this app (and the now
+ * package-targeted [ListsDataChanged.broadcast]) can reach it, so another app cannot spoof the
+ * action to trigger a widget re-render or DB read. The standard app-widget lifecycle is handled
+ * by [ListsWidgetReceiver].
+ */
+class ListsDataChangedReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == ListsDataChanged.ACTION) {
+            ListsWidgetRefresher.refresh(context)
+        }
+    }
+}

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
@@ -103,7 +103,16 @@ class ListsWidgetLaunchCallback : ActionCallback {
         @SuppressLint("RestrictedApi")
         val appWidgetId = (glanceId as AppWidgetId).appWidgetId
         val selectedListId = ListsWidgetConfig.from(context).getSelectedListId(appWidgetId)
-        val route = routeFor(selectedListId)
+        val listExists = if (selectedListId > 0L) {
+            val entry = EntryPointAccessors.fromApplication(
+                context.applicationContext,
+                ListsWidgetDataEntryPoint::class.java,
+            )
+            entry.listNameDao().getById(selectedListId) != null
+        } else {
+            false
+        }
+        val route = routeFor(selectedListId, listExists)
         val intent = Intent(Intent.ACTION_VIEW).apply {
             setClassName(context.packageName, "com.kernel.ai.MainActivity")
             putExtra("navigation_route", route)
@@ -112,9 +121,9 @@ class ListsWidgetLaunchCallback : ActionCallback {
         context.startActivity(intent)
     }
     companion object {
-        /** Deep-link route for a bound list id, or the Lists overview when unconfigured. */
-        internal fun routeFor(selectedListId: Long): String =
-            if (selectedListId > 0L) "lists/$selectedListId" else "lists"
+        /** Deep-link route for an existing bound list, or the Lists overview otherwise. */
+        internal fun routeFor(selectedListId: Long, listExists: Boolean): String =
+            if (selectedListId > 0L && listExists) "lists/$selectedListId" else "lists"
     }
 }
 

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
@@ -1,20 +1,22 @@
 package com.kernel.ai.feature.widget
 
 import android.annotation.SuppressLint
+import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
-import androidx.glance.LocalContext
+import androidx.glance.LocalSize
 import androidx.glance.appwidget.action.ActionCallback
 import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.AppWidgetId
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.provideContent
+import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
 import androidx.glance.background
 import androidx.glance.color.DayNightColorProvider
 import androidx.glance.layout.Box
@@ -23,7 +25,6 @@ import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
-import androidx.glance.layout.wrapContentHeight
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
@@ -35,9 +36,6 @@ import com.kernel.ai.core.ui.theme.FernGreen
 import com.kernel.ai.core.ui.theme.FernGreenLight
 import com.kernel.ai.core.ui.theme.SandLight
 import dagger.hilt.android.EntryPointAccessors
-
-/** Maximum number of active items rendered before a "+N more" hint. */
-private const val MAX_ITEMS = 8
 
 @SuppressLint("RestrictedApi")
 private val SurfaceColor = DayNightColorProvider(day = SandLight.copy(alpha = 0.94f), night = CharcoalDark.copy(alpha = 0.94f))
@@ -58,6 +56,8 @@ private val AccentColor = DayNightColorProvider(day = FernGreen, night = FernGre
  */
 class ListsWidget : GlanceAppWidget() {
 
+    override val sizeMode: SizeMode = SizeMode.Exact
+
     @SuppressLint("RestrictedApi")
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val appWidgetId = (id as AppWidgetId).appWidgetId
@@ -77,23 +77,28 @@ class ListsWidget : GlanceAppWidget() {
 
         provideContent { ListsWidgetContent(projection) }
     }
-        /** Clear per-widget config when the instance is deleted so storage stays bounded. */
-        @SuppressLint("RestrictedApi")
-        override suspend fun onDelete(context: Context, glanceId: GlanceId) {
-            val appWidgetId = (glanceId as AppWidgetId).appWidgetId
-            ListsWidgetConfig.from(context).clear(appWidgetId)
-        }
+    /** Clear per-widget config when the instance is deleted so storage stays bounded. */
+    @SuppressLint("RestrictedApi")
+    override suspend fun onDelete(context: Context, glanceId: GlanceId) {
+        val appWidgetId = (glanceId as AppWidgetId).appWidgetId
+        ListsWidgetConfig.from(context).clear(appWidgetId)
+    }
 }
 
 /**
  * Glance action callback fired when a Lists widget is tapped.
  *
  * Glance 1.1.1 widget clicks cannot carry intent extras, but an [ActionCallback] receives the
- * widget's [GlanceId] (which is its [AppWidgetId]); from that we resolve the bound list and start
- * MainActivity with the `navigation_route` extra — the same deep-link seam the static launcher
- * shortcut uses. This keeps the per-widget route local to the widget and out of any global state,
- * so multiple widgets route to their own lists and the route never leaks into unrelated launches.
+ * widget's [GlanceId] (which is its [AppWidgetId]); from that we resolve the bound list and either
+ * start the existing list detail route or reopen the configuration activity for this widget
+ * instance when its bound list is unavailable. This keeps the per-widget route local to the widget
+ * and out of any global state, so multiple widgets route to their own lists.
  */
+internal sealed interface ListsWidgetLaunchDestination {
+    data class Detail(val route: String) : ListsWidgetLaunchDestination
+    data class Configure(val appWidgetId: Int) : ListsWidgetLaunchDestination
+}
+
 class ListsWidgetLaunchCallback : ActionCallback {
     override suspend fun onAction(
         context: Context,
@@ -112,25 +117,50 @@ class ListsWidgetLaunchCallback : ActionCallback {
         } else {
             false
         }
-        val route = routeFor(selectedListId, listExists)
-        val intent = Intent(Intent.ACTION_VIEW).apply {
-            setClassName(context.packageName, "com.kernel.ai.MainActivity")
-            putExtra("navigation_route", route)
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        when (val destination = launchDestinationFor(selectedListId, listExists, appWidgetId)) {
+            is ListsWidgetLaunchDestination.Detail -> {
+                val intent = Intent(Intent.ACTION_VIEW).apply {
+                    setClassName(context.packageName, "com.kernel.ai.MainActivity")
+                    putExtra("navigation_route", destination.route)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                }
+                context.startActivity(intent)
+            }
+            is ListsWidgetLaunchDestination.Configure -> {
+                val configureIntent = Intent().apply {
+                    setClassName(context.packageName, ListsWidgetConfigureActivity::class.java.name)
+                    putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, destination.appWidgetId)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                }
+                context.startActivity(configureIntent)
+            }
         }
-        context.startActivity(intent)
     }
     companion object {
-        /** Deep-link route for an existing bound list, or the Lists overview otherwise. */
-        internal fun routeFor(selectedListId: Long, listExists: Boolean): String =
-            if (selectedListId > 0L && listExists) "lists/$selectedListId" else "lists"
+        /** Detail route for an existing bound list, or configuration otherwise. */
+        internal fun launchDestinationFor(
+            selectedListId: Long,
+            listExists: Boolean,
+            appWidgetId: Int,
+        ): ListsWidgetLaunchDestination =
+            if (selectedListId > 0L && listExists) {
+                ListsWidgetLaunchDestination.Detail("lists/$selectedListId")
+            } else {
+                ListsWidgetLaunchDestination.Configure(appWidgetId)
+            }
     }
 }
 
 @Composable
 private fun ListsWidgetContent(projection: ListsWidgetProjection) {
     GlanceTheme {
-        val context = LocalContext.current
+        val widgetSize = LocalSize.current
+        val activeItemCount = when (projection) {
+            is ListsWidgetProjection.Configured -> projection.activeItems.size
+            is ListsWidgetProjection.Archived -> projection.activeItems.size
+            else -> 0
+        }
+        val itemLayout = calculateActiveItemLayout(widgetSize.height.value, activeItemCount)
         val rootAction = actionRunCallback(ListsWidgetLaunchCallback::class.java)
 
         val title = when (projection) {
@@ -144,7 +174,7 @@ private fun ListsWidgetContent(projection: ListsWidgetProjection) {
         Box(
             modifier = GlanceModifier
                 .fillMaxWidth()
-                .wrapContentHeight()
+                .height(widgetSize.height)
                 .background(SurfaceColor)
                 .cornerRadius(20.dp)
                 .padding(14.dp)
@@ -160,11 +190,11 @@ private fun ListsWidgetContent(projection: ListsWidgetProjection) {
                 Spacer(GlanceModifier.height(8.dp))
 
                 when (projection) {
-                    is ListsWidgetProjection.Configured -> ActiveItems(projection.activeItems)
+                    is ListsWidgetProjection.Configured -> ActiveItems(projection.activeItems, itemLayout)
                     is ListsWidgetProjection.Archived -> {
                         Text("Archived", style = TextStyle(fontSize = 12.sp, color = HintColor))
                         Spacer(GlanceModifier.height(4.dp))
-                        ActiveItems(projection.activeItems, accent = true)
+                        ActiveItems(projection.activeItems, itemLayout, accent = true)
                     }
                     is ListsWidgetProjection.Empty ->
                         Text("No active items", style = TextStyle(fontSize = 14.sp, color = HintColor))
@@ -174,7 +204,7 @@ private fun ListsWidgetContent(projection: ListsWidgetProjection) {
                             style = TextStyle(fontSize = 14.sp, color = HintColor),
                         )
                     is ListsWidgetProjection.NotConfigured ->
-                        Text("Tap to open your lists.", style = TextStyle(fontSize = 14.sp, color = HintColor))
+                        Text("Tap to choose a list.", style = TextStyle(fontSize = 14.sp, color = HintColor))
                 }
             }
         }
@@ -182,8 +212,12 @@ private fun ListsWidgetContent(projection: ListsWidgetProjection) {
 }
 
 @Composable
-private fun ActiveItems(items: List<String>, accent: Boolean = false) {
-    items.take(MAX_ITEMS).forEach { item ->
+private fun ActiveItems(
+    items: List<String>,
+    layout: ActiveItemLayout,
+    accent: Boolean = false,
+) {
+    items.take(layout.visibleCount).forEach { item ->
         Text(
             text = "• $item",
             style = TextStyle(
@@ -193,9 +227,9 @@ private fun ActiveItems(items: List<String>, accent: Boolean = false) {
             modifier = GlanceModifier.fillMaxWidth(),
         )
     }
-    if (items.size > MAX_ITEMS) {
+    if (layout.overflowCount > 0) {
         Text(
-            text = "+${items.size - MAX_ITEMS} more",
+            text = "+${layout.overflowCount} more",
             style = TextStyle(fontSize = 12.sp, color = HintColor),
             modifier = GlanceModifier.fillMaxWidth(),
         )

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
@@ -1,13 +1,15 @@
 package com.kernel.ai.feature.widget
 
-import android.content.ComponentName
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.LocalContext
-import androidx.glance.action.actionStartActivity
+import androidx.glance.appwidget.action.ActionCallback
+import androidx.glance.action.ActionParameters
+import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.AppWidgetId
 import androidx.glance.appwidget.GlanceAppWidget
@@ -73,32 +75,54 @@ class ListsWidget : GlanceAppWidget() {
             ListsWidgetProjection.NotConfigured
         }
 
-        ListsWidgetConfig.from(context).setLastRoute(routeFor(projection))
         provideContent { ListsWidgetContent(projection) }
     }
+        /** Clear per-widget config when the instance is deleted so storage stays bounded. */
+        @SuppressLint("RestrictedApi")
+        override suspend fun onDelete(context: Context, glanceId: GlanceId) {
+            val appWidgetId = (glanceId as AppWidgetId).appWidgetId
+            ListsWidgetConfig.from(context).clear(appWidgetId)
+        }
 }
 
 /**
- * Deep-link route for a widget tap: the bound list when configured, else the Lists overview.
+ * Glance action callback fired when a Lists widget is tapped.
  *
- * Glance 1.1.1 widget clicks can only launch an Activity by class (no intent extras), so the
- * route is persisted via [ListsWidgetConfig.setLastRoute] and consumed by MainActivity on launch.
+ * Glance 1.1.1 widget clicks cannot carry intent extras, but an [ActionCallback] receives the
+ * widget's [GlanceId] (which is its [AppWidgetId]); from that we resolve the bound list and start
+ * MainActivity with the `navigation_route` extra — the same deep-link seam the static launcher
+ * shortcut uses. This keeps the per-widget route local to the widget and out of any global state,
+ * so multiple widgets route to their own lists and the route never leaks into unrelated launches.
  */
-private fun routeFor(projection: ListsWidgetProjection): String =
-    if (projection is ListsWidgetProjection.Configured ||
-        projection is ListsWidgetProjection.Empty ||
-        projection is ListsWidgetProjection.Archived
+class ListsWidgetLaunchCallback : ActionCallback {
+    override suspend fun onAction(
+        context: Context,
+        glanceId: GlanceId,
+        parameters: ActionParameters,
     ) {
-        "lists/${projection.listId}"
-    } else {
-        "lists"
+        @SuppressLint("RestrictedApi")
+        val appWidgetId = (glanceId as AppWidgetId).appWidgetId
+        val selectedListId = ListsWidgetConfig.from(context).getSelectedListId(appWidgetId)
+        val route = routeFor(selectedListId)
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setClassName(context.packageName, "com.kernel.ai.MainActivity")
+            putExtra("navigation_route", route)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+        context.startActivity(intent)
     }
+    companion object {
+        /** Deep-link route for a bound list id, or the Lists overview when unconfigured. */
+        internal fun routeFor(selectedListId: Long): String =
+            if (selectedListId > 0L) "lists/$selectedListId" else "lists"
+    }
+}
 
 @Composable
 private fun ListsWidgetContent(projection: ListsWidgetProjection) {
     GlanceTheme {
         val context = LocalContext.current
-        val rootAction = actionStartActivity(ComponentName(context.packageName, "com.kernel.ai.MainActivity"))
+        val rootAction = actionRunCallback(ListsWidgetLaunchCallback::class.java)
 
         val title = when (projection) {
             is ListsWidgetProjection.Configured -> projection.listName

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
@@ -4,8 +4,6 @@ import android.annotation.SuppressLint
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
-import android.widget.RemoteViews
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
@@ -15,8 +13,6 @@ import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.AppWidgetId
-import androidx.glance.appwidget.ExperimentalGlanceRemoteViewsApi
-import androidx.glance.appwidget.GlanceRemoteViews
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.cornerRadius
@@ -32,9 +28,9 @@ import androidx.glance.layout.padding
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.Composable
 import com.kernel.ai.core.ui.theme.CharcoalDark
 import com.kernel.ai.core.ui.theme.FernGreen
@@ -65,43 +61,38 @@ class ListsWidget : GlanceAppWidget() {
 
     @SuppressLint("RestrictedApi")
     override suspend fun provideGlance(context: Context, id: GlanceId) {
-        val projection = loadProjection(context, id)
-        provideContent { ListsWidgetContent(projection) }
+        val appWidgetId = (id as AppWidgetId).appWidgetId
+        val config = ListsWidgetConfig.from(context)
+        val entry = widgetDataEntryPoint(context)
+        val initialProjection = loadProjection(config, id, entry)
+        val projectionFlow = observeListsWidgetProjection(
+            selectedListIds = config.observeSelectedListId(appWidgetId),
+            listMetadata = entry.listNameDao().observeAll(),
+            listItems = entry.listItemDao()::observeByList,
+        )
+
+        provideContent {
+            val projection = projectionFlow.collectAsState(initial = initialProjection).value
+            ListsWidgetContent(projection)
+        }
     }
 
-    /**
-     * Compose one synchronous RemoteViews tree for configuration completion.
-     *
-     * Normal refreshes continue through [update]; this path exists only because a freshly configured
-     * launcher widget can defer delivery of Glance's session-backed update until a later host event.
-     */
-    @OptIn(ExperimentalGlanceRemoteViewsApi::class)
-    internal suspend fun compose(
-        context: Context,
-        id: GlanceId,
-        size: DpSize,
-        appWidgetOptions: Bundle,
-    ): RemoteViews {
-        val projection = loadProjection(context, id)
-        return GlanceRemoteViews().compose(
-            context = context,
-            size = size,
-            appWidgetOptions = appWidgetOptions,
-        ) {
-            ListsWidgetContent(projection)
-        }.remoteViews
-    }
+    private fun widgetDataEntryPoint(context: Context): ListsWidgetDataEntryPoint =
+        EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            ListsWidgetDataEntryPoint::class.java,
+        )
 
     @SuppressLint("RestrictedApi")
-    private suspend fun loadProjection(context: Context, id: GlanceId): ListsWidgetProjection {
+    private suspend fun loadProjection(
+        config: ListsWidgetConfig,
+        id: GlanceId,
+        entry: ListsWidgetDataEntryPoint,
+    ): ListsWidgetProjection {
         val appWidgetId = (id as AppWidgetId).appWidgetId
-        val selectedListId = ListsWidgetConfig.from(context).getSelectedListId(appWidgetId)
+        val selectedListId = config.getSelectedListId(appWidgetId)
 
         return if (selectedListId > 0L) {
-            val entry = EntryPointAccessors.fromApplication(
-                context.applicationContext,
-                ListsWidgetDataEntryPoint::class.java,
-            )
             val name = entry.listNameDao().getById(selectedListId)
             val items = entry.listItemDao().getByList(selectedListId)
             projectListsWidget(selectedListId, name, items)

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
+import android.widget.RemoteViews
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
@@ -13,6 +15,8 @@ import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.AppWidgetId
+import androidx.glance.appwidget.ExperimentalGlanceRemoteViewsApi
+import androidx.glance.appwidget.GlanceRemoteViews
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.cornerRadius
@@ -28,6 +32,7 @@ import androidx.glance.layout.padding
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.runtime.Composable
@@ -60,10 +65,39 @@ class ListsWidget : GlanceAppWidget() {
 
     @SuppressLint("RestrictedApi")
     override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val projection = loadProjection(context, id)
+        provideContent { ListsWidgetContent(projection) }
+    }
+
+    /**
+     * Compose one synchronous RemoteViews tree for configuration completion.
+     *
+     * Normal refreshes continue through [update]; this path exists only because a freshly configured
+     * launcher widget can defer delivery of Glance's session-backed update until a later host event.
+     */
+    @OptIn(ExperimentalGlanceRemoteViewsApi::class)
+    internal suspend fun compose(
+        context: Context,
+        id: GlanceId,
+        size: DpSize,
+        appWidgetOptions: Bundle,
+    ): RemoteViews {
+        val projection = loadProjection(context, id)
+        return GlanceRemoteViews().compose(
+            context = context,
+            size = size,
+            appWidgetOptions = appWidgetOptions,
+        ) {
+            ListsWidgetContent(projection)
+        }.remoteViews
+    }
+
+    @SuppressLint("RestrictedApi")
+    private suspend fun loadProjection(context: Context, id: GlanceId): ListsWidgetProjection {
         val appWidgetId = (id as AppWidgetId).appWidgetId
         val selectedListId = ListsWidgetConfig.from(context).getSelectedListId(appWidgetId)
 
-        val projection = if (selectedListId > 0L) {
+        return if (selectedListId > 0L) {
             val entry = EntryPointAccessors.fromApplication(
                 context.applicationContext,
                 ListsWidgetDataEntryPoint::class.java,
@@ -74,8 +108,6 @@ class ListsWidget : GlanceAppWidget() {
         } else {
             ListsWidgetProjection.NotConfigured
         }
-
-        provideContent { ListsWidgetContent(projection) }
     }
     /** Clear per-widget config when the instance is deleted so storage stays bounded. */
     @SuppressLint("RestrictedApi")

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidget.kt
@@ -1,0 +1,170 @@
+package com.kernel.ai.feature.widget
+
+import android.content.ComponentName
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.LocalContext
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.AppWidgetId
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.provideContent
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.background
+import androidx.glance.color.DayNightColorProvider
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.wrapContentHeight
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.runtime.Composable
+import com.kernel.ai.core.ui.theme.CharcoalDark
+import com.kernel.ai.core.ui.theme.FernGreen
+import com.kernel.ai.core.ui.theme.FernGreenLight
+import com.kernel.ai.core.ui.theme.SandLight
+import dagger.hilt.android.EntryPointAccessors
+
+/** Maximum number of active items rendered before a "+N more" hint. */
+private const val MAX_ITEMS = 8
+
+@SuppressLint("RestrictedApi")
+private val SurfaceColor = DayNightColorProvider(day = SandLight.copy(alpha = 0.94f), night = CharcoalDark.copy(alpha = 0.94f))
+@SuppressLint("RestrictedApi")
+private val OnSurfaceColor = DayNightColorProvider(day = CharcoalDark, night = SandLight)
+@SuppressLint("RestrictedApi")
+private val HintColor = DayNightColorProvider(day = CharcoalDark.copy(alpha = 0.6f), night = SandLight.copy(alpha = 0.6f))
+@SuppressLint("RestrictedApi")
+private val AccentColor = DayNightColorProvider(day = FernGreen, night = FernGreenLight)
+
+/**
+ * Home-screen Glance widget bound to one existing local Jandal list.
+ *
+ * The widget never holds its own copy of the list data: on every render (including refreshes
+ * triggered by [ListsWidgetReceiver] after a list mutation) it reads straight from the shared
+ * Room store via [ListsWidgetDataEntryPoint]. There is no polling and no periodic worker — the
+ * only refresh trigger is the `LISTS_DATA_CHANGED` broadcast from a successful mutation.
+ */
+class ListsWidget : GlanceAppWidget() {
+
+    @SuppressLint("RestrictedApi")
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val appWidgetId = (id as AppWidgetId).appWidgetId
+        val selectedListId = ListsWidgetConfig.from(context).getSelectedListId(appWidgetId)
+
+        val projection = if (selectedListId > 0L) {
+            val entry = EntryPointAccessors.fromApplication(
+                context.applicationContext,
+                ListsWidgetDataEntryPoint::class.java,
+            )
+            val name = entry.listNameDao().getById(selectedListId)
+            val items = entry.listItemDao().getByList(selectedListId)
+            projectListsWidget(selectedListId, name, items)
+        } else {
+            ListsWidgetProjection.NotConfigured
+        }
+
+        ListsWidgetConfig.from(context).setLastRoute(routeFor(projection))
+        provideContent { ListsWidgetContent(projection) }
+    }
+}
+
+/**
+ * Deep-link route for a widget tap: the bound list when configured, else the Lists overview.
+ *
+ * Glance 1.1.1 widget clicks can only launch an Activity by class (no intent extras), so the
+ * route is persisted via [ListsWidgetConfig.setLastRoute] and consumed by MainActivity on launch.
+ */
+private fun routeFor(projection: ListsWidgetProjection): String =
+    if (projection is ListsWidgetProjection.Configured ||
+        projection is ListsWidgetProjection.Empty ||
+        projection is ListsWidgetProjection.Archived
+    ) {
+        "lists/${projection.listId}"
+    } else {
+        "lists"
+    }
+
+@Composable
+private fun ListsWidgetContent(projection: ListsWidgetProjection) {
+    GlanceTheme {
+        val context = LocalContext.current
+        val rootAction = actionStartActivity(ComponentName(context.packageName, "com.kernel.ai.MainActivity"))
+
+        val title = when (projection) {
+            is ListsWidgetProjection.Configured -> projection.listName
+            is ListsWidgetProjection.Empty -> projection.listName
+            is ListsWidgetProjection.Archived -> projection.listName
+            is ListsWidgetProjection.Missing -> "List unavailable"
+            is ListsWidgetProjection.NotConfigured -> "Choose a list"
+        }
+
+        Box(
+            modifier = GlanceModifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .background(SurfaceColor)
+                .cornerRadius(20.dp)
+                .padding(14.dp)
+                .clickable(rootAction),
+        ) {
+            Column(modifier = GlanceModifier.fillMaxWidth()) {
+                Text(
+                    text = title,
+                    style = TextStyle(fontSize = 18.sp, fontWeight = FontWeight.Bold, color = OnSurfaceColor),
+                    modifier = GlanceModifier.fillMaxWidth(),
+                )
+
+                Spacer(GlanceModifier.height(8.dp))
+
+                when (projection) {
+                    is ListsWidgetProjection.Configured -> ActiveItems(projection.activeItems)
+                    is ListsWidgetProjection.Archived -> {
+                        Text("Archived", style = TextStyle(fontSize = 12.sp, color = HintColor))
+                        Spacer(GlanceModifier.height(4.dp))
+                        ActiveItems(projection.activeItems, accent = true)
+                    }
+                    is ListsWidgetProjection.Empty ->
+                        Text("No active items", style = TextStyle(fontSize = 14.sp, color = HintColor))
+                    is ListsWidgetProjection.Missing ->
+                        Text(
+                            "This list was deleted. Open Lists to choose another.",
+                            style = TextStyle(fontSize = 14.sp, color = HintColor),
+                        )
+                    is ListsWidgetProjection.NotConfigured ->
+                        Text("Tap to open your lists.", style = TextStyle(fontSize = 14.sp, color = HintColor))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActiveItems(items: List<String>, accent: Boolean = false) {
+    items.take(MAX_ITEMS).forEach { item ->
+        Text(
+            text = "• $item",
+            style = TextStyle(
+                fontSize = 14.sp,
+                color = if (accent) AccentColor else OnSurfaceColor,
+            ),
+            modifier = GlanceModifier.fillMaxWidth(),
+        )
+    }
+    if (items.size > MAX_ITEMS) {
+        Text(
+            text = "+${items.size - MAX_ITEMS} more",
+            style = TextStyle(fontSize = 12.sp, color = HintColor),
+            modifier = GlanceModifier.fillMaxWidth(),
+        )
+    }
+}

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfig.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfig.kt
@@ -3,6 +3,9 @@ package com.kernel.ai.feature.widget
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 
 /**
  * Per-widget configuration: which local Jandal list each widget instance displays.
@@ -21,6 +24,24 @@ class ListsWidgetConfig(private val prefs: SharedPreferences) {
     fun getSelectedListId(appWidgetId: Int): Long {
         val stored = prefs.getLong(key(appWidgetId), INVALID)
         return if (stored > 0L) stored else INVALID
+    }
+
+    /**
+     * Observes the selected list for one widget instance.
+     *
+     * The current value is emitted immediately, and subsequent emissions are limited to changes
+     * for this widget's own preference key.
+     */
+    fun observeSelectedListId(appWidgetId: Int): Flow<Long> = callbackFlow {
+        val selectedKey = key(appWidgetId)
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, changedKey ->
+            if (changedKey == selectedKey) {
+                trySend(getSelectedListId(appWidgetId))
+            }
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        trySend(getSelectedListId(appWidgetId))
+        awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
     }
 
     /** Persist the selected list id for [appWidgetId] (asynchronous; non-config writes). */

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfig.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfig.kt
@@ -1,0 +1,57 @@
+package com.kernel.ai.feature.widget
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+/**
+ * Per-widget configuration: which local Jandal list each widget instance displays.
+ *
+ * This is configuration metadata only — the actual list contents always come from the
+ * shared Room store (see [ListsWidget]). Each widget instance is keyed by its Android
+ * `appWidgetId`, so multiple widgets can point at different lists independently, and the
+ * selection survives process death and normal app restart.
+ *
+ * The [SharedPreferences] instance is injected (rather than looked up from a [Context]) so
+ * the persistence logic is unit-testable with a fake preferences implementation.
+ */
+class ListsWidgetConfig(private val prefs: SharedPreferences) {
+
+    /** Selected list id for [appWidgetId], or [INVALID] if the widget is not configured. */
+    fun getSelectedListId(appWidgetId: Int): Long {
+        val stored = prefs.getLong(key(appWidgetId), INVALID)
+        return if (stored > 0L) stored else INVALID
+    }
+
+    /** Persist the selected list id for [appWidgetId]. */
+    fun setSelectedListId(appWidgetId: Int, listId: Long) {
+        prefs.edit { putLong(key(appWidgetId), listId) }
+    }
+
+    /** Remove configuration for a deleted widget instance. */
+    fun clear(appWidgetId: Int) {
+        prefs.edit { remove(key(appWidgetId)) }
+    }
+
+    /** Most recent deep-link route rendered for a widget tap (consumed by MainActivity). */
+    fun getLastRoute(): String? = prefs.getString(KEY_LAST_ROUTE, null)
+
+    /** Persist the deep-link route for the next widget tap. */
+    fun setLastRoute(route: String) {
+        prefs.edit { putString(KEY_LAST_ROUTE, route) }
+    }
+
+    private fun key(appWidgetId: Int) = "list_id_$appWidgetId"
+
+    companion object {
+        /** Sentinel for "no list selected". */
+        const val INVALID: Long = -1L
+
+        private const val PREF_FILE = "lists_widget_config"
+        private const val KEY_LAST_ROUTE = "last_route"
+
+        /** Runtime accessor — resolves the dedicated preferences file from a [Context]. */
+        fun from(context: Context): ListsWidgetConfig =
+            ListsWidgetConfig(context.getSharedPreferences(PREF_FILE, Context.MODE_PRIVATE))
+    }
+}

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfig.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfig.kt
@@ -23,9 +23,20 @@ class ListsWidgetConfig(private val prefs: SharedPreferences) {
         return if (stored > 0L) stored else INVALID
     }
 
-    /** Persist the selected list id for [appWidgetId]. */
+    /** Persist the selected list id for [appWidgetId] (asynchronous; non-config writes). */
     fun setSelectedListId(appWidgetId: Int, listId: Long) {
         prefs.edit { putLong(key(appWidgetId), listId) }
+    }
+
+    /**
+     * Synchronously commit the selected list id for [appWidgetId].
+     *
+     * Used by the configuration activity so the binding is durable on disk *before* it returns
+     * [android.app.Activity.RESULT_OK]. Returns the result of [SharedPreferences.Editor.commit]
+     * so the caller can detect a failed write and avoid reporting a successful configuration.
+     */
+    fun setSelectedListIdSync(appWidgetId: Int, listId: Long): Boolean {
+        return prefs.edit().putLong(key(appWidgetId), listId).commit()
     }
 
     /** Remove configuration for a deleted widget instance. */

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfig.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfig.kt
@@ -33,13 +33,6 @@ class ListsWidgetConfig(private val prefs: SharedPreferences) {
         prefs.edit { remove(key(appWidgetId)) }
     }
 
-    /** Most recent deep-link route rendered for a widget tap (consumed by MainActivity). */
-    fun getLastRoute(): String? = prefs.getString(KEY_LAST_ROUTE, null)
-
-    /** Persist the deep-link route for the next widget tap. */
-    fun setLastRoute(route: String) {
-        prefs.edit { putString(KEY_LAST_ROUTE, route) }
-    }
 
     private fun key(appWidgetId: Int) = "list_id_$appWidgetId"
 
@@ -48,7 +41,6 @@ class ListsWidgetConfig(private val prefs: SharedPreferences) {
         const val INVALID: Long = -1L
 
         private const val PREF_FILE = "lists_widget_config"
-        private const val KEY_LAST_ROUTE = "last_route"
 
         /** Runtime accessor — resolves the dedicated preferences file from a [Context]. */
         fun from(context: Context): ListsWidgetConfig =

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
@@ -93,8 +93,8 @@ class ListsWidgetConfigureActivity : ComponentActivity() {
     }
 
     private fun persistAndFinish(listId: Long) {
-        // Persist synchronously before any best-effort render work, so the selection always
-        // outlives the config activity even if the glance update below fails or throws.
+        // Persist synchronously before the required initial render, so a failed render leaves a
+        // durable binding without reporting a successful configuration.
         lifecycleScope.launch {
             val result = persistSelectionAndResult(
                 ListsWidgetConfig.from(this@ListsWidgetConfigureActivity),
@@ -102,7 +102,8 @@ class ListsWidgetConfigureActivity : ComponentActivity() {
                 listId,
             ) {
                 val glanceId = GlanceAppWidgetManager(this@ListsWidgetConfigureActivity)
-                    .getGlanceIdBy(appWidgetId)
+                    .getGlanceIdBy(intent)
+                    ?: error("Unable to resolve Glance ID from widget configuration intent")
                 ListsWidget().update(this@ListsWidgetConfigureActivity, glanceId)
             }
             finishWith(result)
@@ -197,10 +198,9 @@ private fun ListsWidgetConfigScreen(
  * fails, [android.app.Activity.RESULT_CANCELED] is returned so the launcher never places an
  * unconfigured widget (which would show "Choose a list").
  *
- * [render] is best-effort and intentionally non-fatal: on some devices the glance id for a freshly
- * placed widget is not yet resolvable from the config activity, so [render] may throw. A failed
- * render must never undo the committed binding — the system fires `APPWIDGET_UPDATE` after a
- * successful config, which re-renders from the persisted selection.
+ * The initial render is required for success: if [render] throws, [android.app.Activity.RESULT_CANCELED]
+ * is returned after preserving the committed binding. This prevents the launcher from placing a
+ * widget that still displays "Choose a list" after successful configuration.
  */
 internal suspend fun persistSelectionAndResult(
     config: ListsWidgetConfig,
@@ -213,7 +213,9 @@ internal suspend fun persistSelectionAndResult(
     try {
         render()
     } catch (_: Throwable) {
-        // Non-fatal: the committed binding survives; APPWIDGET_UPDATE re-renders from the persisted config.
+        // Keep the durable binding, but do not report success while the widget still renders stale
+        // "Choose a list" content.
+        return Activity.RESULT_CANCELED
     }
     return Activity.RESULT_OK
 }

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
@@ -192,11 +192,15 @@ private fun ListsWidgetConfigScreen(
 /**
  * Persists the selected list for [appWidgetId] and returns the config result.
  *
- * The [render] is best-effort and intentionally non-fatal: on some devices the glance id for a
- * freshly placed widget is not yet resolvable from the config activity, so [render] may throw.
- * A failed render must never block [Activity.RESULT_OK] — the system fires `APPWIDGET_UPDATE`
- * after a successful config, which re-renders from the persisted selection, so the binding is
- * preserved either way.
+ * The selection is **synchronously committed** to disk before any [render] work, so the binding is
+ * durable even if the process dies immediately after the config activity returns. If the commit
+ * fails, [android.app.Activity.RESULT_CANCELED] is returned so the launcher never places an
+ * unconfigured widget (which would show "Choose a list").
+ *
+ * [render] is best-effort and intentionally non-fatal: on some devices the glance id for a freshly
+ * placed widget is not yet resolvable from the config activity, so [render] may throw. A failed
+ * render must never undo the committed binding — the system fires `APPWIDGET_UPDATE` after a
+ * successful config, which re-renders from the persisted selection.
  */
 internal suspend fun persistSelectionAndResult(
     config: ListsWidgetConfig,
@@ -204,11 +208,12 @@ internal suspend fun persistSelectionAndResult(
     listId: Long,
     render: suspend () -> Unit,
 ): Int {
-    config.setSelectedListId(appWidgetId, listId)
+    val committed = config.setSelectedListIdSync(appWidgetId, listId)
+    if (!committed) return Activity.RESULT_CANCELED
     try {
         render()
     } catch (_: Throwable) {
-        // Non-fatal: the system's APPWIDGET_UPDATE after RESULT_OK re-renders from the persisted config.
+        // Non-fatal: the committed binding survives; APPWIDGET_UPDATE re-renders from the persisted config.
     }
     return Activity.RESULT_OK
 }

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
@@ -42,6 +42,9 @@ import com.kernel.ai.core.ui.theme.KernelAITheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 
 /**
  * Configuration screen for the Lists widget.
@@ -84,7 +87,13 @@ class ListsWidgetConfigureActivity : ComponentActivity() {
 
     private fun persistAndFinish(listId: Long) {
         ListsWidgetConfig.from(this).setSelectedListId(appWidgetId, listId)
-        finishWith(RESULT_OK)
+        // The config-activity completion does NOT auto-fire APPWIDGET_UPDATE, so render the new
+        // widget here. The refresh signal is internal and safe to call from the UI scope.
+        lifecycleScope.launch {
+            val glanceId = GlanceAppWidgetManager(this@ListsWidgetConfigureActivity).getGlanceIdBy(appWidgetId)
+            ListsWidget().update(this@ListsWidgetConfigureActivity, glanceId)
+            finishWith(RESULT_OK)
+        }
     }
 
     private fun finishWith(result: Int) {

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.compose.ui.unit.DpSize
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.ui.theme.KernelAITheme
@@ -102,22 +101,10 @@ class ListsWidgetConfigureActivity : ComponentActivity() {
                 appWidgetId,
                 listId,
             ) {
-                val manager = GlanceAppWidgetManager(this@ListsWidgetConfigureActivity)
-                val glanceId = manager.getGlanceIdBy(intent)
+                val glanceId = GlanceAppWidgetManager(this@ListsWidgetConfigureActivity)
+                    .getGlanceIdBy(intent)
                     ?: error("Unable to resolve Glance ID from widget configuration intent")
-                val appWidgetManager = AppWidgetManager.getInstance(this@ListsWidgetConfigureActivity)
-                val options = appWidgetManager.getAppWidgetOptions(appWidgetId)
-                val size = DpSize(
-                    options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH).dp,
-                    options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT).dp,
-                )
-                val remoteViews = ListsWidget().compose(
-                    context = this@ListsWidgetConfigureActivity,
-                    id = glanceId,
-                    size = size,
-                    appWidgetOptions = options,
-                )
-                appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
+                ListsWidget().update(this@ListsWidgetConfigureActivity, glanceId)
             }
             finishWith(result)
         }

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
@@ -1,0 +1,168 @@
+package com.kernel.ai.feature.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.dao.ListNameDao
+import com.kernel.ai.core.memory.entity.ListNameEntity
+import com.kernel.ai.core.ui.theme.KernelAITheme
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/**
+ * Configuration screen for the Lists widget.
+ *
+ * Android shows this activity when a user drops the Lists widget onto the home screen. They pick
+ * exactly one existing local list; the selection is persisted per-widget in [ListsWidgetConfig]
+ * and the widget renders that list. The widget never creates its own list — it always binds to a
+ * list that already exists in the app.
+ *
+ * On success it returns [android.appwidget.AppWidgetManager.RESULT_OK] with the widget id so the
+ * system proceeds to place the widget and fire its initial `APPWIDGET_UPDATE`. On cancel/back it
+ * returns [android.appwidget.AppWidgetManager.RESULT_CANCELED] so no widget is placed.
+ */
+@AndroidEntryPoint
+class ListsWidgetConfigureActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var listNameDao: ListNameDao
+
+    private val appWidgetId by lazy {
+        intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            finishWith(RESULT_CANCELED)
+            return
+        }
+        setContent {
+            KernelAITheme {
+                ListsWidgetConfigScreen(
+                    listsFlow = listNameDao.observeActiveLists(),
+                    onSelect = { persistAndFinish(it) },
+                    onCancel = { finishWith(RESULT_CANCELED) },
+                )
+            }
+        }
+    }
+
+    private fun persistAndFinish(listId: Long) {
+        ListsWidgetConfig.from(this).setSelectedListId(appWidgetId, listId)
+        finishWith(RESULT_OK)
+    }
+
+    private fun finishWith(result: Int) {
+        setResult(result, Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId))
+        finish()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ListsWidgetConfigScreen(
+    listsFlow: Flow<List<ListNameEntity>>,
+    onSelect: (Long) -> Unit,
+    onCancel: () -> Unit,
+) {
+    val lists by listsFlow.collectAsStateWithLifecycle(emptyList())
+    var selectedId by remember { mutableStateOf<Long?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Choose a list") },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { selectedId?.let(onSelect) },
+            ) {
+                Icon(Icons.Filled.Check, contentDescription = "Add to Home screen")
+            }
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            if (lists.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(24.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        "No lists yet. Create one in Lists, then add this widget.",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    items(lists, key = { it.id }) { list ->
+                        val isSelected = selectedId == list.id
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { selectedId = list.id }
+                                .padding(12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
+                                selected = isSelected,
+                                onClick = { selectedId = list.id },
+                            )
+                            Text(
+                                text = list.name.replaceFirstChar { it.uppercase() },
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.unit.DpSize
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.ui.theme.KernelAITheme
@@ -101,10 +102,22 @@ class ListsWidgetConfigureActivity : ComponentActivity() {
                 appWidgetId,
                 listId,
             ) {
-                val glanceId = GlanceAppWidgetManager(this@ListsWidgetConfigureActivity)
-                    .getGlanceIdBy(intent)
+                val manager = GlanceAppWidgetManager(this@ListsWidgetConfigureActivity)
+                val glanceId = manager.getGlanceIdBy(intent)
                     ?: error("Unable to resolve Glance ID from widget configuration intent")
-                ListsWidget().update(this@ListsWidgetConfigureActivity, glanceId)
+                val appWidgetManager = AppWidgetManager.getInstance(this@ListsWidgetConfigureActivity)
+                val options = appWidgetManager.getAppWidgetOptions(appWidgetId)
+                val size = DpSize(
+                    options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH).dp,
+                    options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT).dp,
+                )
+                val remoteViews = ListsWidget().compose(
+                    context = this@ListsWidgetConfigureActivity,
+                    id = glanceId,
+                    size = size,
+                    appWidgetOptions = options,
+                )
+                appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
             }
             finishWith(result)
         }

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivity.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.feature.widget
 
 import android.appwidget.AppWidgetManager
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -70,8 +71,14 @@ class ListsWidgetConfigureActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Default to CANCELED (with the widget id attached) so any early exit — invalid id or an
+        // error before a selection — never leaves the launcher with a half-placed, unconfigured widget.
+        setResult(
+            RESULT_CANCELED,
+            Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId),
+        )
         if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
-            finishWith(RESULT_CANCELED)
+            finish()
             return
         }
         setContent {
@@ -86,13 +93,19 @@ class ListsWidgetConfigureActivity : ComponentActivity() {
     }
 
     private fun persistAndFinish(listId: Long) {
-        ListsWidgetConfig.from(this).setSelectedListId(appWidgetId, listId)
-        // The config-activity completion does NOT auto-fire APPWIDGET_UPDATE, so render the new
-        // widget here. The refresh signal is internal and safe to call from the UI scope.
+        // Persist synchronously before any best-effort render work, so the selection always
+        // outlives the config activity even if the glance update below fails or throws.
         lifecycleScope.launch {
-            val glanceId = GlanceAppWidgetManager(this@ListsWidgetConfigureActivity).getGlanceIdBy(appWidgetId)
-            ListsWidget().update(this@ListsWidgetConfigureActivity, glanceId)
-            finishWith(RESULT_OK)
+            val result = persistSelectionAndResult(
+                ListsWidgetConfig.from(this@ListsWidgetConfigureActivity),
+                appWidgetId,
+                listId,
+            ) {
+                val glanceId = GlanceAppWidgetManager(this@ListsWidgetConfigureActivity)
+                    .getGlanceIdBy(appWidgetId)
+                ListsWidget().update(this@ListsWidgetConfigureActivity, glanceId)
+            }
+            finishWith(result)
         }
     }
 
@@ -174,4 +187,28 @@ private fun ListsWidgetConfigScreen(
             }
         }
     }
+}
+
+/**
+ * Persists the selected list for [appWidgetId] and returns the config result.
+ *
+ * The [render] is best-effort and intentionally non-fatal: on some devices the glance id for a
+ * freshly placed widget is not yet resolvable from the config activity, so [render] may throw.
+ * A failed render must never block [Activity.RESULT_OK] — the system fires `APPWIDGET_UPDATE`
+ * after a successful config, which re-renders from the persisted selection, so the binding is
+ * preserved either way.
+ */
+internal suspend fun persistSelectionAndResult(
+    config: ListsWidgetConfig,
+    appWidgetId: Int,
+    listId: Long,
+    render: suspend () -> Unit,
+): Int {
+    config.setSelectedListId(appWidgetId, listId)
+    try {
+        render()
+    } catch (_: Throwable) {
+        // Non-fatal: the system's APPWIDGET_UPDATE after RESULT_OK re-renders from the persisted config.
+    }
+    return Activity.RESULT_OK
 }

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetDataEntryPoint.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetDataEntryPoint.kt
@@ -1,0 +1,22 @@
+package com.kernel.ai.feature.widget
+
+import androidx.glance.appwidget.GlanceAppWidget
+import com.kernel.ai.core.memory.dao.ListItemDao
+import com.kernel.ai.core.memory.dao.ListNameDao
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+/**
+ * Hilt entry point exposing the list DAOs to the Glance widget.
+ *
+ * A [GlanceAppWidget.provideGlance] runs outside any `@AndroidEntryPoint`/ViewModel, so it
+ * cannot use field injection. This entry point lets the widget read the same Room-backed list
+ * data used by the in-app Lists UI and `add_to_list`, keeping a single source of truth.
+ */
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface ListsWidgetDataEntryPoint {
+    fun listNameDao(): ListNameDao
+    fun listItemDao(): ListItemDao
+}

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetProjection.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetProjection.kt
@@ -1,0 +1,74 @@
+package com.kernel.ai.feature.widget
+
+import com.kernel.ai.core.memory.entity.ListItemEntity
+import com.kernel.ai.core.memory.entity.ListNameEntity
+
+/**
+ * Pure, framework-free projection of list data into the widget's display states.
+ *
+ * Extracted from the Glance rendering path so the presentation logic is unit-testable
+ * without Android/Glance runtime classes.
+ */
+sealed interface ListsWidgetProjection {
+    /** The configured list id, or [ListsWidgetConfig.INVALID] when there is no selection. */
+    val listId: Long
+
+    /** A normal, configured, non-archived list with zero or more active items. */
+    data class Configured(
+        override val listId: Long,
+        val listName: String,
+        val activeItems: List<String>,
+    ) : ListsWidgetProjection
+
+    /** A configured list that has been archived (shown read-only). */
+    data class Archived(
+        override val listId: Long,
+        val listName: String,
+        val activeItems: List<String>,
+    ) : ListsWidgetProjection
+
+    /** A configured, non-archived list with no active items. */
+    data class Empty(
+        override val listId: Long,
+        val listName: String,
+    ) : ListsWidgetProjection
+
+    /** The configured list no longer exists (deleted). */
+    data object Missing : ListsWidgetProjection {
+        override val listId: Long get() = ListsWidgetConfig.INVALID
+    }
+
+    /** No list has been selected for this widget instance yet. */
+    data object NotConfigured : ListsWidgetProjection {
+        override val listId: Long get() = ListsWidgetConfig.INVALID
+    }
+}
+
+/**
+ * Build the widget projection from raw list data.
+ *
+ * @param selectedListId the list id persisted for this widget instance.
+ * @param name the resolved [ListNameEntity], or null if the list was deleted.
+ * @param items all items for the list (checked + unchecked).
+ */
+fun projectListsWidget(
+    selectedListId: Long,
+    name: ListNameEntity?,
+    items: List<ListItemEntity>,
+): ListsWidgetProjection {
+    if (selectedListId <= 0L) return ListsWidgetProjection.NotConfigured
+    if (name == null) return ListsWidgetProjection.Missing
+
+    val activeItems = items
+        .filter { !it.checked }
+        .sortedWith(compareBy({ it.displayOrder }, { it.createdAt }, { it.id }))
+        .map { it.text }
+
+    return if (name.archivedAt != null) {
+        ListsWidgetProjection.Archived(selectedListId, name.name, activeItems)
+    } else if (activeItems.isEmpty()) {
+        ListsWidgetProjection.Empty(selectedListId, name.name)
+    } else {
+        ListsWidgetProjection.Configured(selectedListId, name.name, activeItems)
+    }
+}

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetProjection.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetProjection.kt
@@ -2,6 +2,12 @@ package com.kernel.ai.feature.widget
 
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.entity.ListNameEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
 /**
  * Pure, framework-free projection of list data into the widget's display states.
@@ -72,3 +78,29 @@ fun projectListsWidget(
         ListsWidgetProjection.Configured(selectedListId, name.name, activeItems)
     }
 }
+
+/**
+ * Observe one widget's selected list and project live metadata/items into widget content.
+ *
+ * The selected-list flow is per-widget, while the Room metadata flow covers all lists and is
+ * filtered to the current selection. [flatMapLatest] drops the old item observation after
+ * reconfiguration.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal fun observeListsWidgetProjection(
+    selectedListIds: Flow<Long>,
+    listMetadata: Flow<List<ListNameEntity>>,
+    listItems: (Long) -> Flow<List<ListItemEntity>>,
+): Flow<ListsWidgetProjection> =
+    selectedListIds.flatMapLatest { selectedListId ->
+        if (selectedListId <= 0L) {
+            flowOf(ListsWidgetProjection.NotConfigured)
+        } else {
+            combine(
+                listMetadata.map { lists -> lists.firstOrNull { it.id == selectedListId } },
+                listItems(selectedListId),
+            ) { name, items ->
+                projectListsWidget(selectedListId, name, items)
+            }
+        }
+    }

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetReceiver.kt
@@ -1,0 +1,27 @@
+package com.kernel.ai.feature.widget
+
+import android.content.Context
+import android.content.Intent
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import com.kernel.ai.core.memory.lists.ListsDataChanged
+
+/**
+ * AppWidget broadcast receiver for the Lists widget.
+ *
+ * In addition to the standard Glance lifecycle (`APPWIDGET_UPDATE`, etc.), it listens for the
+ * dependency-safe [ListsDataChanged.ACTION] broadcast emitted after any successful local list
+ * mutation (in-app or via `add_to_list`). On that signal it asks Glance to re-render every
+ * widget instance, which causes [ListsWidget.provideGlance] to re-read the shared list store.
+ */
+class ListsWidgetReceiver : GlanceAppWidgetReceiver() {
+
+    override val glanceAppWidget: GlanceAppWidget = ListsWidget()
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        if (intent.action == ListsDataChanged.ACTION) {
+            ListsWidgetRefresher.refresh(context)
+        }
+    }
+}

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetReceiver.kt
@@ -1,27 +1,16 @@
 package com.kernel.ai.feature.widget
 
-import android.content.Context
-import android.content.Intent
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import com.kernel.ai.core.memory.lists.ListsDataChanged
 
 /**
- * AppWidget broadcast receiver for the Lists widget.
+ * AppWidget lifecycle receiver for the Lists widget.
  *
- * In addition to the standard Glance lifecycle (`APPWIDGET_UPDATE`, etc.), it listens for the
- * dependency-safe [ListsDataChanged.ACTION] broadcast emitted after any successful local list
- * mutation (in-app or via `add_to_list`). On that signal it asks Glance to re-render every
- * widget instance, which causes [ListsWidget.provideGlance] to re-read the shared list store.
+ * It only handles the standard app-widget lifecycle (`APPWIDGET_UPDATE`, etc.). The internal
+ * [com.kernel.ai.core.memory.lists.ListsDataChanged.ACTION] refresh signal is handled by the
+ * non-exported [ListsDataChangedReceiver] so another app cannot spoof it to force a widget
+ * re-render or DB read.
  */
 class ListsWidgetReceiver : GlanceAppWidgetReceiver() {
-
     override val glanceAppWidget: GlanceAppWidget = ListsWidget()
-
-    override fun onReceive(context: Context, intent: Intent) {
-        super.onReceive(context, intent)
-        if (intent.action == ListsDataChanged.ACTION) {
-            ListsWidgetRefresher.refresh(context)
-        }
-    }
 }

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetRefresher.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetRefresher.kt
@@ -1,0 +1,27 @@
+package com.kernel.ai.feature.widget
+
+import android.content.Context
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Refreshes all instances of the Lists widget.
+ *
+ * Extracted into a standalone object so the receiver's refresh side-effect is unit-testable: a
+ * test can `mockkObject` this and assert `refresh` is invoked for the lists-changed broadcast
+ * (and not for unrelated actions) without spinning up the Glance runtime.
+ */
+object ListsWidgetRefresher {
+    fun refresh(context: Context) {
+        try {
+            runBlocking {
+                val manager = GlanceAppWidgetManager(context)
+                manager.getGlanceIds(ListsWidget::class.java)
+                    .forEach { ListsWidget().update(context, it) }
+            }
+        } catch (_: Throwable) {
+            // Widget refresh is best-effort; never break the list-mutation path that triggered it.
+        }
+    }
+}

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetSizing.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/ListsWidgetSizing.kt
@@ -1,0 +1,40 @@
+package com.kernel.ai.feature.widget
+
+import kotlin.math.floor
+
+/** Maximum number of active item rows the widget renders before an overflow hint. */
+internal const val MAX_WIDGET_ITEMS = 8
+
+/** Item rows and overflow hint that fit in the widget's allocated height. */
+internal data class ActiveItemLayout(
+    val visibleCount: Int,
+    val overflowCount: Int,
+)
+
+/**
+ * Calculate the active-item rows that fit in an exact-height Glance widget.
+ *
+ * The fixed allowance covers the widget's title, spacer, and vertical padding. One row is
+ * reserved for the overflow hint whenever there is more content and enough room to show it.
+ */
+internal fun calculateActiveItemLayout(
+    widgetHeightDp: Float,
+    activeItemCount: Int,
+): ActiveItemLayout {
+    val heightDp = widgetHeightDp.coerceAtLeast(0f)
+    val itemCount = activeItemCount.coerceAtLeast(0)
+    val rowCapacity = floor((heightDp - 58f) / 24f).toInt().coerceAtLeast(0)
+    val visibleCapacity = rowCapacity.coerceAtMost(MAX_WIDGET_ITEMS)
+    val visibleCount = when {
+        itemCount == 0 || visibleCapacity == 0 -> 0
+        itemCount <= visibleCapacity -> itemCount
+        rowCapacity >= 2 -> (visibleCapacity - 1).coerceAtLeast(1)
+        else -> visibleCapacity
+    }
+    val overflowCount = if (rowCapacity >= 2) {
+        (itemCount - visibleCount).coerceAtLeast(0)
+    } else {
+        0
+    }
+    return ActiveItemLayout(visibleCount, overflowCount)
+}

--- a/feature/widget/src/main/res/values/strings.xml
+++ b/feature/widget/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="widget_description">Jandal quick actions widget</string>
+    <string name="lists_widget_label">Lists</string>
+    <string name="lists_widget_description">Shows items from one of your lists</string>
 </resources>

--- a/feature/widget/src/main/res/xml/lists_widget_info.xml
+++ b/feature/widget/src/main/res/xml/lists_widget_info.xml
@@ -12,4 +12,5 @@
     android:initialLayout="@layout/glance_default_loading_layout"
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
+    android:previewLayout="@layout/glance_default_loading_layout"
     android:configure="com.kernel.ai.feature.widget.ListsWidgetConfigureActivity" />

--- a/feature/widget/src/main/res/xml/lists_widget_info.xml
+++ b/feature/widget/src/main/res/xml/lists_widget_info.xml
@@ -12,5 +12,6 @@
     android:initialLayout="@layout/glance_default_loading_layout"
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
+    android:widgetFeatures="reconfigurable"
     android:previewLayout="@layout/glance_default_loading_layout"
     android:configure="com.kernel.ai.feature.widget.ListsWidgetConfigureActivity" />

--- a/feature/widget/src/main/res/xml/lists_widget_info.xml
+++ b/feature/widget/src/main/res/xml/lists_widget_info.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="3"
+    android:targetCellHeight="2"
+    android:minResizeWidth="120dp"
+    android:minResizeHeight="80dp"
+    android:updatePeriodMillis="0"
+    android:label="@string/lists_widget_label"
+    android:description="@string/lists_widget_description"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:configure="com.kernel.ai.feature.widget.ListsWidgetConfigureActivity" />

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsDataChangedReceiverTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsDataChangedReceiverTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class ListsWidgetReceiverTest {
+class ListsDataChangedReceiverTest {
 
     @BeforeEach
     fun setUp() { mockkObject(ListsWidgetRefresher) }
@@ -26,14 +26,17 @@ class ListsWidgetReceiverTest {
         // Intent.getAction() is a stubbed no-op under the JVM unit-test runtime, so the action
         // must be mocked for the receiver's `intent.action == ACTION` gate to pass.
         val intent = mockk<Intent> { every { action } returns ListsDataChanged.ACTION }
-        ListsWidgetReceiver().onReceive(context, intent)
+        ListsDataChangedReceiver().onReceive(context, intent)
         verify { ListsWidgetRefresher.refresh(context) }
     }
 
     @Test
     fun `ignores unrelated actions`() {
         val context = mockk<Context>(relaxed = true)
-        ListsWidgetReceiver().onReceive(context, Intent("com.kernel.ai.action.SOMETHING_ELSE"))
+        // Mock the action explicitly (a plain Intent would return null under the JVM runtime and
+        // only exercise the null path, not the genuine mismatch).
+        val intent = mockk<Intent> { every { action } returns "com.kernel.ai.action.SOMETHING_ELSE" }
+        ListsDataChangedReceiver().onReceive(context, intent)
         verify(exactly = 0) { ListsWidgetRefresher.refresh(any()) }
     }
 }

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsDataChangedTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsDataChangedTest.kt
@@ -1,0 +1,27 @@
+package com.kernel.ai.feature.widget
+
+import android.content.Context
+import com.kernel.ai.core.memory.lists.ListsDataChanged
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class ListsDataChangedTest {
+
+    @Test
+    fun `broadcast sends the lists data changed action`() {
+        val context = mockk<Context>(relaxed = true)
+        ListsDataChanged.broadcast(context)
+        verify(exactly = 1) { context.sendBroadcast(any()) }
+    }
+
+    @Test
+    fun `broadcast never throws even when sendBroadcast fails`() {
+        val context = mockk<Context> {
+            every { sendBroadcast(any()) } throws SecurityException("blocked")
+        }
+        // Must not propagate — a failed broadcast must never roll back a mutation.
+        ListsDataChanged.broadcast(context)
+    }
+}

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigObservationTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigObservationTest.kt
@@ -1,0 +1,81 @@
+package com.kernel.ai.feature.widget
+
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ListsWidgetConfigObservationTest {
+
+    @Test
+    fun `emits current selected list immediately and unregisters after collection`() = runTest {
+        val (prefs, _, listenerCount) = makePrefs(mapOf("list_id_7" to 42L))
+        val values = mutableListOf<Long>()
+        val job = launch { ListsWidgetConfig(prefs).observeSelectedListId(7).take(1).toList(values) }
+
+        runCurrent()
+        job.join()
+
+        assertEquals(listOf(42L), values)
+        assertEquals(0, listenerCount())
+    }
+
+    @Test
+    fun `only the exact widget key emits and invalid values map to INVALID`() = runTest {
+        val (prefs, update, _) = makePrefs()
+        val values = mutableListOf<Long>()
+        val job = launch { ListsWidgetConfig(prefs).observeSelectedListId(7).take(3).toList(values) }
+
+        runCurrent()
+        update("list_id_8", 88L)
+        update("list_id_7", 0L)
+        update("list_id_7", 23L)
+        job.join()
+
+        assertEquals(listOf(ListsWidgetConfig.INVALID, ListsWidgetConfig.INVALID, 23L), values)
+    }
+
+    @Test
+    fun `widget bindings remain independent`() = runTest {
+        val (prefs, update, _) = makePrefs(mapOf("list_id_7" to 70L, "list_id_8" to 80L))
+        val widgetA = mutableListOf<Long>()
+        val widgetB = mutableListOf<Long>()
+        val jobA = launch { ListsWidgetConfig(prefs).observeSelectedListId(7).take(2).toList(widgetA) }
+        val jobB = launch { ListsWidgetConfig(prefs).observeSelectedListId(8).take(2).toList(widgetB) }
+
+        runCurrent()
+        update("list_id_8", 81L)
+        jobB.join()
+        update("list_id_7", 71L)
+        jobA.join()
+
+        assertEquals(listOf(70L, 71L), widgetA)
+        assertEquals(listOf(80L, 81L), widgetB)
+    }
+
+    private fun makePrefs(
+        initial: Map<String, Long> = emptyMap(),
+    ): Triple<SharedPreferences, (String, Long) -> Unit, () -> Int> {
+        val store = initial.toMutableMap()
+        val listeners = mutableSetOf<SharedPreferences.OnSharedPreferenceChangeListener>()
+        val prefs = mockk<SharedPreferences>()
+        every { prefs.getLong(any(), any()) } answers { store[firstArg()] ?: secondArg() }
+        every { prefs.registerOnSharedPreferenceChangeListener(any()) } answers {
+            listeners += firstArg<SharedPreferences.OnSharedPreferenceChangeListener>()
+        }
+        every { prefs.unregisterOnSharedPreferenceChangeListener(any()) } answers {
+            listeners -= firstArg<SharedPreferences.OnSharedPreferenceChangeListener>()
+        }
+        val update: (String, Long) -> Unit = { key, value ->
+            store[key] = value
+            listeners.toList().forEach { it.onSharedPreferenceChanged(prefs, key) }
+        }
+        return Triple(prefs, update, { listeners.size })
+    }
+}

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigTest.kt
@@ -1,0 +1,53 @@
+package com.kernel.ai.feature.widget
+
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ListsWidgetConfigTest {
+
+    private fun makePrefs(): SharedPreferences {
+        val store = mutableMapOf<String, Long>()
+        val prefs = mockk<SharedPreferences>()
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        every { prefs.edit() } returns editor
+        every { prefs.getLong(any(), any()) } answers { store[firstArg()] ?: secondArg() }
+        every { editor.putLong(any(), any()) } answers {
+            store[firstArg()] = secondArg()
+            editor
+        }
+        every { editor.remove(any()) } answers {
+            store.remove(firstArg())
+            editor
+        }
+        return prefs
+    }
+
+    @Test
+    fun `returns INVALID sentinel when nothing stored`() {
+        val config = ListsWidgetConfig(makePrefs())
+        assertEquals(ListsWidgetConfig.INVALID, config.getSelectedListId(7))
+    }
+
+    @Test
+    fun `persists and reads selected list id per widget independently`() {
+        val config = ListsWidgetConfig(makePrefs())
+        config.setSelectedListId(3, 42L)
+        config.setSelectedListId(9, 99L)
+        assertEquals(42L, config.getSelectedListId(3))
+        assertEquals(99L, config.getSelectedListId(9))
+        assertEquals(ListsWidgetConfig.INVALID, config.getSelectedListId(1))
+    }
+
+    @Test
+    fun `clear removes only the targeted widget`() {
+        val config = ListsWidgetConfig(makePrefs())
+        config.setSelectedListId(3, 42L)
+        config.setSelectedListId(9, 99L)
+        config.clear(3)
+        assertEquals(ListsWidgetConfig.INVALID, config.getSelectedListId(3))
+        assertEquals(99L, config.getSelectedListId(9))
+    }
+}

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivityTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivityTest.kt
@@ -45,20 +45,27 @@ class ListsWidgetConfigureActivityTest {
     }
 
     @Test
-    fun `commit success persists selection and still returns RESULT_OK when render throws`() = runTest {
+    fun `commit success persists selection but returns RESULT_CANCELED when initial render fails`() = runTest {
         val config = ListsWidgetConfig(makePrefs())
+        var rendered = false
         val result = persistSelectionAndResult(config, 12, 99L) {
-            throw RuntimeException("glance id not resolvable yet on fresh placement")
+            rendered = true
+            throw RuntimeException("initial widget render failed")
         }
-        assertEquals(Activity.RESULT_OK, result)
+        assertEquals(Activity.RESULT_CANCELED, result)
+        assertEquals(true, rendered)
         assertEquals(99L, config.getSelectedListId(12))
     }
 
     @Test
-    fun `commit failure does not report RESULT_OK and does not persist selection`() = runTest {
+    fun `commit failure returns RESULT_CANCELED without attempting initial render`() = runTest {
         val config = ListsWidgetConfig(makePrefs(commitSucceeds = false))
-        val result = persistSelectionAndResult(config, 7, 555L) { /* render must not run */ }
+        var rendered = false
+        val result = persistSelectionAndResult(config, 7, 555L) {
+            rendered = true
+        }
         assertEquals(Activity.RESULT_CANCELED, result)
+        assertEquals(false, rendered)
         assertEquals(ListsWidgetConfig.INVALID, config.getSelectedListId(7))
     }
 

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivityTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivityTest.kt
@@ -3,47 +3,79 @@ package com.kernel.ai.feature.widget
 import android.app.Activity
 import android.content.SharedPreferences
 import io.mockk.every
+import org.junit.jupiter.api.Test
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import kotlinx.coroutines.test.runTest
 
 class ListsWidgetConfigureActivityTest {
 
-    private fun makePrefs(): SharedPreferences {
+    /**
+     * Fake prefs that distinguish synchronous [SharedPreferences.Editor.commit] from asynchronous
+     * [SharedPreferences.Editor.apply]: [SharedPreferences.Editor.putLong] only stages a value, and
+     * [SharedPreferences.Editor.commit] (when [commitSucceeds]) is what flushes it to the readable
+     * store. This proves the configuration path relies on the synchronous commit, not apply.
+     */
+    private fun makePrefs(commitSucceeds: Boolean = true): SharedPreferences {
         val store = mutableMapOf<String, Long>()
+        val staged = mutableMapOf<String, Long>()
         val prefs = mockk<SharedPreferences>()
-        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val editor = mockk<SharedPreferences.Editor>()
         every { prefs.edit() } returns editor
         every { prefs.getLong(any(), any()) } answers { store[firstArg()] ?: secondArg() }
-        every { editor.putLong(any(), any()) } answers {
-            store[firstArg()] = secondArg()
-            editor
+        every { editor.putLong(any(), any()) } answers { staged[firstArg()] = secondArg(); editor }
+        every { editor.remove(any()) } answers { staged.remove(firstArg()); editor }
+        every { editor.commit() } answers {
+            val ok = commitSucceeds
+            if (ok) { store.putAll(staged); staged.clear() }
+            ok
         }
-        every { editor.remove(any()) } answers {
-            store.remove(firstArg())
-            editor
-        }
+        every { editor.apply() } answers { /* asynchronous: not flushed synchronously */ }
         return prefs
     }
 
     @Test
-    fun `selection persists and RESULT_OK returned even when render throws`() = runTest {
+    fun `commit success persists selection and returns RESULT_OK on render success`() = runTest {
         val config = ListsWidgetConfig(makePrefs())
-        val result = persistSelectionAndResult(config, 11, 4242L) {
-            throw RuntimeException("glance id not resolvable yet on fresh placement")
-        }
+        var rendered = false
+        val result = persistSelectionAndResult(config, 11, 4242L) { rendered = true }
         assertEquals(Activity.RESULT_OK, result)
         assertEquals(4242L, config.getSelectedListId(11))
+        assertEquals(true, rendered)
     }
 
     @Test
-    fun `selection persists and RESULT_OK returned when render succeeds`() = runTest {
+    fun `commit success persists selection and still returns RESULT_OK when render throws`() = runTest {
         val config = ListsWidgetConfig(makePrefs())
-        var rendered = false
-        val result = persistSelectionAndResult(config, 12, 99L) { rendered = true }
+        val result = persistSelectionAndResult(config, 12, 99L) {
+            throw RuntimeException("glance id not resolvable yet on fresh placement")
+        }
         assertEquals(Activity.RESULT_OK, result)
         assertEquals(99L, config.getSelectedListId(12))
-        assertEquals(true, rendered)
+    }
+
+    @Test
+    fun `commit failure does not report RESULT_OK and does not persist selection`() = runTest {
+        val config = ListsWidgetConfig(makePrefs(commitSucceeds = false))
+        val result = persistSelectionAndResult(config, 7, 555L) { /* render must not run */ }
+        assertEquals(Activity.RESULT_CANCELED, result)
+        assertEquals(ListsWidgetConfig.INVALID, config.getSelectedListId(7))
+    }
+
+    @Test
+    fun `same appWidgetId is used for the committed binding`() = runTest {
+        val config = ListsWidgetConfig(makePrefs())
+        persistSelectionAndResult(config, 21, 808L) {}
+        assertEquals(808L, config.getSelectedListId(21))
+        assertEquals(ListsWidgetConfig.INVALID, config.getSelectedListId(22))
+    }
+
+    @Test
+    fun `multiple widget ids remain independently persisted`() = runTest {
+        val config = ListsWidgetConfig(makePrefs())
+        assertEquals(Activity.RESULT_OK, persistSelectionAndResult(config, 31, 1L) {})
+        assertEquals(Activity.RESULT_OK, persistSelectionAndResult(config, 32, 2L) {})
+        assertEquals(1L, config.getSelectedListId(31))
+        assertEquals(2L, config.getSelectedListId(32))
     }
 }

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivityTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivityTest.kt
@@ -1,0 +1,49 @@
+package com.kernel.ai.feature.widget
+
+import android.app.Activity
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import kotlinx.coroutines.test.runTest
+
+class ListsWidgetConfigureActivityTest {
+
+    private fun makePrefs(): SharedPreferences {
+        val store = mutableMapOf<String, Long>()
+        val prefs = mockk<SharedPreferences>()
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        every { prefs.edit() } returns editor
+        every { prefs.getLong(any(), any()) } answers { store[firstArg()] ?: secondArg() }
+        every { editor.putLong(any(), any()) } answers {
+            store[firstArg()] = secondArg()
+            editor
+        }
+        every { editor.remove(any()) } answers {
+            store.remove(firstArg())
+            editor
+        }
+        return prefs
+    }
+
+    @Test
+    fun `selection persists and RESULT_OK returned even when render throws`() = runTest {
+        val config = ListsWidgetConfig(makePrefs())
+        val result = persistSelectionAndResult(config, 11, 4242L) {
+            throw RuntimeException("glance id not resolvable yet on fresh placement")
+        }
+        assertEquals(Activity.RESULT_OK, result)
+        assertEquals(4242L, config.getSelectedListId(11))
+    }
+
+    @Test
+    fun `selection persists and RESULT_OK returned when render succeeds`() = runTest {
+        val config = ListsWidgetConfig(makePrefs())
+        var rendered = false
+        val result = persistSelectionAndResult(config, 12, 99L) { rendered = true }
+        assertEquals(Activity.RESULT_OK, result)
+        assertEquals(99L, config.getSelectedListId(12))
+        assertEquals(true, rendered)
+    }
+}

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivityTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetConfigureActivityTest.kt
@@ -45,16 +45,26 @@ class ListsWidgetConfigureActivityTest {
     }
 
     @Test
-    fun `commit success persists selection but returns RESULT_CANCELED when initial render fails`() = runTest {
+    fun `commit success persists selection but returns RESULT_CANCELED when initial composition fails`() = runTest {
         val config = ListsWidgetConfig(makePrefs())
         var rendered = false
         val result = persistSelectionAndResult(config, 12, 99L) {
             rendered = true
-            throw RuntimeException("initial widget render failed")
+            throw RuntimeException("initial widget composition failed")
         }
         assertEquals(Activity.RESULT_CANCELED, result)
         assertEquals(true, rendered)
         assertEquals(99L, config.getSelectedListId(12))
+    }
+
+    @Test
+    fun `platform RemoteViews update failure returns RESULT_CANCELED`() = runTest {
+        val config = ListsWidgetConfig(makePrefs())
+        val result = persistSelectionAndResult(config, 13, 100L) {
+            throw IllegalStateException("AppWidgetManager.updateAppWidget failed")
+        }
+        assertEquals(Activity.RESULT_CANCELED, result)
+        assertEquals(100L, config.getSelectedListId(13))
     }
 
     @Test

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetLaunchCallbackTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetLaunchCallbackTest.kt
@@ -3,11 +3,16 @@ package com.kernel.ai.feature.widget
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.glance.GlanceId
-import androidx.glance.action.ActionParameters
 import androidx.glance.action.actionParametersOf
 import androidx.glance.appwidget.AppWidgetId
+import com.kernel.ai.core.memory.dao.ListNameDao
+import com.kernel.ai.core.memory.entity.ListNameEntity
+import dagger.hilt.android.EntryPointAccessors
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -16,28 +21,46 @@ import org.junit.jupiter.api.Test
 class ListsWidgetLaunchCallbackTest {
 
     @Test
-    fun `routeFor maps a configured list to its deep link`() {
-        assertEquals("lists/42", ListsWidgetLaunchCallback.routeFor(42L))
+    fun `routeFor maps an existing configured list to its deep link`() {
+        assertEquals("lists/42", ListsWidgetLaunchCallback.routeFor(42L, listExists = true))
     }
 
     @Test
     fun `routeFor falls back to the overview for unconfigured or invalid ids`() {
-        assertEquals("lists", ListsWidgetLaunchCallback.routeFor(-1L))
-        assertEquals("lists", ListsWidgetLaunchCallback.routeFor(0L))
+        assertEquals("lists", ListsWidgetLaunchCallback.routeFor(-1L, listExists = false))
+        assertEquals("lists", ListsWidgetLaunchCallback.routeFor(0L, listExists = false))
     }
 
     @Test
-    fun `onAction launches MainActivity once for a configured widget`() = runTest {
+    fun `routeFor falls back to the overview when the configured list was deleted`() {
+        assertEquals("lists", ListsWidgetLaunchCallback.routeFor(42L, listExists = false))
+    }
+
+    @Test
+    fun `onAction launches MainActivity once for an existing configured widget`() = runTest {
         val context = mockk<Context>(relaxed = true)
         every { context.packageName } returns "com.kernel.ai"
+        every { context.applicationContext } returns context
         val prefs = mockk<SharedPreferences>()
         every { prefs.getLong(any(), any()) } returns 42L
         every { context.getSharedPreferences("lists_widget_config", any()) } returns prefs
-        val glanceId: GlanceId = AppWidgetId(APPWIDGET_ID)
+        val listNameDao = mockk<ListNameDao>()
+        coEvery { listNameDao.getById(42L) } returns ListNameEntity(id = 42L, name = "Groceries")
+        val entryPoint = mockk<ListsWidgetDataEntryPoint>()
+        every { entryPoint.listNameDao() } returns listNameDao
+        mockkStatic(EntryPointAccessors::class)
+        try {
+            every {
+                EntryPointAccessors.fromApplication(context, ListsWidgetDataEntryPoint::class.java)
+            } returns entryPoint
 
-        ListsWidgetLaunchCallback().onAction(context, glanceId, actionParametersOf())
+            val glanceId: GlanceId = AppWidgetId(APPWIDGET_ID)
+            ListsWidgetLaunchCallback().onAction(context, glanceId, actionParametersOf())
 
-        verify(exactly = 1) { context.startActivity(any()) }
+            verify(exactly = 1) { context.startActivity(any()) }
+        } finally {
+            unmockkStatic(EntryPointAccessors::class)
+        }
     }
 
     private companion object {

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetLaunchCallbackTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetLaunchCallbackTest.kt
@@ -1,0 +1,46 @@
+package com.kernel.ai.feature.widget
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.glance.GlanceId
+import androidx.glance.action.ActionParameters
+import androidx.glance.action.actionParametersOf
+import androidx.glance.appwidget.AppWidgetId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ListsWidgetLaunchCallbackTest {
+
+    @Test
+    fun `routeFor maps a configured list to its deep link`() {
+        assertEquals("lists/42", ListsWidgetLaunchCallback.routeFor(42L))
+    }
+
+    @Test
+    fun `routeFor falls back to the overview for unconfigured or invalid ids`() {
+        assertEquals("lists", ListsWidgetLaunchCallback.routeFor(-1L))
+        assertEquals("lists", ListsWidgetLaunchCallback.routeFor(0L))
+    }
+
+    @Test
+    fun `onAction launches MainActivity once for a configured widget`() = runTest {
+        val context = mockk<Context>(relaxed = true)
+        every { context.packageName } returns "com.kernel.ai"
+        val prefs = mockk<SharedPreferences>()
+        every { prefs.getLong(any(), any()) } returns 42L
+        every { context.getSharedPreferences("lists_widget_config", any()) } returns prefs
+        val glanceId: GlanceId = AppWidgetId(APPWIDGET_ID)
+
+        ListsWidgetLaunchCallback().onAction(context, glanceId, actionParametersOf())
+
+        verify(exactly = 1) { context.startActivity(any()) }
+    }
+
+    private companion object {
+        const val APPWIDGET_ID = 5
+    }
+}

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetLaunchCallbackTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetLaunchCallbackTest.kt
@@ -21,19 +21,47 @@ import org.junit.jupiter.api.Test
 class ListsWidgetLaunchCallbackTest {
 
     @Test
-    fun `routeFor maps an existing configured list to its deep link`() {
-        assertEquals("lists/42", ListsWidgetLaunchCallback.routeFor(42L, listExists = true))
+    fun `launch destination uses list detail for an existing configured list`() {
+        assertEquals(
+            ListsWidgetLaunchDestination.Detail("lists/42"),
+            ListsWidgetLaunchCallback.launchDestinationFor(
+                42L,
+                listExists = true,
+                appWidgetId = APPWIDGET_ID,
+            ),
+        )
     }
 
     @Test
-    fun `routeFor falls back to the overview for unconfigured or invalid ids`() {
-        assertEquals("lists", ListsWidgetLaunchCallback.routeFor(-1L, listExists = false))
-        assertEquals("lists", ListsWidgetLaunchCallback.routeFor(0L, listExists = false))
+    fun `launch destination requests configuration for an unconfigured widget`() {
+        assertEquals(
+            ListsWidgetLaunchDestination.Configure(APPWIDGET_ID),
+            ListsWidgetLaunchCallback.launchDestinationFor(
+                selectedListId = 0L,
+                listExists = false,
+                appWidgetId = APPWIDGET_ID,
+            ),
+        )
+        assertEquals(
+            ListsWidgetLaunchDestination.Configure(APPWIDGET_ID),
+            ListsWidgetLaunchCallback.launchDestinationFor(
+                selectedListId = -1L,
+                listExists = false,
+                appWidgetId = APPWIDGET_ID,
+            ),
+        )
     }
 
     @Test
-    fun `routeFor falls back to the overview when the configured list was deleted`() {
-        assertEquals("lists", ListsWidgetLaunchCallback.routeFor(42L, listExists = false))
+    fun `launch destination requests configuration when the configured list was deleted`() {
+        assertEquals(
+            ListsWidgetLaunchDestination.Configure(APPWIDGET_ID),
+            ListsWidgetLaunchCallback.launchDestinationFor(
+                selectedListId = 42L,
+                listExists = false,
+                appWidgetId = APPWIDGET_ID,
+            ),
+        )
     }
 
     @Test

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetProjectionFlowTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetProjectionFlowTest.kt
@@ -1,0 +1,83 @@
+package com.kernel.ai.feature.widget
+
+import com.kernel.ai.core.memory.entity.ListItemEntity
+import com.kernel.ai.core.memory.entity.ListNameEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ListsWidgetProjectionFlowTest {
+
+    @Test
+    fun `selection and Room changes update the active projection`() = runTest {
+        val selectedListId = MutableStateFlow(ListsWidgetConfig.INVALID)
+        val listOne = ListNameEntity(id = 1L, name = "shopping list", createdAt = 0L, updatedAt = 0L)
+        val listTwo = ListNameEntity(id = 2L, name = "work", createdAt = 0L, updatedAt = 0L)
+        val metadata = MutableStateFlow(listOf(listOne, listTwo))
+        val listOneItems = MutableStateFlow(listOf(item(1L, 1L, "jam")))
+        val listTwoItems = MutableStateFlow(listOf(item(2L, 2L, "email")))
+        val itemFlows = mapOf(1L to listOneItems, 2L to listTwoItems)
+        val emissions = mutableListOf<ListsWidgetProjection>()
+        val job = launch {
+            observeListsWidgetProjection(
+                selectedListIds = selectedListId,
+                listMetadata = metadata,
+                listItems = { itemFlows.getValue(it) },
+            ).collect { emissions += it }
+        }
+
+        runCurrent()
+        assertTrue(emissions.last() is ListsWidgetProjection.NotConfigured)
+
+        selectedListId.value = 1L
+        runCurrent()
+        assertEquals(ListsWidgetProjection.Configured(1L, "shopping list", listOf("jam")), emissions.last())
+
+        metadata.value = listOf(listOne.copy(name = "renamed"), listTwo)
+        runCurrent()
+        assertEquals(ListsWidgetProjection.Configured(1L, "renamed", listOf("jam")), emissions.last())
+
+        listOneItems.value = listOf(item(1L, 1L, "jam"), item(3L, 1L, "eggs"))
+        runCurrent()
+        assertEquals(
+            ListsWidgetProjection.Configured(1L, "renamed", listOf("jam", "eggs")),
+            emissions.last(),
+        )
+
+        metadata.value = listOf(listOne.copy(name = "renamed", archivedAt = 1L), listTwo)
+        runCurrent()
+        assertEquals(
+            ListsWidgetProjection.Archived(1L, "renamed", listOf("jam", "eggs")),
+            emissions.last(),
+        )
+
+        metadata.value = listOf(listTwo)
+        runCurrent()
+        assertTrue(emissions.last() is ListsWidgetProjection.Missing)
+
+        selectedListId.value = 2L
+        runCurrent()
+        assertEquals(ListsWidgetProjection.Configured(2L, "work", listOf("email")), emissions.last())
+
+        val emissionsAfterReconfigure = emissions.size
+        listOneItems.value = listOf(item(4L, 1L, "stale old-list item"))
+        runCurrent()
+        assertEquals(emissionsAfterReconfigure, emissions.size)
+
+        job.cancel()
+    }
+
+    private fun item(id: Long, listId: Long, text: String) = ListItemEntity(
+        id = id,
+        listId = listId,
+        text = text,
+        createdAt = id,
+        updatedAt = id,
+        displayOrder = id,
+    )
+}

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetProjectionTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetProjectionTest.kt
@@ -43,6 +43,7 @@ class ListsWidgetProjectionTest {
     fun `empty when the active list has no active items`() {
         val projected = projectListsWidget(1L, activeName, listOf(item(1, "done", checked = true)))
         assertEquals(ListsWidgetProjection.Empty(1L, "shopping list"), projected)
+        assertEquals(1L, projected.listId)
     }
 
     @Test
@@ -58,6 +59,7 @@ class ListsWidgetProjectionTest {
         projected as ListsWidgetProjection.Configured
         assertEquals("shopping list", projected.listName)
         assertEquals(listOf("A", "B", "C"), projected.activeItems)
+        assertEquals(1L, projected.listId)
     }
 
     @Test
@@ -74,5 +76,20 @@ class ListsWidgetProjectionTest {
         assertTrue(projected is ListsWidgetProjection.Archived)
         projected as ListsWidgetProjection.Archived
         assertEquals(listOf("A"), projected.activeItems)
+        assertEquals(1L, projected.listId)
+    }
+
+    @Test
+    fun `orders equal display order by createdAt then id`() {
+        // Two items share displayOrder 0; the secondary key is createdAt (ascending), so the
+        // earlier-created item comes first and ordering stays deterministic via the id tie-break.
+        val items = listOf(
+            item(2, "later", displayOrder = 0L, createdAt = 20L),
+            item(1, "earlier", displayOrder = 0L, createdAt = 10L),
+        )
+        val projected = projectListsWidget(1L, activeName, items)
+        assertTrue(projected is ListsWidgetProjection.Configured)
+        projected as ListsWidgetProjection.Configured
+        assertEquals(listOf("earlier", "later"), projected.activeItems)
     }
 }

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetProjectionTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetProjectionTest.kt
@@ -1,0 +1,78 @@
+package com.kernel.ai.feature.widget
+
+import com.kernel.ai.core.memory.entity.ListItemEntity
+import com.kernel.ai.core.memory.entity.ListNameEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ListsWidgetProjectionTest {
+
+    private fun item(
+        id: Long,
+        text: String,
+        checked: Boolean = false,
+        displayOrder: Long = 0L,
+        createdAt: Long = id,
+    ) = ListItemEntity(
+        id = id,
+        listId = 1L,
+        text = text,
+        createdAt = createdAt,
+        updatedAt = createdAt,
+        checked = checked,
+        displayOrder = displayOrder,
+    )
+
+    private val activeName = ListNameEntity(id = 1L, name = "shopping list", createdAt = 0L, updatedAt = 0L)
+
+    @Test
+    fun `not configured when no list selected`() {
+        assertTrue(
+            projectListsWidget(ListsWidgetConfig.INVALID, activeName, emptyList())
+                is ListsWidgetProjection.NotConfigured,
+        )
+    }
+
+    @Test
+    fun `missing when the selected list no longer exists`() {
+        assertTrue(projectListsWidget(1L, null, emptyList()) is ListsWidgetProjection.Missing)
+    }
+
+    @Test
+    fun `empty when the active list has no active items`() {
+        val projected = projectListsWidget(1L, activeName, listOf(item(1, "done", checked = true)))
+        assertEquals(ListsWidgetProjection.Empty(1L, "shopping list"), projected)
+    }
+
+    @Test
+    fun `configured shows only active items sorted by display order then recency`() {
+        val items = listOf(
+            item(3, "C", displayOrder = 2L, createdAt = 30L),
+            item(1, "A", displayOrder = 0L, createdAt = 10L),
+            item(2, "B", displayOrder = 1L, createdAt = 20L),
+            item(4, "done", checked = true),
+        )
+        val projected = projectListsWidget(1L, activeName, items)
+        assertTrue(projected is ListsWidgetProjection.Configured)
+        projected as ListsWidgetProjection.Configured
+        assertEquals("shopping list", projected.listName)
+        assertEquals(listOf("A", "B", "C"), projected.activeItems)
+    }
+
+    @Test
+    fun `archived list projects as archived but still surfaces active items`() {
+        val archivedName = ListNameEntity(
+            id = 1L,
+            name = "old",
+            createdAt = 0L,
+            updatedAt = 0L,
+            archivedAt = 100L,
+        )
+        val items = listOf(item(1, "A"), item(2, "B", checked = true))
+        val projected = projectListsWidget(1L, archivedName, items)
+        assertTrue(projected is ListsWidgetProjection.Archived)
+        projected as ListsWidgetProjection.Archived
+        assertEquals(listOf("A"), projected.activeItems)
+    }
+}

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetReceiverTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetReceiverTest.kt
@@ -1,0 +1,39 @@
+package com.kernel.ai.feature.widget
+
+import android.content.Context
+import android.content.Intent
+import com.kernel.ai.core.memory.lists.ListsDataChanged
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ListsWidgetReceiverTest {
+
+    @BeforeEach
+    fun setUp() { mockkObject(ListsWidgetRefresher) }
+
+    @AfterEach
+    fun tearDown() { unmockkObject(ListsWidgetRefresher) }
+
+    @Test
+    fun `refreshes widget on the lists data changed broadcast`() {
+        val context = mockk<Context>(relaxed = true)
+        // Intent.getAction() is a stubbed no-op under the JVM unit-test runtime, so the action
+        // must be mocked for the receiver's `intent.action == ACTION` gate to pass.
+        val intent = mockk<Intent> { every { action } returns ListsDataChanged.ACTION }
+        ListsWidgetReceiver().onReceive(context, intent)
+        verify { ListsWidgetRefresher.refresh(context) }
+    }
+
+    @Test
+    fun `ignores unrelated actions`() {
+        val context = mockk<Context>(relaxed = true)
+        ListsWidgetReceiver().onReceive(context, Intent("com.kernel.ai.action.SOMETHING_ELSE"))
+        verify(exactly = 0) { ListsWidgetRefresher.refresh(any()) }
+    }
+}

--- a/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetSizingTest.kt
+++ b/feature/widget/src/test/java/com/kernel/ai/feature/widget/ListsWidgetSizingTest.kt
@@ -1,0 +1,45 @@
+package com.kernel.ai.feature.widget
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ListsWidgetSizingTest {
+
+    @Test
+    fun `compact height reserves room for overflow hint`() {
+        assertEquals(
+            ActiveItemLayout(visibleCount = 1, overflowCount = 5),
+            calculateActiveItemLayout(widgetHeightDp = 110f, activeItemCount = 6),
+        )
+    }
+
+    @Test
+    fun `larger height exposes more active rows`() {
+        val compact = calculateActiveItemLayout(widgetHeightDp = 110f, activeItemCount = 6)
+        val taller = calculateActiveItemLayout(widgetHeightDp = 160f, activeItemCount = 6)
+
+        assertEquals(1, compact.visibleCount)
+        assertEquals(3, taller.visibleCount)
+        assertEquals(3, taller.overflowCount)
+    }
+
+    @Test
+    fun `visible rows never exceed active items or maximum`() {
+        assertEquals(
+            ActiveItemLayout(visibleCount = 6, overflowCount = 0),
+            calculateActiveItemLayout(widgetHeightDp = 204f, activeItemCount = 6),
+        )
+        assertEquals(
+            ActiveItemLayout(visibleCount = MAX_WIDGET_ITEMS - 1, overflowCount = 5),
+            calculateActiveItemLayout(widgetHeightDp = 260f, activeItemCount = 12),
+        )
+    }
+
+    @Test
+    fun `empty content produces no rows or overflow`() {
+        assertEquals(
+            ActiveItemLayout(visibleCount = 0, overflowCount = 0),
+            calculateActiveItemLayout(widgetHeightDp = 204f, activeItemCount = 0),
+        )
+    }
+}


### PR DESCRIPTION
Closes #1489

## Summary
- Adds a Glance home-screen widget (`ListsWidget`) bound to one existing local Jandal list. The widget reads live from the shared Room store on every render and refreshes only via the `LISTS_DATA_CHANGED` broadcast emitted after a successful list mutation — no polling, no periodic worker, no second data store.
- Adds a canonical launcher/app shortcut for Lists (`shortcuts.xml` static shortcut) and an in-app "Add Lists shortcut to Home screen" pin action (`ListsShortcut`). The pin action honestly reports `Unsupported` when `ShortcutManager.isRequestPinShortcutSupported` is false.
- Adds the navigation seam: `NativeIntentHandler` and `ListsViewModel` broadcast `ListsDataChanged` after `add_to_list` / `bulk_add_to_list` / etc. mutations; `ListsWidgetReceiver` refreshes all widget instances via `GlanceAppWidgetManager.getGlanceIds` + per-id update.
- Widget deep-link uses a `SharedPreferences`-handed route (`lists/{id}` or `lists`) consumed by `MainActivity.consumeWidgetRoute()` (Glance 1.1.1 cannot pass intent extras through `actionStartActivity`).

## Notes
- Reuses `:feature:widget`; no new module, no fourth bottom-nav tab, no Room schema migration.
- Config stored outside Room (per-widget `SharedPreferences` keyed by `appWidgetId`).

Do not merge — wait for review.