### PR TITLE
fix(1418): filter malformed thinking close marker

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -101,6 +101,8 @@ internal fun checkGpuRestartNeeded(
 private const val MIN_AVAIL_MEM_FOR_GPU_BYTES = 2L * 1024 * 1024 * 1024 // 2 GB absolute floor — catches 4-6 GB devices; 8 GB devices pass this
 internal const val THINKING_CHANNEL_HEADER = "<|channel>thought"
 internal const val THINKING_CLOSE_MARKER = "<channel|>"
+/** Exact malformed close marker observed in the S21 Journey 1 regression. */
+internal const val MALFORMED_THINK_CLOSE_MARKER = "</|/think|>"
 
 @OptIn(ExperimentalApi::class)
 internal inline fun <T> withSpeculativeDecodingEnabledForInit(enabled: Boolean, block: () -> T): T {
@@ -544,28 +546,44 @@ internal class ThinkingStreamStateMachine(
         )
 
     private fun findExpectedClose(text: String, channel: Boolean): MarkerMatch? =
-        if (channel) findChannelClose(text) else {
+        if (channel) {
+            findChannelClose(text)
+        } else {
             for (index in text.indices) {
-                if (text.startsWith(THINK_CLOSE_MARKER, index)) {
-                    return MarkerMatch(
-                        type = MarkerType.THINK_CLOSE,
-                        start = index,
-                        endExclusive = index + THINK_CLOSE_MARKER.length,
-                        complete = true,
-                    )
-                }
-                val suffix = text.substring(index)
-                if (suffix.length >= 1 && THINK_CLOSE_MARKER.startsWith(suffix)) {
-                    return MarkerMatch(
-                        type = MarkerType.THINK_CLOSE,
-                        start = index,
-                        endExclusive = text.length,
-                        complete = false,
-                    )
-                }
+                val close = findThinkClose(text, index) ?: continue
+                return close.copy(
+                    start = close.start + index,
+                    endExclusive = close.endExclusive + index,
+                )
             }
             null
         }
+
+    private fun findThinkClose(text: String, offset: Int = 0): MarkerMatch? {
+        val completeMarker = THINK_CLOSE_MARKERS.firstOrNull { text.startsWith(it, offset) }
+        if (completeMarker != null) {
+            return MarkerMatch(
+                type = MarkerType.THINK_CLOSE,
+                start = 0,
+                endExclusive = completeMarker.length,
+                complete = true,
+            )
+        }
+        val remainingLength = text.length - offset
+        val partialMarker = THINK_CLOSE_MARKERS.firstOrNull {
+            remainingLength >= 1 &&
+                remainingLength < it.length &&
+                it.regionMatches(0, text, offset, remainingLength)
+        }
+        return partialMarker?.let {
+            MarkerMatch(
+                type = MarkerType.THINK_CLOSE,
+                start = 0,
+                endExclusive = remainingLength,
+                complete = false,
+            )
+        }
+    }
 
     private fun findChannelClose(text: String): MarkerMatch? {
         for (index in text.indices) {
@@ -603,8 +621,13 @@ internal class ThinkingStreamStateMachine(
             if (includeThinkOpen && text.startsWith(THINK_OPEN_MARKER, index)) {
                 return MarkerMatch(MarkerType.THINK_OPEN, index, index + THINK_OPEN_MARKER.length, true)
             }
-            if (includeThinkClose && text.startsWith(THINK_CLOSE_MARKER, index)) {
-                return MarkerMatch(MarkerType.THINK_CLOSE, index, index + THINK_CLOSE_MARKER.length, true)
+            if (includeThinkClose) {
+                findThinkClose(text, index)?.let { close ->
+                    return close.copy(
+                        start = close.start + index,
+                        endExclusive = close.endExclusive + index,
+                    )
+                }
             }
             if (includeChannelOpen && text.startsWith(CHANNEL_OPEN_PREFIX, index)) {
                 return MarkerMatch(MarkerType.CHANNEL_OPEN, index, index + CHANNEL_OPEN_PREFIX.length, true)
@@ -621,7 +644,6 @@ internal class ThinkingStreamStateMachine(
             val suffix = text.substring(index)
             val partialType = when {
                 includeThinkOpen && suffix.length >= 1 && THINK_OPEN_MARKER.startsWith(suffix) -> MarkerType.THINK_OPEN
-                includeThinkClose && suffix.length >= 1 && THINK_CLOSE_MARKER.startsWith(suffix) -> MarkerType.THINK_CLOSE
                 includeChannelOpen && suffix.length >= 1 && CHANNEL_OPEN_PREFIX.startsWith(suffix) -> MarkerType.CHANNEL_OPEN
                 else -> null
             }
@@ -667,6 +689,7 @@ internal class ThinkingStreamStateMachine(
             .replace(thinkingHeader, "")
             .replace(THINK_OPEN_MARKER, "")
             .replace(THINK_CLOSE_MARKER, "")
+            .replace(MALFORMED_THINK_CLOSE_MARKER, "")
             .replace(closeMarker, "")
 
     private fun deletePrefix(target: StringBuilder, count: Int) {
@@ -687,12 +710,17 @@ internal class ThinkingStreamStateMachine(
         const val THINK_OPEN_MARKER = "<|think|>"
         const val THINK_CLOSE_MARKER = "<|/think|>"
         const val MAX_AMBIGUOUS_LENGTH = 256
+        val THINK_CLOSE_MARKERS = listOf(
+            THINK_CLOSE_MARKER,
+            MALFORMED_THINK_CLOSE_MARKER,
+        )
         val PROTOCOL_MARKERS = listOf(
             THINKING_CHANNEL_HEADER,
             CHANNEL_OPEN_PREFIX,
             CHANNEL_CLOSE_PREFIX + ">",
             THINK_OPEN_MARKER,
             THINK_CLOSE_MARKER,
+            MALFORMED_THINK_CLOSE_MARKER,
         )
     }
 }
@@ -715,6 +743,7 @@ private val PROTOCOL_MARKERS_FOR_BOUNDARY = listOf(
     "<channel|>",
     "<|think|>",
     "<|/think|>",
+    MALFORMED_THINK_CLOSE_MARKER,
     "<|/think",
     "<|think",
 )

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -103,6 +103,8 @@ internal const val THINKING_CHANNEL_HEADER = "<|channel>thought"
 internal const val THINKING_CLOSE_MARKER = "<channel|>"
 /** Exact malformed close marker observed in the S21 Journey 1 regression. */
 internal const val MALFORMED_THINK_CLOSE_MARKER = "</|/think|>"
+/** Truncated close-marker tail emitted by the same callback protocol. */
+internal const val TRUNCATED_THINK_CLOSE_MARKER = "|/think>"
 
 @OptIn(ExperimentalApi::class)
 internal inline fun <T> withSpeculativeDecodingEnabledForInit(enabled: Boolean, block: () -> T): T {
@@ -585,6 +587,31 @@ internal class ThinkingStreamStateMachine(
         }
     }
 
+    private fun findTruncatedThinkClose(text: String, offset: Int = 0): MarkerMatch? {
+        if (text.startsWith(TRUNCATED_THINK_CLOSE_MARKER, offset)) {
+            return MarkerMatch(
+                type = MarkerType.THINK_CLOSE,
+                start = 0,
+                endExclusive = TRUNCATED_THINK_CLOSE_MARKER.length,
+                complete = true,
+            )
+        }
+        val remainingLength = text.length - offset
+        return if (remainingLength >= 1 &&
+            remainingLength < TRUNCATED_THINK_CLOSE_MARKER.length &&
+            TRUNCATED_THINK_CLOSE_MARKER.regionMatches(0, text, offset, remainingLength)
+        ) {
+            MarkerMatch(
+                type = MarkerType.THINK_CLOSE,
+                start = 0,
+                endExclusive = remainingLength,
+                complete = false,
+            )
+        } else {
+            null
+        }
+    }
+
     private fun findChannelClose(text: String): MarkerMatch? {
         for (index in text.indices) {
             if (!text.startsWith(CHANNEL_CLOSE_PREFIX, index)) continue
@@ -623,6 +650,12 @@ internal class ThinkingStreamStateMachine(
             }
             if (includeThinkClose) {
                 findThinkClose(text, index)?.let { close ->
+                    return close.copy(
+                        start = close.start + index,
+                        endExclusive = close.endExclusive + index,
+                    )
+                }
+                findTruncatedThinkClose(text, index)?.let { close ->
                     return close.copy(
                         start = close.start + index,
                         endExclusive = close.endExclusive + index,
@@ -690,6 +723,7 @@ internal class ThinkingStreamStateMachine(
             .replace(THINK_OPEN_MARKER, "")
             .replace(THINK_CLOSE_MARKER, "")
             .replace(MALFORMED_THINK_CLOSE_MARKER, "")
+            .replace(TRUNCATED_THINK_CLOSE_MARKER, "")
             .replace(closeMarker, "")
 
     private fun deletePrefix(target: StringBuilder, count: Int) {
@@ -744,6 +778,7 @@ private val PROTOCOL_MARKERS_FOR_BOUNDARY = listOf(
     "<|think|>",
     "<|/think|>",
     MALFORMED_THINK_CLOSE_MARKER,
+    TRUNCATED_THINK_CLOSE_MARKER,
     "<|/think",
     "<|think",
 )

--- a/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
+++ b/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
@@ -133,6 +133,34 @@ class ThinkingStreamStateMachineTest {
     }
 
     @Test
+    fun `observed malformed think close marker never reaches visible response`() {
+        val result = collect(
+            ThinkingStreamStateMachine(),
+            listOf(
+                null to "Kia ora. Hello there. $MALFORMED_THINK_CLOSE_MARKER",
+                null to "How can I help?",
+            ),
+        )
+
+        assertEquals("", result.thinking)
+        assertEquals("Kia ora. Hello there. How can I help?", result.response)
+        assertVisibleDeltasAreSafe(result.responseDeltas)
+    }
+
+    @Test
+    fun `observed malformed think close marker split across callbacks is withheld`() {
+        val raw = "Kia ora. Hello! $MALFORMED_THINK_CLOSE_MARKER"
+        val result = collect(
+            ThinkingStreamStateMachine(),
+            raw.map { null to it.toString() },
+        )
+
+        assertEquals("", result.thinking)
+        assertEquals("Kia ora. Hello! ", result.response)
+        assertVisibleDeltasAreSafe(result.responseDeltas)
+    }
+
+    @Test
     fun `opening and closing markers split at every character boundary`() {
         listOf(
             "<|channel>thought\nReasoning<channel|>Final answer",

--- a/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
+++ b/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
@@ -119,6 +119,19 @@ class ThinkingStreamStateMachineTest {
         assertEquals("Final answer", result.response)
         assertVisibleDeltasAreSafe(result.responseDeltas)
     }
+    @Test
+    fun `channel thought followed by split think close stays out of response`() {
+        val raw = "<|channel>thought\nReasoning<channel|><|/think|>\nFinal answer"
+        val result = collect(
+            ThinkingStreamStateMachine(),
+            raw.map { null to it.toString() },
+        )
+
+        assertEquals("Reasoning", result.thinking)
+        assertEquals("\nFinal answer", result.response)
+        assertVisibleDeltasAreSafe(result.responseDeltas)
+    }
+
 
     @Test
     fun `raw think wrapper emits clean thought and visible suffix`() {
@@ -157,6 +170,34 @@ class ThinkingStreamStateMachineTest {
 
         assertEquals("", result.thinking)
         assertEquals("Kia ora. Hello! ", result.response)
+        assertVisibleDeltasAreSafe(result.responseDeltas)
+    }
+
+    @Test
+    fun `observed malformed think close marker in cumulative callbacks is withheld`() {
+        val raw = "Kia ora. Hello! $MALFORMED_THINK_CLOSE_MARKER How can I help?"
+        val result = collect(
+            ThinkingStreamStateMachine(),
+            raw.indices.map { index -> null to raw.substring(0, index + 1) },
+        )
+
+        assertEquals("", result.thinking)
+        assertEquals("Kia ora. Hello!  How can I help?", result.response)
+        assertVisibleDeltasAreSafe(result.responseDeltas)
+    }
+
+    @Test
+    fun `truncated think close tail never reaches visible response`() {
+        val result = collect(
+            ThinkingStreamStateMachine(),
+            listOf(
+                null to "Kia ora. Hello! $TRUNCATED_THINK_CLOSE_MARKER",
+                null to "How can I help?",
+            ),
+        )
+
+        assertEquals("", result.thinking)
+        assertEquals("Kia ora. Hello! How can I help?", result.response)
         assertVisibleDeltasAreSafe(result.responseDeltas)
     }
 


### PR DESCRIPTION
## Summary

- treat the exact S21-reproduced `</|/think|>` token as a supported thinking close marker
- retain one incremental parser boundary for split and cumulative callbacks
- add regressions for exact, split, cumulative, repeated, unterminated, normal, and downstream-clean output paths
- filter the separate truncated `|/think>` callback tail observed during bounded S21 smoke without changing the structured callback contract

Structured thought/primary callback handling and downstream chat/TTS/persistence consumers are unchanged.

## Verification

- `:core:inference:testDebugUnitTest --tests com.kernel.ai.core.inference.ThinkingStreamStateMachineTest` — passed (23 tests)
- combined `:core:inference:testDebugUnitTest :feature:chat:testDebugUnitTest :app:testDebugUnitTest :app:assembleDebug` — passed
- current debug APK installed with `adb install -r` on S21 `R5CR605B71K`; latest bounded Hello smoke exercised the app and reached the existing blank-response fallback without protocol-token output. It did not reproduce a normal model response, so Journey 1 is not marked proven.
- J2 S23U baseline was not touched.

Related: #1418, #1329

Do not merge — wait for review.