### PR TITLE
fix(1418): contain malformed thinking callbacks

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -305,8 +305,9 @@ internal class ThinkingStreamStateMachine(
         val response = mutableListOf<String>()
 
         if (rawMode == RawMode.MALFORMED_THOUGHT_CANDIDATE) {
-            rawPending.insert(0, malformedThoughtCandidate.toString())
-            rawPending.insert(0, MALFORMED_THINK_REOPEN_MARKER)
+            // The confirmed malformed-thought candidate is private reasoning. If its
+            // closing marker never arrives, fail closed and let the blank-response
+            // fallback handle the generation instead of exposing it as visible text.
             malformedThoughtCandidate.clear()
             malformedReopenEligible = false
             rawMode = RawMode.VISIBLE

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -238,6 +238,7 @@ internal class ThinkingStreamStateMachine(
         CHANNEL_HEADER,
         CHANNEL_THOUGHT,
         CHANNEL_VISIBLE,
+        MALFORMED_THOUGHT_CANDIDATE,
     }
 
     private enum class MarkerType {
@@ -261,6 +262,8 @@ internal class ThinkingStreamStateMachine(
     private val emittedThinking = StringBuilder()
     private val emittedStructuredThinking = StringBuilder()
     private val emittedResponse = StringBuilder()
+    private val malformedThoughtCandidate = StringBuilder()
+    private var malformedReopenEligible = false
     private var rawMode = RawMode.VISIBLE
 
     fun consume(channelDelta: String?, rawMessage: String): ThinkingStreamEmission {
@@ -300,6 +303,15 @@ internal class ThinkingStreamStateMachine(
     fun finish(): ThinkingStreamEmission {
         val thinking = mutableListOf<String>()
         val response = mutableListOf<String>()
+
+        if (rawMode == RawMode.MALFORMED_THOUGHT_CANDIDATE) {
+            rawPending.insert(0, malformedThoughtCandidate.toString())
+            rawPending.insert(0, MALFORMED_THINK_REOPEN_MARKER)
+            malformedThoughtCandidate.clear()
+            malformedReopenEligible = false
+            rawMode = RawMode.VISIBLE
+        }
+
         processRaw(thinking, response)
         processStructuredThinking(thinking)
 
@@ -370,6 +382,7 @@ internal class ThinkingStreamStateMachine(
                 RawMode.CHANNEL_HEADER -> processChannelHeader()
                 RawMode.CHANNEL_THOUGHT -> processChannelThought(thinking)
                 RawMode.CHANNEL_VISIBLE -> processChannelVisible(response)
+                RawMode.MALFORMED_THOUGHT_CANDIDATE -> processMalformedThoughtCandidate(thinking)
             }
             if (beforeLength == rawPending.length && beforeMode == rawMode) return
             if (rawPending.isNotEmpty() && rawMode == RawMode.VISIBLE) {
@@ -384,9 +397,10 @@ internal class ThinkingStreamStateMachine(
         response: MutableList<String>,
     ) {
         val text = rawPending.toString()
-        if (text.startsWith(MALFORMED_THINK_REOPEN_MARKER)) {
+        if (malformedReopenEligible && text.startsWith(MALFORMED_THINK_REOPEN_MARKER)) {
             deletePrefix(rawPending, MALFORMED_THINK_REOPEN_MARKER.length)
-            rawMode = RawMode.THOUGHT
+            malformedReopenEligible = false
+            rawMode = RawMode.MALFORMED_THOUGHT_CANDIDATE
             return
         }
         val marker = findRawMarker(text)
@@ -427,6 +441,20 @@ internal class ThinkingStreamStateMachine(
         emitThinking(text.substring(0, stableEnd ?: text.length), thinking)
         deletePrefix(rawPending, stableEnd ?: text.length)
     }
+    private fun processMalformedThoughtCandidate(thinking: MutableList<String>) {
+        malformedThoughtCandidate.append(rawPending)
+        rawPending.clear()
+
+        val candidate = malformedThoughtCandidate.toString()
+        val closeStart = candidate.indexOf(MALFORMED_HTML_THINK_CLOSE_MARKER)
+        if (closeStart < 0) return
+
+        emitThinking(candidate.substring(0, closeStart), thinking)
+        val closeEnd = closeStart + MALFORMED_HTML_THINK_CLOSE_MARKER.length
+        rawPending.append(candidate.substring(closeEnd))
+        malformedThoughtCandidate.clear()
+        rawMode = RawMode.VISIBLE
+    }
 
     private fun processChannelHeader() {
         val text = rawPending.toString()
@@ -458,6 +486,7 @@ internal class ThinkingStreamStateMachine(
         if (marker?.complete == true) {
             emitThinking(text.substring(0, marker.start), thinking)
             deletePrefix(rawPending, marker.endExclusive)
+            malformedReopenEligible = true
             rawMode = RawMode.VISIBLE
             return
         }
@@ -467,7 +496,6 @@ internal class ThinkingStreamStateMachine(
         emitThinking(text.substring(0, stableEnd ?: text.length), thinking)
         deletePrefix(rawPending, stableEnd ?: text.length)
     }
-
     private fun processChannelVisible(response: MutableList<String>) {
         val text = rawPending.toString()
         val marker = findChannelClose(text)
@@ -503,6 +531,7 @@ internal class ThinkingStreamStateMachine(
         response: MutableList<String>,
     ) {
         if (candidate.isEmpty()) return
+        malformedReopenEligible = false
         if (containsProtocolSyntaxOrPrefix(candidate)) {
             warnAmbiguous(candidate.length)
             return
@@ -597,6 +626,7 @@ internal class ThinkingStreamStateMachine(
     }
 
     private fun findTruncatedThinkClose(text: String, offset: Int = 0): MarkerMatch? {
+        if (offset > 0 && text[offset - 1] == '<') return null
         if (text.startsWith(TRUNCATED_THINK_CLOSE_MARKER, offset)) {
             return MarkerMatch(
                 type = MarkerType.THINK_CLOSE,
@@ -758,7 +788,6 @@ internal class ThinkingStreamStateMachine(
         val THINK_CLOSE_MARKERS = listOf(
             THINK_CLOSE_MARKER,
             MALFORMED_THINK_CLOSE_MARKER,
-            MALFORMED_HTML_THINK_CLOSE_MARKER,
         )
         val PROTOCOL_MARKERS = listOf(
             THINKING_CHANNEL_HEADER,
@@ -767,8 +796,6 @@ internal class ThinkingStreamStateMachine(
             THINK_OPEN_MARKER,
             THINK_CLOSE_MARKER,
             MALFORMED_THINK_CLOSE_MARKER,
-            MALFORMED_THINK_REOPEN_MARKER,
-            MALFORMED_HTML_THINK_CLOSE_MARKER,
         )
     }
 }
@@ -792,11 +819,6 @@ private val PROTOCOL_MARKERS_FOR_BOUNDARY = listOf(
     "<|think|>",
     "<|/think|>",
     MALFORMED_THINK_CLOSE_MARKER,
-    MALFORMED_THINK_REOPEN_MARKER,
-    MALFORMED_HTML_THINK_CLOSE_MARKER,
-    TRUNCATED_THINK_CLOSE_MARKER,
-    "<|/think",
-    "</think",
     "<|think",
 )
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -105,6 +105,10 @@ internal const val THINKING_CLOSE_MARKER = "<channel|>"
 internal const val MALFORMED_THINK_CLOSE_MARKER = "</|/think|>"
 /** Truncated close-marker tail emitted by the same callback protocol. */
 internal const val TRUNCATED_THINK_CLOSE_MARKER = "|/think>"
+/** Exact malformed thought opener observed after a channel close on S21. */
+internal const val MALFORMED_THINK_REOPEN_MARKER = "<|/think>"
+/** Exact malformed thought close observed after that S21 callback sequence. */
+internal const val MALFORMED_HTML_THINK_CLOSE_MARKER = "</think>"
 
 @OptIn(ExperimentalApi::class)
 internal inline fun <T> withSpeculativeDecodingEnabledForInit(enabled: Boolean, block: () -> T): T {
@@ -380,6 +384,11 @@ internal class ThinkingStreamStateMachine(
         response: MutableList<String>,
     ) {
         val text = rawPending.toString()
+        if (text.startsWith(MALFORMED_THINK_REOPEN_MARKER)) {
+            deletePrefix(rawPending, MALFORMED_THINK_REOPEN_MARKER.length)
+            rawMode = RawMode.THOUGHT
+            return
+        }
         val marker = findRawMarker(text)
         if (marker == null) {
             val stableEnd = trailingProtocolPrefixStart(text)
@@ -723,6 +732,8 @@ internal class ThinkingStreamStateMachine(
             .replace(THINK_OPEN_MARKER, "")
             .replace(THINK_CLOSE_MARKER, "")
             .replace(MALFORMED_THINK_CLOSE_MARKER, "")
+            .replace(MALFORMED_THINK_REOPEN_MARKER, "")
+            .replace(MALFORMED_HTML_THINK_CLOSE_MARKER, "")
             .replace(TRUNCATED_THINK_CLOSE_MARKER, "")
             .replace(closeMarker, "")
 
@@ -747,6 +758,7 @@ internal class ThinkingStreamStateMachine(
         val THINK_CLOSE_MARKERS = listOf(
             THINK_CLOSE_MARKER,
             MALFORMED_THINK_CLOSE_MARKER,
+            MALFORMED_HTML_THINK_CLOSE_MARKER,
         )
         val PROTOCOL_MARKERS = listOf(
             THINKING_CHANNEL_HEADER,
@@ -755,6 +767,8 @@ internal class ThinkingStreamStateMachine(
             THINK_OPEN_MARKER,
             THINK_CLOSE_MARKER,
             MALFORMED_THINK_CLOSE_MARKER,
+            MALFORMED_THINK_REOPEN_MARKER,
+            MALFORMED_HTML_THINK_CLOSE_MARKER,
         )
     }
 }
@@ -778,8 +792,11 @@ private val PROTOCOL_MARKERS_FOR_BOUNDARY = listOf(
     "<|think|>",
     "<|/think|>",
     MALFORMED_THINK_CLOSE_MARKER,
+    MALFORMED_THINK_REOPEN_MARKER,
+    MALFORMED_HTML_THINK_CLOSE_MARKER,
     TRUNCATED_THINK_CLOSE_MARKER,
     "<|/think",
+    "</think",
     "<|think",
 )
 

--- a/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
+++ b/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
@@ -134,6 +134,38 @@ class ThinkingStreamStateMachineTest {
 
 
     @Test
+    fun `captured S21 callback boundary keeps malformed second thought out of response`() {
+        // Redacted replay of the physical callback order. The protocol fragments
+        // and callback boundaries are preserved; model prose is intentionally not.
+        val result = collect(
+            ThinkingStreamStateMachine(),
+            listOf(
+                "<|channel>",
+                "thought",
+                "\n",
+                "redacted first thought",
+                "<channel|>",
+                "<|/",
+                "think",
+                ">",
+                "\n",
+                "redacted second thought",
+                "</",
+                "think",
+                ">",
+                "\n",
+                "Final answer",
+            ).map { null to it },
+        )
+
+        assertEquals("redacted first thought\nredacted second thought", result.thinking)
+        assertEquals("\nFinal answer", result.response)
+        assertFalse(result.thinking.contains("<|"))
+        assertFalse(result.thinking.contains("</"))
+        assertVisibleDeltasAreSafe(result.responseDeltas)
+    }
+
+    @Test
     fun `raw think wrapper emits clean thought and visible suffix`() {
         val result = collect(
             ThinkingStreamStateMachine(),

--- a/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
+++ b/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
@@ -196,18 +196,26 @@ class ThinkingStreamStateMachineTest {
     }
 
     @Test
-    fun `malformed reopen without matching close preserves following visible text`() {
+    fun `unterminated malformed thought is withheld and does not poison next generation`() {
         val result = collect(
             ThinkingStreamStateMachine(),
             listOf(
+                null to "Visible ",
                 null to "<|channel>thought\nReasoning<channel|>",
-                null to "<|/think>Literal response",
+                null to "<|/think>private reasoning",
             ),
         )
+        assertEquals("Visible ", result.response)
+        assertTrue(result.responseDeltas.none { it.contains("Reasoning") })
+        assertTrue(result.responseDeltas.none { it.contains("private reasoning") })
+        assertTrue(result.responseDeltas.none { containsProtocolSyntaxOrPrefix(it) })
 
-        assertEquals("Reasoning", result.thinking)
-        assertEquals("<|/think>Literal response", result.response)
-        assertVisibleDeltasAreSafe(result.responseDeltas)
+        val nextGeneration = collect(
+            ThinkingStreamStateMachine(),
+            listOf(null to "Next answer"),
+        )
+        assertEquals("Next answer", nextGeneration.response)
+        assertVisibleDeltasAreSafe(nextGeneration.responseDeltas)
     }
 
     @Test

--- a/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
+++ b/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
@@ -159,9 +159,54 @@ class ThinkingStreamStateMachineTest {
         )
 
         assertEquals("redacted first thought\nredacted second thought", result.thinking)
+        assertEquals(listOf("redacted first thought", "\nredacted second thought"), result.thinkingDeltas)
         assertEquals("\nFinal answer", result.response)
+        assertEquals(listOf("\n", "Final answer"), result.responseDeltas)
         assertFalse(result.thinking.contains("<|"))
         assertFalse(result.thinking.contains("</"))
+        assertVisibleDeltasAreSafe(result.responseDeltas)
+    }
+
+    @Test
+    fun `literal html thought close remains visible with following text`() {
+        val callbacks = listOf("Visible ", "</", "think", ">", " after")
+        val result = collect(
+            ThinkingStreamStateMachine(),
+            callbacks.map { null to it },
+        )
+
+        assertEquals("Visible </think> after", result.response)
+        assertEquals(listOf("Visible ", "</think", ">", " after"), result.responseDeltas)
+        assertEquals("", result.thinking)
+        assertVisibleDeltasAreSafe(result.responseDeltas)
+    }
+
+    @Test
+    fun `literal malformed reopen remains visible when split across callbacks`() {
+        val callbacks = listOf("Visible ", "<|/", "think", ">", " after")
+        val result = collect(
+            ThinkingStreamStateMachine(),
+            callbacks.map { null to it },
+        )
+
+        assertEquals("Visible <|/think> after", result.response)
+        assertEquals(listOf("Visible ", "<|/think>", " after"), result.responseDeltas)
+        assertEquals("", result.thinking)
+        assertVisibleDeltasAreSafe(result.responseDeltas)
+    }
+
+    @Test
+    fun `malformed reopen without matching close preserves following visible text`() {
+        val result = collect(
+            ThinkingStreamStateMachine(),
+            listOf(
+                null to "<|channel>thought\nReasoning<channel|>",
+                null to "<|/think>Literal response",
+            ),
+        )
+
+        assertEquals("Reasoning", result.thinking)
+        assertEquals("<|/think>Literal response", result.response)
         assertVisibleDeltasAreSafe(result.responseDeltas)
     }
 


### PR DESCRIPTION
## Summary

Refs #1418 and #1329. The S21 E2B callback stream after PR #1522 emitted a malformed second thought segment:

`<channel|>` → `<|/think>` (split) → second thought text → `</think>` (split) → final answer.

The fallback state machine now recovers that exact sequence only after the observed channel-thought close. This follow-up fixes the remaining P1: if the malformed second-thought candidate never receives its closing `</think>`, the buffered candidate is discarded at completion instead of being restored into visible output.

Smallest change:

- remove unresolved-candidate restoration from `finish()`;
- clear the confirmed private candidate and return to the terminal visible state;
- let the existing blank-response retry/fallback handle a generation with no visible answer;
- replace the prior unterminated-candidate visibility expectation with a fail-closed regression preserving a legitimate visible prefix and verifying the next independent parser remains clean.

No new marker variants, sanitizer, parser layer, ChatViewModel, TTS, Room, RAG, clipboard, QIR, model, or UX changes.

## Verification

- `:core:inference:testDebugUnitTest --tests com.kernel.ai.core.inference.ThinkingStreamStateMachineTest` — PASS
- `:core:inference:testDebugUnitTest :feature:chat:testDebugUnitTest` — PASS
- `:app:assembleDebug` — PASS
- Final debug APK SHA-256: `5b29803f42b5385be0920f47f47a16d0b89ff479710aa1a9ead66265ed1a9398`.
- S21 `R5CR605B71K`, existing E2B cache, no app-data/model-cache clear: final APK installed with `adb install -r`. Physical inference was blocked during this run by the existing debug startup failure `ForegroundServiceStartNotAllowedException: startForegroundService() not allowed due to mAllowStartForeground false` from `InferenceLoadingService`; the app remained on the model-loading screen. No ordinary completion or leak claim is made from this blocked run.
- The established `load_skill`/`run_intent` fixture was attempted on the final APK. The app reached the generation path but ended with `Sorry, generation was cancelled`; the same run logged the foreground-service startup failure. Successful repeated automatic-tool completion is not claimed.

Focused parser coverage proves the unresolved candidate emits no reasoning or protocol fragment, preserves `Visible ` emitted before the confirmed malformed context, and does not affect a subsequent independent generation. #1418, #1329, and Journey 1 remain open. No full golden-journey matrix was restarted.

Do not merge — wait for review.