### PR TITLE
feat(#1510): ship Inflect Micro for supported devices

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -299,11 +299,12 @@ dependencies {
     implementation(project(":feature:widget"))
     implementation(project(":feature:convert"))
 
-    // Keep the stock Sherpa runtime in release and the Inflect-enabled rebuild in debug only.
-    val stockSherpaAar = rootProject.file("third_party/sherpa-onnx/sherpa-onnx-1.13.0-noort.aar")
+    // Release and debug use the same pinned Inflect-enabled Sherpa runtime. The AAR is the
+    // existing v1.13.0 rebuild from scripts/sherpa-onnx-v1.13.0-inflect-build.md; no native
+    // binary is rebuilt or duplicated by this release-exposure change.
     val inflectSherpaAar =
         rootProject.file("third_party/sherpa-onnx/sherpa-onnx-1.13.0-noort-inflect.aar")
-    releaseImplementation(files(stockSherpaAar.absolutePath))
+    releaseImplementation(files(inflectSherpaAar.absolutePath))
     debugImplementation(files(inflectSherpaAar.absolutePath))
 
     implementation(platform(libs.compose.bom))

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
@@ -275,7 +275,7 @@ enum class KernelModel(
         showInModelManagement = false,
     ),
 
-    // ── Inflect Micro v2 ONNX (debug-only voice output) ─────────────────────
+    // ── Inflect Micro v2 ONNX voice output ────────────────────────────────────
     //
     // Official Apache-2.0 export from owensong/Inflect-Micro-v2-ONNX. The
     // frontend and runner require both graphs; Voice settings owns this pair.

--- a/core/voice/build.gradle.kts
+++ b/core/voice/build.gradle.kts
@@ -39,6 +39,7 @@ android {
 // at runtime; see :app/build.gradle.kts for the conditional implementation block.
 
 dependencies {
+    implementation(project(":core:inference"))
     implementation(libs.core.ktx)
     implementation(libs.coroutines.android)
     implementation(libs.datastore.preferences)

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidTextToSpeechController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidTextToSpeechController.kt
@@ -227,14 +227,12 @@ class AndroidTextToSpeechController @Inject constructor(
             "Text-to-speech is unavailable on this device."
         )
 
-        val availability = engine.isLanguageAvailable(locale)
-        if (availability < TextToSpeech.LANG_AVAILABLE) {
-            return VoiceOutputResult.Unavailable(
+        val resolvedLocale = resolveAvailableLocale(engine, locale)
+            ?: return VoiceOutputResult.Unavailable(
                 "Text-to-speech voice for ${locale.toLanguageTag()} is not available on this device."
             )
-        }
 
-        engine.language = locale
+        engine.language = resolvedLocale
         requestAudioFocus()
         val resolvedUtteranceId = utteranceId ?: "kernel-voice-${System.nanoTime()}"
         synchronized(playbackLock) {
@@ -270,6 +268,24 @@ class AndroidTextToSpeechController @Inject constructor(
             VoiceOutputResult.Unavailable("Text-to-speech failed to start.")
         } else {
             VoiceOutputResult.Spoken
+        }
+    }
+
+    private fun resolveAvailableLocale(
+        engine: TextToSpeech,
+        requested: Locale,
+    ): Locale? {
+        val languageFallback = requested.language
+            .takeIf { it.isNotBlank() }
+            ?.let(Locale::forLanguageTag)
+        val candidates = sequenceOf(
+            requested,
+            languageFallback,
+            if (requested.language == Locale.ENGLISH.language) Locale.US else null,
+            Locale.getDefault(),
+        ).filterNotNull().distinct()
+        return candidates.firstOrNull { candidate ->
+            engine.isLanguageAvailable(candidate) >= TextToSpeech.LANG_AVAILABLE
         }
     }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
@@ -17,7 +17,7 @@ private const val TAG = "KernelAI"
  * - [VoiceOutputEngine.AndroidTts] routes directly to [AndroidTextToSpeechController].
  * - [VoiceOutputEngine.SherpaExperimental] tries [SherpaOnnxVoiceOutputController] first, but
  *   still falls back to Android TTS if Sherpa assets/runtime are missing or if synthesis fails.
- * - [VoiceOutputEngine.InflectMicroExperimental] tries the debug Inflect controller first, but
+ * - [VoiceOutputEngine.InflectMicroExperimental] tries the Inflect controller first, but
  *   still falls back to Android TTS if the model/frontend/runtime is unavailable.
  * Events are forwarded from whichever backend is active via [flatMapLatest].
  */

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/InflectMicroModelSpec.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/InflectMicroModelSpec.kt
@@ -1,6 +1,8 @@
 package com.kernel.ai.core.voice
 
 import android.content.Context
+import android.os.Build
+import com.kernel.ai.core.inference.hardware.HardwareTier
 import java.io.File
 
 /** Inflect Micro model pair managed from Voice settings on eligible devices. */
@@ -14,6 +16,15 @@ object InflectMicroModelSpec {
         RequiredModel("duration.onnx", "Inflect Micro duration graph"),
         RequiredModel("decode.onnx", "Inflect Micro decode graph"),
     )
+
+    /**
+     * The pinned Inflect JNI extension is present only in the arm64-v8a AAR payload.
+     */
+    fun isReleaseEligible(
+        tier: HardwareTier,
+        supportedAbis: Array<String> = Build.SUPPORTED_ABIS ?: emptyArray(),
+    ): Boolean = tier == HardwareTier.FLAGSHIP &&
+        supportedAbis.any { it == "arm64-v8a" }
 
     fun modelDirectory(context: Context): File {
         val modelsDirectory = context.getExternalFilesDir("models")

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/InflectMicroModelSpec.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/InflectMicroModelSpec.kt
@@ -3,7 +3,7 @@ package com.kernel.ai.core.voice
 import android.content.Context
 import java.io.File
 
-/** Debug-only Inflect Micro model pair managed from Voice settings. */
+/** Inflect Micro model pair managed from Voice settings on eligible devices. */
 object InflectMicroModelSpec {
     data class RequiredModel(
         val fileName: String,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/InflectMicroVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/InflectMicroVoiceOutputController.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
-/** Debug-only Inflect Micro runtime text -> IPA -> ONNX -> AudioTrack controller. */
+/** Inflect Micro runtime text -> IPA -> ONNX -> AudioTrack controller. */
 @Singleton
 class InflectMicroVoiceOutputController @Inject constructor(
     @ApplicationContext private val context: Context,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputEngine.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputEngine.kt
@@ -16,11 +16,12 @@ enum class VoiceOutputEngine(
     KokoroExperimental(
         displayName = "Kokoro (Experimental)",
         description = "Studio-grade Kokoro-82M TTS. Requires a ~130MB download. Falls back to Android TTS if unavailable.",
+        debugOnly = true,
     ),
     InflectMicroExperimental(
-        displayName = "Inflect Micro (Debug)",
-        description = "Debug-only Inflect Micro v2 quality path using the downloaded Sherpa eSpeak frontend.",
-        debugOnly = true,
+        displayName = "Inflect Micro",
+        description = "Higher-quality local Inflect Micro v2 speech for supported high-memory devices; falls back to Android TTS if unavailable.",
+        debugOnly = false,
     ),
     ;
 
@@ -28,7 +29,34 @@ enum class VoiceOutputEngine(
         fun fromStorage(value: String?): VoiceOutputEngine =
             entries.firstOrNull { it.name == value } ?: AndroidTts
 
-        fun entriesForBuild(isRelease: Boolean): List<VoiceOutputEngine> =
-            entries.filter { !isRelease || !it.debugOnly }
+        /**
+         * Returns the engine catalogue allowed for this build and device.
+         *
+         * Inflect is release-visible only when the caller has established that the device is in
+         * the validated high-memory class. The caller supplies that capability so this enum does
+         * not duplicate hardware detection.
+         */
+        fun entriesForBuild(
+            isRelease: Boolean,
+            inflectEligible: Boolean,
+        ): List<VoiceOutputEngine> = entries.filter { engine ->
+            !isRelease ||
+                (!engine.debugOnly &&
+                    (engine != InflectMicroExperimental || inflectEligible))
+        }
+
+        fun resolveForBuild(
+            value: String?,
+            isRelease: Boolean,
+            inflectEligible: Boolean,
+        ): VoiceOutputEngine {
+            val engine = fromStorage(value)
+            return engine.takeIf {
+                it in entriesForBuild(
+                    isRelease = isRelease,
+                    inflectEligible = inflectEligible,
+                )
+            } ?: AndroidTts
+        }
     }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.util.Log
 import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
-import com.kernel.ai.core.inference.hardware.HardwareTier
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
@@ -36,7 +35,7 @@ class VoiceOutputPreferences @Inject constructor(
     private val isReleaseBuild: Boolean =
         (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) == 0
     private val inflectReleaseEligible: Boolean =
-        hardwareProfileDetector.profile.tier == HardwareTier.FLAGSHIP
+        InflectMicroModelSpec.isReleaseEligible(hardwareProfileDetector.profile.tier)
 
     init {
         if (isReleaseBuild) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
@@ -3,6 +3,8 @@ package com.kernel.ai.core.voice
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.util.Log
+import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
+import com.kernel.ai.core.inference.hardware.HardwareTier
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
@@ -29,18 +31,20 @@ private val Context.voiceOutputPrefsDataStore by preferencesDataStore(name = "vo
 @Singleton
 class VoiceOutputPreferences @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val hardwareProfileDetector: HardwareProfileDetector,
 ) {
     private val isReleaseBuild: Boolean =
         (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) == 0
+    private val inflectReleaseEligible: Boolean =
+        hardwareProfileDetector.profile.tier == HardwareTier.FLAGSHIP
 
     init {
         if (isReleaseBuild) {
             CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
-                migrateIfNotReleaseVisible()
+                migrateReleasePreferences()
             }
         }
     }
-
     private val spokenResponsesEnabledKey =
         booleanPreferencesKey("quick_actions_spoken_responses_enabled")
     private val selectedEngineKey = stringPreferencesKey("selected_voice_output_engine")
@@ -75,9 +79,11 @@ class VoiceOutputPreferences @Inject constructor(
             }
         }
         .map { prefs ->
-            VoiceOutputEngine.fromStorage(prefs[selectedEngineKey]).let { engine ->
-                if (isReleaseBuild && engine.debugOnly) VoiceOutputEngine.AndroidTts else engine
-            }
+            VoiceOutputEngine.resolveForBuild(
+                value = prefs[selectedEngineKey],
+                isRelease = isReleaseBuild,
+                inflectEligible = inflectReleaseEligible,
+            )
         }
 
     val selectedSherpaVoice: Flow<SherpaPiperVoice> = context.voiceOutputPrefsDataStore.data
@@ -123,8 +129,13 @@ class VoiceOutputPreferences @Inject constructor(
     }
 
     suspend fun setSelectedEngine(engine: VoiceOutputEngine) {
+        val effectiveEngine = VoiceOutputEngine.resolveForBuild(
+            value = engine.name,
+            isRelease = isReleaseBuild,
+            inflectEligible = inflectReleaseEligible,
+        )
         context.voiceOutputPrefsDataStore.edit { prefs ->
-            prefs[selectedEngineKey] = engine.name
+            prefs[selectedEngineKey] = effectiveEngine.name
         }
     }
 
@@ -250,19 +261,34 @@ class VoiceOutputPreferences @Inject constructor(
     }
 
     /**
-     * Persists the migration of a non-release-visible stored voice (e.g. Semaine)
-     * to [SherpaPiperVoice.CoriHigh] in release builds.
+     * Persists release migrations for hidden engines and non-release-visible stored voices.
      *
      * Called once at construction time in release builds via [init]. The runtime
-     * mapping in [selectedSherpaVoice] also handles this case as a safety net.
+     * mappings also handle this case as a safety net.
      */
-    private suspend fun migrateIfNotReleaseVisible() {
-        val storedName = context.voiceOutputPrefsDataStore.data.first()[selectedSherpaVoiceKey]
-        val stored = SherpaPiperVoice.fromStorage(storedName)
-        if (!stored.releaseVisible) {
-            Log.i(TAG, "Persisting migration: ${stored.name} → ${SherpaPiperVoice.CoriHigh.name}")
-            context.voiceOutputPrefsDataStore.edit { editor ->
-                editor[selectedSherpaVoiceKey] = SherpaPiperVoice.CoriHigh.name
+    private suspend fun migrateReleasePreferences() {
+        val prefs = context.voiceOutputPrefsDataStore.data.first()
+        val storedSherpa = SherpaPiperVoice.fromStorage(prefs[selectedSherpaVoiceKey])
+        val resolvedSherpa = resolveReleaseBuildVoice(storedSherpa, isReleaseBuild)
+        val storedEngineName = prefs[selectedEngineKey]
+        val resolvedEngine = VoiceOutputEngine.resolveForBuild(
+            value = storedEngineName,
+            isRelease = isReleaseBuild,
+            inflectEligible = inflectReleaseEligible,
+        )
+        val sherpaChanged = resolvedSherpa != storedSherpa
+        val engineChanged = storedEngineName != null && resolvedEngine.name != storedEngineName
+        if (!sherpaChanged && !engineChanged) return
+
+        Log.i(TAG, "Persisting release voice migration: " +
+            "${storedSherpa.name} → ${resolvedSherpa.name}; " +
+            "${storedEngineName ?: VoiceOutputEngine.AndroidTts.name} → ${resolvedEngine.name}")
+        context.voiceOutputPrefsDataStore.edit { editor ->
+            if (sherpaChanged) {
+                editor[selectedSherpaVoiceKey] = resolvedSherpa.name
+            }
+            if (engineChanged) {
+                editor[selectedEngineKey] = resolvedEngine.name
             }
         }
     }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidTextToSpeechControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidTextToSpeechControllerTest.kt
@@ -58,6 +58,7 @@ class AndroidTextToSpeechControllerTest {
         private val initStatuses: List<Int> = listOf(TextToSpeech.SUCCESS),
         private val defaultEnginePackage: String? = null,
         private val installedEngines: List<TextToSpeech.EngineInfo> = emptyList(),
+        private val languageStatuses: Map<Locale, Int> = emptyMap(),
     ) : TextToSpeechFactory {
         val created = mutableListOf<TextToSpeech>()
         val packages = mutableListOf<String?>()
@@ -68,6 +69,9 @@ class AndroidTextToSpeechControllerTest {
                 every { engine.defaultEngine } returns defaultEnginePackage
             }
             every { engine.engines } returns installedEngines
+            every { engine.isLanguageAvailable(any()) } answers {
+                languageStatuses[args[0] as Locale] ?: TextToSpeech.LANG_AVAILABLE
+            }
             created += engine
             packages += enginePackage
             // repeat the last configured status for any additional attempts
@@ -271,4 +275,28 @@ class AndroidTextToSpeechControllerTest {
         verify { recovered.speak("streamed reply", TextToSpeech.QUEUE_FLUSH, any(), any()) }
         verify(exactly = 0) { factory.created[0].speak(any(), any(), any(), any()) }
     }
+
+    @Test
+    fun `speak falls back from unavailable regional locale to available language locale`() =
+        runTest(dispatcher) {
+            val (controller, factory) = buildController(
+                factory = FakeTtsFactory(
+                    languageStatuses = mapOf(
+                        Locale.forLanguageTag("en-AU") to TextToSpeech.LANG_NOT_SUPPORTED,
+                        Locale.ENGLISH to TextToSpeech.LANG_AVAILABLE,
+                    ),
+                ),
+            )
+
+            val result = controller.speak(
+                VoiceSpeakRequest(
+                    text = "hello",
+                    locale = Locale.forLanguageTag("en-AU"),
+                ),
+            )
+
+            assertEquals(VoiceOutputResult.Spoken, result)
+            verify { factory.created.single().language = Locale.ENGLISH }
+            verify { factory.created.single().speak("hello", TextToSpeech.QUEUE_FLUSH, any(), any()) }
+        }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceOutputEngineTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceOutputEngineTest.kt
@@ -1,0 +1,48 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class VoiceOutputEngineTest {
+    @Test
+    fun `release eligible high-memory catalogue includes Inflect`() {
+        assertTrue(
+            VoiceOutputEngine.entriesForBuild(
+                isRelease = true,
+                inflectEligible = true,
+            ).contains(VoiceOutputEngine.InflectMicroExperimental),
+        )
+    }
+
+    @Test
+    fun `release ineligible catalogue excludes Inflect`() {
+        assertFalse(
+            VoiceOutputEngine.entriesForBuild(
+                isRelease = true,
+                inflectEligible = false,
+            ).contains(VoiceOutputEngine.InflectMicroExperimental),
+        )
+    }
+
+    @Test
+    fun `release catalogue excludes Kokoro and other debug engines`() {
+        val engines = VoiceOutputEngine.entriesForBuild(
+            isRelease = true,
+            inflectEligible = true,
+        )
+
+        assertFalse(engines.contains(VoiceOutputEngine.KokoroExperimental))
+    }
+
+    @Test
+    fun `debug catalogue retains explicit experimental engines`() {
+        val engines = VoiceOutputEngine.entriesForBuild(
+            isRelease = false,
+            inflectEligible = false,
+        )
+
+        assertTrue(engines.contains(VoiceOutputEngine.KokoroExperimental))
+        assertTrue(engines.contains(VoiceOutputEngine.InflectMicroExperimental))
+    }
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceOutputEngineTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceOutputEngineTest.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.core.voice
 
+import com.kernel.ai.core.inference.hardware.HardwareTier
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -16,11 +17,15 @@ class VoiceOutputEngineTest {
     }
 
     @Test
-    fun `release ineligible catalogue excludes Inflect`() {
+    fun `flagship wrong ABI catalogue excludes Inflect`() {
+        val inflectEligible = InflectMicroModelSpec.isReleaseEligible(
+            tier = HardwareTier.FLAGSHIP,
+            supportedAbis = arrayOf("x86_64"),
+        )
         assertFalse(
             VoiceOutputEngine.entriesForBuild(
                 isRelease = true,
-                inflectEligible = false,
+                inflectEligible = inflectEligible,
             ).contains(VoiceOutputEngine.InflectMicroExperimental),
         )
     }
@@ -44,5 +49,35 @@ class VoiceOutputEngineTest {
 
         assertTrue(engines.contains(VoiceOutputEngine.KokoroExperimental))
         assertTrue(engines.contains(VoiceOutputEngine.InflectMicroExperimental))
+    }
+
+    @Test
+    fun `flagship arm64 support is release eligible`() {
+        assertTrue(
+            InflectMicroModelSpec.isReleaseEligible(
+                tier = HardwareTier.FLAGSHIP,
+                supportedAbis = arrayOf("arm64-v8a"),
+            ),
+        )
+    }
+
+    @Test
+    fun `flagship non-arm64 support is not release eligible`() {
+        assertFalse(
+            InflectMicroModelSpec.isReleaseEligible(
+                tier = HardwareTier.FLAGSHIP,
+                supportedAbis = arrayOf("x86_64"),
+            ),
+        )
+    }
+
+    @Test
+    fun `mid-range arm64 support is not release eligible`() {
+        assertFalse(
+            InflectMicroModelSpec.isReleaseEligible(
+                tier = HardwareTier.MID_RANGE,
+                supportedAbis = arrayOf("arm64-v8a"),
+            ),
+        )
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceOutputPreferencesTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceOutputPreferencesTest.kt
@@ -48,4 +48,40 @@ class VoiceOutputPreferencesTest {
             ),
         )
     }
+
+    @Test
+    fun `resolveForBuild preserves Inflect for eligible release device`() {
+        assertEquals(
+            VoiceOutputEngine.InflectMicroExperimental,
+            VoiceOutputEngine.resolveForBuild(
+                value = VoiceOutputEngine.InflectMicroExperimental.name,
+                isRelease = true,
+                inflectEligible = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `resolveForBuild demotes persisted Inflect on ineligible release device`() {
+        assertEquals(
+            VoiceOutputEngine.AndroidTts,
+            VoiceOutputEngine.resolveForBuild(
+                value = VoiceOutputEngine.InflectMicroExperimental.name,
+                isRelease = true,
+                inflectEligible = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `resolveForBuild demotes persisted Kokoro in release`() {
+        assertEquals(
+            VoiceOutputEngine.AndroidTts,
+            VoiceOutputEngine.resolveForBuild(
+                value = VoiceOutputEngine.KokoroExperimental.name,
+                isRelease = true,
+                inflectEligible = true,
+            ),
+        )
+    }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceOutputPreferencesTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceOutputPreferencesTest.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.core.voice
 
+import com.kernel.ai.core.inference.hardware.HardwareTier
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -51,24 +52,32 @@ class VoiceOutputPreferencesTest {
 
     @Test
     fun `resolveForBuild preserves Inflect for eligible release device`() {
+        val inflectEligible = InflectMicroModelSpec.isReleaseEligible(
+            tier = HardwareTier.FLAGSHIP,
+            supportedAbis = arrayOf("arm64-v8a"),
+        )
         assertEquals(
             VoiceOutputEngine.InflectMicroExperimental,
             VoiceOutputEngine.resolveForBuild(
                 value = VoiceOutputEngine.InflectMicroExperimental.name,
                 isRelease = true,
-                inflectEligible = true,
+                inflectEligible = inflectEligible,
             ),
         )
     }
 
     @Test
-    fun `resolveForBuild demotes persisted Inflect on ineligible release device`() {
+    fun `resolveForBuild demotes persisted Inflect on flagship wrong ABI`() {
+        val inflectEligible = InflectMicroModelSpec.isReleaseEligible(
+            tier = HardwareTier.FLAGSHIP,
+            supportedAbis = arrayOf("x86_64"),
+        )
         assertEquals(
             VoiceOutputEngine.AndroidTts,
             VoiceOutputEngine.resolveForBuild(
                 value = VoiceOutputEngine.InflectMicroExperimental.name,
                 isRelease = true,
-                inflectEligible = false,
+                inflectEligible = inflectEligible,
             ),
         )
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -1015,27 +1015,27 @@ private fun VoiceScreenContent(
                 val inflectActive =
                     uiState.selectedOutputEngine == VoiceOutputEngine.InflectMicroExperimental
                 Text(
-                    text = "Inflect Micro debug model",
+                    text = "Inflect Micro model",
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
                 VoiceInfoCard(
                     title = if (inflectActive) {
-                        "Inflect Micro (Debug) is active"
+                        "Inflect Micro is active"
                     } else {
-                        "Inflect Micro (Debug) is available"
+                        "Inflect Micro is available"
                     },
                     message = if (inflectActive) {
-                        "This debug-only path uses the selected Sherpa eSpeak frontend and Inflect Micro model bundle. It remains available only while the model bundle and selected Sherpa voice pack are downloaded."
+                        "This higher-quality local path uses the selected Sherpa eSpeak frontend and Inflect Micro model bundle. It remains available while the model bundle and selected Sherpa voice pack are downloaded."
                     } else {
-                        "Download Inflect Micro and the selected Sherpa voice pack to enable this debug-only quality path."
+                        "Download Inflect Micro and the selected Sherpa voice pack to enable this higher-quality local speech path."
                     },
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
                 ModelCardCompact(
-                    title = "Inflect Micro (Debug)",
-                    description = "Debug-only local TTS model; uses the selected Sherpa voice pack for its frontend.",
+                    title = "Inflect Micro",
+                    description = "Higher-quality local TTS model; uses the selected Sherpa voice pack for its frontend.",
                     state = inflectModelState,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
@@ -1534,7 +1534,7 @@ private fun VoiceOutputSelectionCard(
         VoiceOutputEngine.KokoroExperimental ->
             "Kokoro (Experimental) is currently the only engine that will speak. Android TTS is inactive until you switch back."
         VoiceOutputEngine.InflectMicroExperimental ->
-            "Inflect Micro (Debug) is selected. It uses the downloaded Inflect graphs and Sherpa eSpeak data, with Android TTS fallback if setup is unavailable."
+            "Inflect Micro is selected. It uses the downloaded Inflect graphs and Sherpa eSpeak data, with Android TTS fallback if setup is unavailable."
     }
 
     VoiceInfoCard(

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
 import com.kernel.ai.core.voice.AndroidNativeRecognitionAvailability
+import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
+import com.kernel.ai.core.inference.hardware.HardwareTier
 import com.kernel.ai.core.voice.SherpaKokoroVoice
 import com.kernel.ai.core.voice.InflectMicroModelSpec
 import com.kernel.ai.core.voice.SherpaPiperVoice
@@ -98,7 +100,7 @@ data class VoiceUiState(
     val isWakeWordModelAvailable: Boolean = false,
     /** Wake word confidence threshold in [0, 1]. Reflects [WakeWordPreferences.confidenceThreshold]. */
     val wakeWordThreshold: Float = WAKE_WORD_DEFAULT_THRESHOLD,
-    // ── Debug-only Inflect Micro model pair ───────────────────────────────────
+    // ── Inflect Micro model pair ─────────────────────────────────────────────
     val inflectMicroStates: Map<KernelModel, DownloadState> = emptyMap(),
     val inflectMicroAvailability: ModelAvailabilityState =
         ModelAvailabilityState.NotDisplayed,
@@ -206,10 +208,13 @@ class VoiceViewModel @Inject constructor(
     private val wakeWordPreferences: WakeWordPreferences,
     private val wakeWordDetector: WakeWordDetector,
     private val modelDownloadManager: ModelDownloadManager,
+    private val hardwareProfileDetector: HardwareProfileDetector,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
     private val isReleaseBuild: Boolean =
         (context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) == 0
+    private val inflectReleaseEligible: Boolean =
+        hardwareProfileDetector.profile.tier == HardwareTier.FLAGSHIP
     private val visibleSherpaVoices: List<SherpaPiperVoice> =
         SherpaPiperVoice.entriesForBuild(isReleaseBuild)
     private val inflectModels: List<KernelModel> =
@@ -221,7 +226,10 @@ class VoiceViewModel @Inject constructor(
     private var inflectModelDownloadStatesLoaded = false
     private val _uiState = MutableStateFlow(
         VoiceUiState(
-            availableOutputEngines = VoiceOutputEngine.entriesForBuild(isReleaseBuild),
+            availableOutputEngines = VoiceOutputEngine.entriesForBuild(
+                isRelease = isReleaseBuild,
+                inflectEligible = inflectReleaseEligible,
+            ),
             sherpaVoices = visibleSherpaVoices.map { voice ->
                 SherpaVoiceRowUiState(voice = voice)
             },
@@ -254,7 +262,10 @@ class VoiceViewModel @Inject constructor(
         viewModelScope.launch {
             voiceOutputPreferences.selectedEngine.collect { engine ->
                 val effectiveEngine = engine.takeIf {
-                    it in VoiceOutputEngine.entriesForBuild(isReleaseBuild)
+                    it in VoiceOutputEngine.entriesForBuild(
+                        isRelease = isReleaseBuild,
+                        inflectEligible = inflectReleaseEligible,
+                    )
                 } ?: VoiceOutputEngine.AndroidTts
                 _uiState.update { it.copy(selectedOutputEngine = effectiveEngine) }
                 if (effectiveEngine != engine) {
@@ -580,7 +591,11 @@ class VoiceViewModel @Inject constructor(
     }
 
     fun setVoiceOutputEngine(engine: VoiceOutputEngine) {
-        if (engine !in VoiceOutputEngine.entriesForBuild(isReleaseBuild)) return
+        if (engine !in VoiceOutputEngine.entriesForBuild(
+                isRelease = isReleaseBuild,
+                inflectEligible = inflectReleaseEligible,
+            )
+        ) return
         if (engine == VoiceOutputEngine.InflectMicroExperimental &&
             !_uiState.value.isInflectMicroReady
         ) {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
 import com.kernel.ai.core.voice.AndroidNativeRecognitionAvailability
 import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
-import com.kernel.ai.core.inference.hardware.HardwareTier
 import com.kernel.ai.core.voice.SherpaKokoroVoice
 import com.kernel.ai.core.voice.InflectMicroModelSpec
 import com.kernel.ai.core.voice.SherpaPiperVoice
@@ -214,7 +213,7 @@ class VoiceViewModel @Inject constructor(
     private val isReleaseBuild: Boolean =
         (context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) == 0
     private val inflectReleaseEligible: Boolean =
-        hardwareProfileDetector.profile.tier == HardwareTier.FLAGSHIP
+        InflectMicroModelSpec.isReleaseEligible(hardwareProfileDetector.profile.tier)
     private val visibleSherpaVoices: List<SherpaPiperVoice> =
         SherpaPiperVoice.entriesForBuild(isReleaseBuild)
     private val inflectModels: List<KernelModel> =

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -3,6 +3,8 @@ package com.kernel.ai.feature.settings
 import android.content.Context
 import com.kernel.ai.core.inference.download.DownloadState
 import com.kernel.ai.core.inference.download.KernelModel
+import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
+import com.kernel.ai.core.inference.hardware.HardwareTier
 import com.kernel.ai.core.inference.download.ModelDownloadManager
 import com.kernel.ai.core.voice.WakeWordDetector
 import com.kernel.ai.core.voice.WakeWordPreferences
@@ -53,6 +55,7 @@ class VoiceViewModelTest {
     private val wakeWordPreferences: WakeWordPreferences = mockk(relaxed = true)
     private val wakeWordDetector: WakeWordDetector = mockk()
     private val modelDownloadManager: ModelDownloadManager = mockk()
+    private val hardwareProfileDetector: HardwareProfileDetector = mockk(relaxed = true)
     private val context: Context = mockk(relaxed = true)
     private val heyJandalEnabled = MutableStateFlow(false)
     private val wakeWordThreshold = MutableStateFlow(0.80f)
@@ -129,6 +132,7 @@ class VoiceViewModelTest {
         every { wakeWordDetector.isAvailable } returns false
         every { sherpaVoicePackDownloadManager.kokoroDownloadStates } returns kokoroDownloadStates
         every { modelDownloadManager.downloadStates } returns modelDownloadStates
+        every { hardwareProfileDetector.profile.tier } returns HardwareTier.FLAGSHIP
         every { modelDownloadManager.startDownload(any()) } just Runs
         every { modelDownloadManager.cancelDownload(any()) } just Runs
         every { sherpaVoicePackDownloadManager.startDownload(any()) } just Runs
@@ -148,6 +152,7 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            hardwareProfileDetector,
             context,
         )
     }
@@ -205,6 +210,7 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            hardwareProfileDetector,
             context,
         )
         testDispatcher.scheduler.advanceUntilIdle()
@@ -234,6 +240,7 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            hardwareProfileDetector,
             context,
         )
         testDispatcher.scheduler.advanceUntilIdle()
@@ -263,6 +270,7 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            hardwareProfileDetector,
             context,
         )
         testDispatcher.scheduler.advanceUntilIdle()
@@ -369,6 +377,7 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            hardwareProfileDetector,
             releaseContext,
         )
 
@@ -381,7 +390,7 @@ class VoiceViewModelTest {
         )
     }
     @Test
-    fun `debug builds expose Inflect while release builds hide it`() = runTest {
+    fun `eligible release builds expose Inflect while debug builds expose all engines`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(
@@ -400,11 +409,12 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            hardwareProfileDetector,
             releaseContext,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertFalse(
+        assertTrue(
             releaseViewModel.uiState.value.availableOutputEngines.contains(
                 VoiceOutputEngine.InflectMicroExperimental,
             ),
@@ -678,6 +688,7 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            hardwareProfileDetector,
             releaseContext,
         )
         testDispatcher.scheduler.advanceUntilIdle()
@@ -724,6 +735,7 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            hardwareProfileDetector,
             releaseContext,
         )
         testDispatcher.scheduler.advanceUntilIdle()

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -390,7 +390,7 @@ class VoiceViewModelTest {
         )
     }
     @Test
-    fun `eligible release builds expose Inflect while debug builds expose all engines`() = runTest {
+    fun `release builds mirror shared Inflect eligibility while debug builds expose all engines`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(
@@ -414,7 +414,8 @@ class VoiceViewModelTest {
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertTrue(
+        assertEquals(
+            InflectMicroModelSpec.isReleaseEligible(HardwareTier.FLAGSHIP),
             releaseViewModel.uiState.value.availableOutputEngines.contains(
                 VoiceOutputEngine.InflectMicroExperimental,
             ),

--- a/scripts/sherpa-onnx-v1.13.0-inflect-build.md
+++ b/scripts/sherpa-onnx-v1.13.0-inflect-build.md
@@ -1,8 +1,8 @@
 # Inflect Micro Sherpa frontend build provenance
 
-This is the debug-only Sherpa-ONNX rebuild used by issue #1475. It is not a
-production dependency. The checked-in patch is
-`scripts/sherpa-onnx-v1.13.0-inflect.patch`.
+This is the pinned Sherpa-ONNX rebuild used by the Inflect Micro release
+voice path (#1510), originally produced and validated by issue #1475. The
+checked-in patch is `scripts/sherpa-onnx-v1.13.0-inflect.patch`.
 
 ## Exact inputs
 
@@ -15,18 +15,24 @@ production dependency. The checked-in patch is
 - ABI: `arm64-v8a`
 - Android platform: `android-21`
 - CMake: 4.4.2
-- Custom debug AAR: `third_party/sherpa-onnx/sherpa-onnx-1.13.0-noort-inflect.aar`
-- Custom debug AAR SHA-256:
+- Custom Inflect-enabled AAR used by debug and release:
+  `third_party/sherpa-onnx/sherpa-onnx-1.13.0-noort-inflect.aar`
+- Custom Inflect-enabled AAR SHA-256:
   `cf35bb1999586fb6c2f5746bfc556504a6ee8407e02ed3047f1274fa8d2008dc`
-- Stock release AAR: `third_party/sherpa-onnx/sherpa-onnx-1.13.0-noort.aar`
-- Stock release AAR SHA-256:
+- Stock no-ORT AAR retained as a byte-level comparison/reference artifact:
+  `third_party/sherpa-onnx/sherpa-onnx-1.13.0-noort.aar`
+- Stock reference AAR SHA-256:
   `233b6b19fb5515c047adebde0dbf873a9fd8ac23f1d2ff6a3701f7ffc923b23c`
 - arm64 JNI SHA-256 before AAR packaging:
   `3fa47f550edfe2bebaa8f6d219cfc2c62c38b77284f124b79f43701a535d4eac`
 
-The custom AAR is checked in under the ignored `third_party/sherpa-onnx/`
-directory with an explicit force-add. The stock AAR remains the release
-runtime artifact; the custom AAR is debug-only.
+The app uses the custom AAR for both debug and release so the release-visible
+Inflect controller resolves the existing narrow JNI symbol. The native binary
+is unchanged by #1510; this issue only promotes the already-validated artifact
+to the supported release configuration.
+
+Both AARs remain checked in under the ignored `third_party/sherpa-onnx/`
+directory with explicit force-adds.
 
 ## Rebuild
 


### PR DESCRIPTION
## Summary

Closes #1510.

- Ships the existing Inflect-enabled Sherpa v1.13.0 AAR in both debug and release variants.
- Makes Inflect Micro release-visible only on the validated high-memory hardware class (`HardwareTier.FLAGSHIP`, the existing >=10 GB RAM tier).
- Keeps the intentional release catalogue to Android TTS, release-visible Sherpa Piper voices, and Inflect Micro; Kokoro and other debug-only engines remain hidden.
- Normalizes persisted hidden/ineligible engine selections to Android TTS and persists the migration.
- Preserves the existing Inflect model-pair download/readiness lifecycle and Android fallback.
- Recovers Android TTS from unavailable regional locales (for example `en-AU`) through installed language fallbacks without writing global device settings.
- Reuses the checked-in native artifact without changing native source or adding another eSpeak runtime.

## Evidence

- `:core:voice:testDebugUnitTest :feature:settings:testDebugUnitTest` — passed (268 voice tests; settings suite passed).
- `:app:assembleDebug :app:assembleRelease` — passed.
- Release APK arm64 Sherpa JNI payload matches the pinned Inflect AAR payload (`3fa47f550edfe2bebaa8f6d219cfc2c62c38b77284f124b79f43701a535d4eac`).
- Release-equivalent, debug-signed APK smoke on S23 Ultra: app reports `FLAGSHIP`; Voice settings exposes `Inflect Micro` and retains Android TTS/Sherpa fallback. Model download remains explicit; no auto-download was triggered.
- Release-equivalent, debug-signed APK smoke on S21: Voice settings exposes Android TTS fallback and does not expose Inflect Micro or Kokoro.
- Honor validation is unchanged from #1485: this PR does not rebuild or alter the native runtime, so the prior manual Honor pass remains the applicable evidence.

## Deliberate non-scope

- No Kokoro or Qwen3-TTS release exposure.
- No second eSpeak/native implementation and no legal/provenance change beyond documenting the existing pinned artifact.
- No full benchmark rerun. Journey 8 durable validation remains a post-merge release-candidate follow-up through the existing `test-results` evidence pipeline.

Do not merge — wait for review.