### PR TITLE
fix(#1504): restore evidence store and fail closed

### DIFF
--- a/.docs/agents/test-evidence-workflow.md
+++ b/.docs/agents/test-evidence-workflow.md
@@ -310,6 +310,23 @@ The schema (`docs/testing/test-evidence-schema.md`) distinguishes `ci` from `on_
 | PR-number-first workflow | `.github/workflows/publish-pr-test-evidence.yml` | PR-number-only dispatch → resolve run/artifact → publish → dashboard rebuild |
 | Dashboard publishing workflow | `.github/workflows/publish-test-dashboard.yml` | Manual dispatch OR push to main OR repository_dispatch |
 
+### Store availability and deletion protection
+
+The dashboard workflow treats `test-results/results/` as a required checkout
+contract. A missing or unreadable branch, or a checkout without `results/`,
+fails the workflow before Pages packaging; it must not be replaced with an
+empty directory. An existing empty `results/` directory remains valid and
+renders an intentionally empty dashboard. The local dashboard builder enforces
+the same distinction.
+
+The `test-results` branch must have GitHub branch protection with deletion and
+force-push protection enabled, while leaving required status checks and pull
+request reviews unset so the evidence publishers can append directly. If the
+repository cannot apply that protection through its available administration
+permissions, configure it manually at **Settings → Rules → Rulesets → New
+branch ruleset**, target `test-results`, enable **Restrict deletions** and
+**Block force pushes**, and leave merge/status requirements disabled.
+
 ## Current non-goals
 
 - **No merge gates** — evidence publishing is not required to merge.

--- a/.github/workflows/publish-test-dashboard.yml
+++ b/.github/workflows/publish-test-dashboard.yml
@@ -29,18 +29,16 @@ jobs:
 
       - name: Checkout test-results
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0
-        continue-on-error: true
         with:
           ref: test-results
           path: test-results
           fetch-depth: 1
 
-      - name: Ensure test-results checkout
+      - name: Verify test-results checkout
         run: |
           if [ ! -d test-results/results ]; then
-            rm -rf test-results
-            mkdir -p test-results/results
-            echo "::warning::test-results branch not found or empty; using empty results"
+            echo "::error::test-results checkout is unavailable or missing the required results/ directory; refusing to build an empty dashboard" >&2
+            exit 1
           fi
 
       - name: Install test evidence dependencies

--- a/scripts/build_test_dashboard.py
+++ b/scripts/build_test_dashboard.py
@@ -1441,6 +1441,26 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _require_results_dir(results_dir: Path) -> None:
+    """Fail closed when the evidence store is unavailable.
+
+    An existing but empty ``results/`` directory is valid and renders the
+    normal empty dashboard.  A missing, non-directory, or unreadable store
+    must not silently look like an empty evidence history.
+    """
+    if not results_dir.is_dir():
+        raise SystemExit(
+            f"ERROR: test-results evidence store is unavailable at {results_dir}; "
+            "refusing to build an empty dashboard"
+        )
+    try:
+        next(results_dir.iterdir(), None)
+    except OSError as exc:
+        raise SystemExit(
+            f"ERROR: test-results evidence store is unreadable at {results_dir}: {exc}"
+        ) from exc
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -1453,6 +1473,8 @@ def main() -> None:
 
     print(f"Results dir: {results_dir}")
     print(f"Output dir:  {out_dir}")
+
+    _require_results_dir(results_dir)
 
     # Load evidence
     evidence = _discover_results(results_dir)

--- a/scripts/publish_test_evidence.py
+++ b/scripts/publish_test_evidence.py
@@ -525,7 +525,7 @@ def _collect_input_files(args: argparse.Namespace) -> list[Path]:
             sys.exit(1)
         return allowed
 
-    in_path = Path(args.input_file)
+    in_path = Path(args.input)
     if not in_path.is_file() or in_path.is_symlink():
         print(f"ERROR: input file not found or unsafe: {in_path}", file=sys.stderr)
         sys.exit(1)

--- a/scripts/tests/test_build_test_dashboard_metrics.py
+++ b/scripts/tests/test_build_test_dashboard_metrics.py
@@ -22,6 +22,7 @@ from build_test_dashboard import (
     _build_metrics_json,
     _render_metrics_section,
     _render_wake_metrics_section,
+    _require_results_dir,
 )
 
 
@@ -92,6 +93,20 @@ def _make_record(**overrides: object) -> dict:
 
 class DashboardMetricsIntegrationTest(unittest.TestCase):
     """Tests for the metrics block in build_test_dashboard.py."""
+    def test_missing_results_dir_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "results"
+            with self.assertRaisesRegex(
+                SystemExit, "evidence store is unavailable"
+            ):
+                _require_results_dir(missing)
+
+    def test_empty_results_dir_remains_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            empty = Path(tmp) / "results"
+            empty.mkdir()
+            _require_results_dir(empty)
+
     def test_device_latest_run_is_separate_from_historical_aggregate(self) -> None:
         old = _make_record(
             timestamp="2026-06-13T00:00:00Z",

--- a/scripts/tests/test_publish_test_dashboard_workflow.py
+++ b/scripts/tests/test_publish_test_dashboard_workflow.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Regression tests for the test-results dashboard workflow contract."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "publish-test-dashboard.yml"
+)
+
+
+class DashboardWorkflowContractTest(unittest.TestCase):
+    def test_missing_store_fails_before_pages_deployment(self) -> None:
+        workflow = WORKFLOW.read_text()
+
+        self.assertIn("ref: test-results", workflow)
+        self.assertNotIn("continue-on-error: true", workflow)
+        self.assertIn("if [ ! -d test-results/results ]; then", workflow)
+        self.assertIn("refusing to build an empty dashboard", workflow)
+        self.assertIn("exit 1", workflow)
+        self.assertNotIn("mkdir -p test-results/results", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_publish_test_evidence.py
+++ b/scripts/tests/test_publish_test_evidence.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Regression tests for evidence publisher input compatibility."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from publish_test_evidence import _collect_input_files, _parse_args
+
+
+class PublishTestEvidenceInputTest(unittest.TestCase):
+    def test_single_input_file_matches_cli_option(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence = Path(tmp) / "evidence.json"
+            evidence.write_text("{}")
+            args = _parse_args(
+                [
+                    "--input",
+                    str(evidence),
+                    "--source",
+                    "ci",
+                    "--pr",
+                    "1152",
+                    "--commit",
+                    "2798a1dd0a08f654e6fea0f36d0accb2531fb5ef",
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(_collect_input_files(args), [evidence])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1504

## Changes

- Restores `test-results` at the exact recovered historical tip `16718854a350ba62a916b6a4e711b572b571d552`.
- Removes dashboard checkout `continue-on-error` and empty-directory fallback.
- Fails before Pages packaging when `test-results/results/` is unavailable or malformed; preserves valid empty `results/` behavior.
- Makes the local dashboard builder enforce the same missing/unreadable-store distinction.
- Fixes single-file publisher dry-run compatibility (`--input`).
- Adds focused regression tests and documents deletion-protection requirements.

## Recovery evidence

- Recovered tip: `16718854a350ba62a916b6a4e711b572b571d552`.
- Snapshot: 451 files, including 406 JSON files; 12 JSON records satisfy the current dashboard schema. The remaining historical JSON files are preserved artifacts or older schema records and are reported by the builder as invalid rather than rewritten.
- Dashboard build from the restored snapshot completed and generated `_site/index.html` plus dashboard data files.
- No synthetic evidence was created.

## Validation

- Focused tests: 23 passed.
- Full `scripts/tests` suite: 753 passed.
- Publisher dry-run against restored evidence completed without a network push.
- Missing-store and valid-empty-store behavior exercised directly.
- Workflow YAML parsed successfully.

## Protection

The authenticated repository token has `write` but not administration permission; classic branch protection and rulesets are not available to this session. The exact manual ruleset configuration is documented in `.docs/agents/test-evidence-workflow.md`: target `test-results`, enable deletion and force-push restrictions, and leave merge/status requirements disabled so publishers can append directly.

Do not merge — wait for review.