### PR TITLE
fix(#1513): guard Android 16 microphone FGS startup

### DIFF
--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -475,6 +475,27 @@ private const val CHANNEL_ID = "kernel_wake_word"
 private const val NOTIFICATION_ID = 9_500
 
 /**
+ * Promote the service to the microphone foreground state without allowing Android's
+ * while-in-use eligibility failure to escape the service start callback.
+ *
+ * The callback is deliberately limited to the [startForeground] call site so unrelated
+ * service defects are not suppressed. The caller decides how to stop and diagnose a
+ * rejected start.
+ */
+internal fun tryPromoteToMicrophoneForeground(
+    promote: () -> Unit,
+    onRejected: (SecurityException) -> Unit,
+): Boolean {
+    return try {
+        promote()
+        true
+    } catch (error: SecurityException) {
+        onRejected(error)
+        false
+    }
+}
+
+/**
  * Foreground service that keeps [WakeWordDetector] running continuously.
  *
  * Started when "Listen for Hey Jandal" is enabled in Settings → Voice.
@@ -561,7 +582,24 @@ class WakeWordService : Service() {
             return START_NOT_STICKY
         }
 
-        startForeground(NOTIFICATION_ID, buildNotification())
+        val foregroundStarted = tryPromoteToMicrophoneForeground(
+            promote = { startForeground(NOTIFICATION_ID, buildNotification()) },
+            onRejected = { error ->
+                Log.w(
+                    TAG,
+                    "WakeWordService: microphone FGS promotion not allowed; " +
+                        "will retry when the app is foreground (${error.message})",
+                )
+                AcousticJournalBridge.record(
+                    type = AcousticEventType.SERVICE_ERROR,
+                    metadata = { mapOf("category" to "microphone_fgs_start_not_allowed") },
+                )
+            },
+        )
+        if (!foregroundStarted) {
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
 
         if (!wakeWordDetector.isAvailable) {
             Log.i(TAG, "WakeWordService: model not yet available (#984) — stopping")

--- a/app/src/test/java/com/kernel/ai/assistant/WakeWordServiceStartupTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/WakeWordServiceStartupTest.kt
@@ -1,0 +1,41 @@
+package com.kernel.ai.assistant
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WakeWordServiceStartupTest {
+
+    @Test
+    fun `microphone FGS rejection becomes a non-start result`() {
+        val rejection = SecurityException("microphone FGS start not allowed")
+        var rejected: SecurityException? = null
+
+        val started = tryPromoteToMicrophoneForeground(
+            promote = {
+                throw rejection
+            },
+            onRejected = { error -> rejected = error },
+        )
+
+        assertFalse(started)
+        assertSame(rejection, rejected)
+    }
+
+    @Test
+    fun `successful microphone FGS promotion remains a start result`() {
+        var promotionCount = 0
+        var rejectionCount = 0
+
+        val started = tryPromoteToMicrophoneForeground(
+            promote = { promotionCount++ },
+            onRejected = { rejectionCount++ },
+        )
+
+        assertTrue(started)
+        assertEquals(1, promotionCount)
+        assertEquals(0, rejectionCount)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1513.

Android 16 can allow `startForegroundService()` from the application-start path but reject microphone foreground promotion when the app is not visibly eligible. The uncaught `SecurityException` killed the process before the existing `MainActivity.onResume` retry could run.

This change:

- guards only the `startForeground(...)` promotion call;
- logs the rejected promotion and records `microphone_fgs_start_not_allowed`;
- stops that service start with `START_NOT_STICKY`;
- leaves the Hey Jandal preference unchanged so the existing visible-activity retry remains authoritative;
- avoids detector/model initialization after a rejected promotion.

No manifest, permission, application collector, detector, TTS, or wake-word tuning changes.

## Verification

- `./gradlew :app:testDebugUnitTest --tests com.kernel.ai.assistant.WakeWordServiceStartupTest --no-daemon`
- `./gradlew :app:testDebugUnitTest --tests 'com.kernel.ai.assistant.*' --no-daemon`
- `./gradlew :app:testDebugUnitTest :core:voice:testDebugUnitTest :feature:settings:testDebugUnitTest :app:assembleDebug --no-daemon`
- Installed and exercised the debug APK on S23 Ultra (`SM-S918B`, API 36).
- Toggled Hey Jandal off/on in Voice settings.
- Revoked and restored `RECORD_AUDIO`; the service failed closed without a crash while revoked.
- Persisted-enabled cold launch reached a foreground service record (`startForegroundCount=1`, `isForeground=true`, microphone type `0x80`).
- Bounded post-launch scan: crash buffer empty; `fatal_or_androidruntime=0`; `anr=0`.

The connected-device harness cannot emit a real spoken phrase into the S23 Ultra microphone, so a manual audible “Hey Jandal” activation was not claimed as automated evidence.

Do not merge — wait for review.