### PR TITLE
fix(voice): safely fall back from Inflect streaming synthesis

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
@@ -162,7 +162,38 @@ class FallbackVoiceOutputController @Inject constructor(
         val warmUpResult = inflect.warmUp()
         if (warmUpResult !is VoiceOutputResult.Unavailable) {
             activate(inflect)
-            return inflect.openStreamingSession(request)
+            val inflectSession = inflect.openStreamingSession(request)
+            return object : VoiceOutputStreamingSession {
+                private val bufferedText = StringBuilder()
+                private var isClosed = false
+
+                override suspend fun append(
+                    text: String,
+                    isFinal: Boolean,
+                ): VoiceOutputResult {
+                    if (isClosed) return VoiceOutputResult.Spoken
+                    if (text.isNotBlank()) bufferedText.append(text)
+                    if (!isFinal) return inflectSession.append(text, isFinal = false)
+
+                    isClosed = true
+                    val inflectResult = inflectSession.append(text, isFinal = true)
+                    if (inflectResult !is VoiceOutputResult.Unavailable) return inflectResult
+
+                    val finalText = bufferedText.toString().trim()
+                    if (finalText.isBlank()) return inflectResult
+                    Log.w(
+                        TAG,
+                        "Inflect Micro TTS streaming synthesis failed (${inflectResult.message}); " +
+                            "routing to Android TTS fallback.",
+                    )
+                    activate(androidTts)
+                    val androidWarmUpResult = androidTts.warmUp()
+                    if (androidWarmUpResult is VoiceOutputResult.Unavailable) {
+                        return androidWarmUpResult
+                    }
+                    return androidTts.speak(request.copy(text = finalText))
+                }
+            }
         }
         Log.i(
             TAG,

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/FallbackVoiceOutputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/FallbackVoiceOutputControllerTest.kt
@@ -249,6 +249,125 @@ class FallbackVoiceOutputControllerTest {
         coVerify(exactly = 0) { androidTts.speak(any()) }
     }
     @Test
+    fun `streaming Inflect success does not use Android TTS`() = runTest(dispatcher) {
+        selectedEngine.value = VoiceOutputEngine.InflectMicroExperimental
+        val request = VoiceSpeakRequest("Inflect stream")
+        val inflectSession = mockk<VoiceOutputStreamingSession>()
+        coEvery { inflect.warmUp() } returns VoiceOutputResult.Spoken
+        coEvery { inflect.openStreamingSession(request) } returns inflectSession
+        coEvery { inflectSession.append("Inflect stream", true) } returns VoiceOutputResult.Spoken
+
+        val session = buildController().openStreamingSession(request)
+        val result = session.append("Inflect stream", isFinal = true)
+
+        assertEquals(VoiceOutputResult.Spoken, result)
+        coVerify(exactly = 1) { inflectSession.append("Inflect stream", true) }
+        coVerify(exactly = 0) { androidTts.warmUp() }
+        coVerify(exactly = 0) { androidTts.speak(any()) }
+    }
+
+    @Test
+    fun `streaming Inflect final failure speaks the full buffered response with Android TTS`() =
+        runTest(dispatcher) {
+            selectedEngine.value = VoiceOutputEngine.InflectMicroExperimental
+            val request = VoiceSpeakRequest(text = "")
+            val inflectSession = mockk<VoiceOutputStreamingSession>()
+            val fullText = "The sky appears blue due to Rayleigh scattering."
+            coEvery { inflect.warmUp() } returns VoiceOutputResult.Spoken
+            coEvery { inflect.openStreamingSession(request) } returns inflectSession
+            coEvery { inflectSession.append("The sky appears blue due to ", false) } returns
+                VoiceOutputResult.Spoken
+            coEvery { inflectSession.append("Rayleigh scattering.", true) } returns
+                VoiceOutputResult.Unavailable("phonemizer failed")
+            coEvery { androidTts.warmUp() } returns VoiceOutputResult.Spoken
+            coEvery { androidTts.speak(request.copy(text = fullText)) } returns VoiceOutputResult.Spoken
+
+            val session = buildController().openStreamingSession(request)
+            session.append("The sky appears blue due to ", isFinal = false)
+            val result = session.append("Rayleigh scattering.", isFinal = true)
+
+            assertEquals(VoiceOutputResult.Spoken, result)
+            coVerify(exactly = 1) { androidTts.warmUp() }
+            coVerify(exactly = 1) { androidTts.speak(request.copy(text = fullText)) }
+            coVerify(exactly = 1) { inflectSession.append("The sky appears blue due to ", false) }
+            coVerify(exactly = 1) { inflectSession.append("Rayleigh scattering.", true) }
+            assertEquals(VoiceOutputResult.Spoken, session.append("ignored", isFinal = true))
+            coVerify(exactly = 1) { androidTts.warmUp() }
+        }
+
+    @Test
+    fun `streaming Inflect warmUp failure still uses Android TTS session`() = runTest(dispatcher) {
+        selectedEngine.value = VoiceOutputEngine.InflectMicroExperimental
+        val request = VoiceSpeakRequest("Fallback stream")
+        val androidSession = mockk<VoiceOutputStreamingSession>()
+        coEvery { inflect.warmUp() } returns VoiceOutputResult.Unavailable("models missing")
+        coEvery { androidTts.warmUp() } returns VoiceOutputResult.Spoken
+        coEvery { androidTts.openStreamingSession(request) } returns androidSession
+
+        val result = buildController().openStreamingSession(request)
+
+        assertEquals(androidSession, result)
+        coVerify(exactly = 1) { androidTts.warmUp() }
+        coVerify(exactly = 1) { androidTts.openStreamingSession(request) }
+        coVerify(exactly = 0) { inflect.openStreamingSession(any()) }
+    }
+
+    @Test
+    fun `streaming Inflect failure returns Android Unavailable when fallback warmUp fails`() =
+        runTest(dispatcher) {
+            selectedEngine.value = VoiceOutputEngine.InflectMicroExperimental
+            val request = VoiceSpeakRequest(text = "")
+            val inflectSession = mockk<VoiceOutputStreamingSession>()
+            val androidUnavailable = VoiceOutputResult.Unavailable("Android TTS unavailable")
+            coEvery { inflect.warmUp() } returns VoiceOutputResult.Spoken
+            coEvery { inflect.openStreamingSession(request) } returns inflectSession
+            coEvery { inflectSession.append("Response text", true) } returns
+                VoiceOutputResult.Unavailable("phonemizer failed")
+            coEvery { androidTts.warmUp() } returns androidUnavailable
+
+            val session = buildController().openStreamingSession(request)
+            val result = session.append("Response text", isFinal = true)
+
+            assertEquals(androidUnavailable, result)
+            coVerify(exactly = 1) { androidTts.warmUp() }
+            coVerify(exactly = 0) { androidTts.speak(any()) }
+        }
+
+    @Test
+    fun `streaming Inflect failure does not change selected engine for the next turn`() =
+        runTest(dispatcher) {
+            selectedEngine.value = VoiceOutputEngine.InflectMicroExperimental
+            val request = VoiceSpeakRequest(text = "")
+            val firstInflectSession = mockk<VoiceOutputStreamingSession>()
+            val secondInflectSession = mockk<VoiceOutputStreamingSession>()
+            coEvery { inflect.warmUp() } returns VoiceOutputResult.Spoken
+            coEvery { inflect.openStreamingSession(request) } returnsMany
+                listOf(firstInflectSession, secondInflectSession)
+            coEvery { firstInflectSession.append("First response", true) } returns
+                VoiceOutputResult.Unavailable("phonemizer failed")
+            coEvery { secondInflectSession.append("Second response", true) } returns
+                VoiceOutputResult.Spoken
+            coEvery { androidTts.warmUp() } returns VoiceOutputResult.Spoken
+            coEvery { androidTts.speak(request.copy(text = "First response")) } returns
+                VoiceOutputResult.Spoken
+
+            val controller = buildController()
+            val firstSession = controller.openStreamingSession(request)
+            assertEquals(
+                VoiceOutputResult.Spoken,
+                firstSession.append("First response", isFinal = true),
+            )
+            val secondSession = controller.openStreamingSession(request)
+            val secondResult = secondSession.append("Second response", isFinal = true)
+
+            assertEquals(VoiceOutputResult.Spoken, secondResult)
+            assertEquals(VoiceOutputEngine.InflectMicroExperimental, selectedEngine.value)
+            coVerify(exactly = 2) { inflect.warmUp() }
+            coVerify(exactly = 2) { inflect.openStreamingSession(request) }
+            coVerify(exactly = 1) { androidTts.speak(any()) }
+        }
+
+    @Test
     fun `stop stops all controllers defensively`() = runTest(dispatcher) {
         every { sherpa.stop() } just runs
         every { inflect.stop() } just runs


### PR DESCRIPTION
Closes #1517

## Root cause

`FallbackVoiceOutputController.openInflectStreamingSessionOrFallback()` only fell back when Inflect warm-up was unavailable. After a successful warm-up it returned Inflect's raw buffered streaming session, so an `Unavailable` result from the final synthesis append went directly to `ChatViewModel` instead of the existing Android TTS fallback boundary.

## Fix

The existing fallback boundary now wraps only the Inflect streaming session. It retains the same streamed chunks locally, lets Inflect attempt the final buffered synthesis, and on final `Unavailable` activates Android TTS, warms it, and speaks the complete accumulated response once. Activation stops inactive Inflect state through the existing controller logic. Android unavailability is returned unchanged; the selected Inflect preference is never migrated.

The intermittent Inflect phonemizer/synthesis defect is intentionally unchanged. No ChatViewModel, Inflect frontend/runtime, Kokoro, Qwen3-TTS, or TTS architecture changes were made.

## Tests

- `:core:voice:testDebugUnitTest` — PASS
- `:feature:chat:testDebugUnitTest` — PASS
- `:app:testDebugUnitTest` — PASS
- `:app:assembleDebug` — PASS
- Focused regression coverage proves Inflect streaming success, final-synthesis fallback with full buffered text, warm-up fallback, Android fallback unavailability, fallback-once/closed-session behavior, and subsequent Inflect turn with preference unchanged.

## S23 Ultra validation

Candidate APK was installed non-destructively with `adb install -r` on Samsung Galaxy S23 Ultra (SM-S918B, Android API 36); app data and downloaded models were preserved. The bounded voice run could not start because the existing #1513 Android 16 microphone foreground-service crash still occurs during launch in `WakeWordService.onStartCommand` (`SecurityException` from `startForeground`, `FATAL EXCEPTION` x2). Per scope, I did not continue the aborted Journey 8 validation or apply a workaround. Therefore no Inflect control, streaming attempt, Android fallback observation, Stop check, or subsequent physical turn is claimed for this PR.

Physical log scan for the attempted launch: `fatal_or_androidruntime=2`, `anr=0`; the two fatal markers are the pre-existing #1513 crash, not this change. Physical validation must be rerun after #1513 is fixed.

Journey 8 remains pending/blocked post-merge; #1447 and #1014 remain unchanged. Do not merge — wait for review.