### PR TITLE
fix(#1502): yield Hey Jandal while Honor Camera is foreground

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,16 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <!-- Wake word foreground service requires microphone access type (API 35+) -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <!--
+        #1502: special (AppOps) access, not a runtime permission. Requested only to let Hey Jandal
+        detect the Honor stock Camera entering the foreground on the affected device (HONOR
+        BKQ-N49) so wake capture can release the microphone before the camera records. The user
+        grants it from system settings and can revoke it at any time. Only the Camera's own
+        foreground state is evaluated; no usage history is stored or transmitted.
+    -->
+    <uses-permission
+        android:name="android.permission.PACKAGE_USAGE_STATS"
+        tools:ignore="ProtectedPermissions" />
 
     <!--
         Android 11+ package visibility: declare which implicit intents we resolve

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -648,24 +648,6 @@ class WakeWordService : Service() {
             return START_NOT_STICKY
         }
 
-        // #1502: on the Honor device where the camera contends for the microphone, wake capture may
-        // only run with Usage Access — without it Jandal cannot learn that the camera needs the
-        // microphone and would silently block video recording. Refuse before promoting to the
-        // microphone foreground state so no misleading "listening" notification is ever posted.
-        if (!HonorCameraCoexistence.isWakeCaptureAllowed(this)) {
-            Log.w(
-                TAG,
-                "WakeWordService: Usage Access missing on ${Build.MANUFACTURER} ${Build.MODEL} " +
-                    "— refusing to start wake capture",
-            )
-            stopSelf(startId)
-            AcousticJournalBridge.record(
-                type = AcousticEventType.SERVICE_ERROR,
-                metadata = { mapOf("category" to "usage_access_missing") },
-            )
-            return START_NOT_STICKY
-        }
-
         val foregroundStarted = tryPromoteToMicrophoneForeground(
             promote = { startForeground(NOTIFICATION_ID, buildNotification(NOTIFICATION_TEXT_LISTENING)) },
             onRejected = { error ->
@@ -682,6 +664,28 @@ class WakeWordService : Service() {
         )
         if (!foregroundStarted) {
             stopSelf(startId)
+            return START_NOT_STICKY
+        }
+
+        // #1502: on the Honor device where the camera contends for the microphone, wake capture may
+        // only run with Usage Access — without it Jandal cannot learn that the camera needs the
+        // microphone and would silently block video recording.
+        //
+        // This refusal deliberately runs *after* the foreground promotion: a service started with
+        // startForegroundService() must reach startForeground() or Android kills the process with
+        // ForegroundServiceDidNotStartInTimeException. The service is stopped immediately after, so
+        // the ongoing notification never outlives the refusal.
+        if (!HonorCameraCoexistence.isWakeCaptureAllowed(this)) {
+            Log.w(
+                TAG,
+                "WakeWordService: Usage Access missing on ${Build.MANUFACTURER} ${Build.MODEL} " +
+                    "— refusing to start wake capture",
+            )
+            stopSelf(startId)
+            AcousticJournalBridge.record(
+                type = AcousticEventType.SERVICE_ERROR,
+                metadata = { mapOf("category" to "usage_access_missing") },
+            )
             return START_NOT_STICKY
         }
 

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -883,8 +883,10 @@ class WakeWordService : Service() {
     /** Re-arms [wakeWordDetector] with the standard callbacks. */
     private fun rearmDetector() {
         // #1502: a camera-driven suspension is a latch — no re-arm path may take the microphone
-        // back while the Honor Camera needs it.
-        if (isWakeCaptureSuspended) {
+        // back while the Honor Camera needs it. The latch is set on the monitor's next poll, so a
+        // session ending inside that gap is covered by an immediate, bounded foreground check;
+        // otherwise that session end would hand the microphone straight back to Jandal.
+        if (isWakeCaptureSuspended || HonorCameraCoexistence.shouldWithholdWakeCapture(this)) {
             Log.i(TAG, "WakeWordService: wake capture suspended — not re-arming")
             return
         }

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -20,6 +20,7 @@ import com.kernel.ai.core.voice.NO_SPEECH_WINDOW_EXHAUSTED
 import com.kernel.ai.core.voice.AcousticJournalBridge
 import com.kernel.ai.core.voice.CameraForegroundMonitor
 import com.kernel.ai.core.voice.HonorCameraCoexistence
+import com.kernel.ai.core.voice.UsageStatsCurrentForegroundSource
 import com.kernel.ai.core.voice.UsageStatsForegroundEventSource
 import com.kernel.ai.core.voice.WakeWordPreferences
 import com.kernel.ai.core.voice.containsWakePhrase
@@ -498,13 +499,6 @@ private const val NOTIFICATION_TEXT_CAMERA_PAUSED = "Paused while Camera is in u
 internal const val HONOR_CAMERA_POLL_INTERVAL_MS = 2_000L
 
 /**
- * #1502: bounded lookback used only for the monitor's *initial* foreground state, so a service
- * that starts while the camera is already foreground still releases the microphone. Every later
- * poll reads only the window since the previous poll.
- */
-internal const val HONOR_CAMERA_INITIAL_LOOKBACK_MS = 60_000L
-
-/**
  * #1502: release every Jandal-owned microphone capture so the Honor Camera can record.
  *
  * The suspension latch is set *before* any capture is released: every re-arm path (voice-session
@@ -512,6 +506,10 @@ internal const val HONOR_CAMERA_INITIAL_LOOKBACK_MS = 60_000L
  * take the microphone back while the release is still in flight. On BKQ-N49 the wake detector is
  * not the only Jandal-owned capture that can block the camera — a session left over from a
  * wake→STT flow holds one too, hence [releaseVoiceCapture].
+ *
+ * Both releases are attempted even when one of them throws: a single failing release must not
+ * leave the other capture holding the microphone. The first failure is re-thrown so the caller can
+ * retry the whole release on its next attempt.
  */
 internal fun releaseWakeCaptureForCamera(
     suspendLatch: () -> Unit,
@@ -519,8 +517,42 @@ internal fun releaseWakeCaptureForCamera(
     releaseVoiceCapture: () -> Unit,
 ) {
     suspendLatch()
-    releaseWakeDetector()
-    releaseVoiceCapture()
+    var failure: Exception? = null
+    fun attempt(release: () -> Unit) {
+        try {
+            release()
+        } catch (e: Exception) {
+            Log.w(TAG, "WakeWordService: releasing a microphone capture failed", e)
+            val first = failure
+            if (first == null) failure = e else first.addSuppressed(e)
+        }
+    }
+    attempt(releaseWakeDetector)
+    attempt(releaseVoiceCapture)
+    failure?.let { throw it }
+}
+
+/**
+ * #1502: release Jandal's captures and stop the wake service, even when a release throws.
+ *
+ * Losing the camera-coexistence capability means Jandal can no longer yield the microphone, so
+ * listening must not continue — and a service that keeps running after that loss is a worse
+ * outcome than a release that has to be retried. The release failure is re-thrown after the stop
+ * so callers that retry cleanup (the camera monitor) still see it.
+ */
+internal fun releaseWakeCaptureAndStop(
+    releaseCaptures: () -> Unit,
+    stopService: () -> Unit,
+) {
+    var failure: Exception? = null
+    try {
+        releaseCaptures()
+    } catch (e: Exception) {
+        Log.w(TAG, "WakeWordService: releasing microphone captures failed", e)
+        failure = e
+    }
+    stopService()
+    failure?.let { throw it }
 }
 
 /**
@@ -707,7 +739,7 @@ class WakeWordService : Service() {
         }
 
         Log.i(TAG, "WakeWordService: starting wake word detection")
-        rearmDetector()
+        startWakeCapture()
 
         // Automatically yield the AudioRecord whenever another voice session is active.
         eventCollectorJob = serviceScope.launch {
@@ -753,6 +785,23 @@ class WakeWordService : Service() {
     // ── Honor camera coexistence (#1502) ───────────────────────────────────────
 
     /**
+     * #1502: take the microphone, but only once wake capture may legitimately run.
+     *
+     * Unaffected devices arm straight away. On the affected Honor device the camera monitor owns
+     * the first arm: it establishes the current foreground package from usage aggregation and
+     * reports it, so a service or process restart while the Honor Camera has already been in front
+     * cannot take the microphone first and fix it on a later poll — a camera foreground for longer
+     * than any event window appears in no window at all.
+     */
+    private fun startWakeCapture() {
+        if (HonorCameraCoexistence.isAffectedDevice(this)) {
+            startHonorCameraMonitor()
+        } else {
+            rearmDetector()
+        }
+    }
+
+    /**
      * #1502: start the single Honor-camera foreground monitor.
      *
      * Only runs on the proven affected device (Usage Access is already verified by the refusal
@@ -767,7 +816,7 @@ class WakeWordService : Service() {
                 source = UsageStatsForegroundEventSource(applicationContext),
                 targetPackage = HonorCameraCoexistence.CAMERA_PACKAGE,
                 pollIntervalMs = HONOR_CAMERA_POLL_INTERVAL_MS,
-                initialLookbackMillis = HONOR_CAMERA_INITIAL_LOOKBACK_MS,
+                currentForegroundPackage = UsageStatsCurrentForegroundSource(applicationContext),
                 isReady = { HonorCameraCoexistence.hasUsageAccess(this@WakeWordService) },
                 onCameraEntered = { suspendForHonorCamera() },
                 onCameraExited = { resumeAfterHonorCamera() },
@@ -822,7 +871,7 @@ class WakeWordService : Service() {
             Log.i(TAG, "WakeWordService: camera left foreground but wake capture may not re-arm yet")
             return
         }
-        Log.i(TAG, "WakeWordService: camera left foreground — re-arming wake capture")
+        Log.i(TAG, "WakeWordService: camera not foreground — arming wake capture")
         rearmDetector()
     }
 
@@ -838,12 +887,16 @@ class WakeWordService : Service() {
             type = AcousticEventType.SERVICE_ERROR,
             metadata = { mapOf("category" to "usage_access_revoked") },
         )
-        releaseWakeCaptureForCamera(
-            suspendLatch = { isWakeCaptureSuspended = true },
-            releaseWakeDetector = { wakeWordDetector.stop() },
-            releaseVoiceCapture = { voiceInputController.stopListening() },
+        releaseWakeCaptureAndStop(
+            releaseCaptures = {
+                releaseWakeCaptureForCamera(
+                    suspendLatch = { isWakeCaptureSuspended = true },
+                    releaseWakeDetector = { wakeWordDetector.stop() },
+                    releaseVoiceCapture = { voiceInputController.stopListening() },
+                )
+            },
+            stopService = { stopSelf() },
         )
-        stopSelf()
     }
 
     // ── Detection handoff ──────────────────────────────────────────────────────
@@ -883,9 +936,10 @@ class WakeWordService : Service() {
     /** Re-arms [wakeWordDetector] with the standard callbacks. */
     private fun rearmDetector() {
         // #1502: a camera-driven suspension is a latch — no re-arm path may take the microphone
-        // back while the Honor Camera needs it. The latch is set on the monitor's next poll, so a
-        // session ending inside that gap is covered by an immediate, bounded foreground check;
-        // otherwise that session end would hand the microphone straight back to Jandal.
+        // back while the Honor Camera needs it. On top of the latch, ask whether the camera owns
+        // the foreground right now: that covers a session ending between the camera appearing and
+        // the monitor's next poll, and a restart that lost the latch while the camera was already
+        // in front (see HonorCameraCoexistence.shouldWithholdWakeCapture).
         if (isWakeCaptureSuspended || HonorCameraCoexistence.shouldWithholdWakeCapture(this)) {
             Log.i(TAG, "WakeWordService: wake capture suspended — not re-arming")
             return

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.IBinder
 import android.os.Handler
 import android.os.Looper
@@ -17,7 +18,12 @@ import com.kernel.ai.MainActivity
 import com.kernel.ai.core.voice.AcousticEventType
 import com.kernel.ai.core.voice.NO_SPEECH_WINDOW_EXHAUSTED
 import com.kernel.ai.core.voice.AcousticJournalBridge
+import com.kernel.ai.core.voice.CameraForegroundMonitor
+import com.kernel.ai.core.voice.HonorCameraCoexistence
+import com.kernel.ai.core.voice.UsageStatsForegroundEventSource
+import com.kernel.ai.core.voice.WakeWordPreferences
 import com.kernel.ai.core.voice.containsWakePhrase
+import com.kernel.ai.core.voice.mayRearmAfterCamera
 import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.kernel.ai.core.voice.StartListeningCueResult
 import com.kernel.ai.core.voice.StartListeningCueContext
@@ -46,6 +52,7 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
 import java.security.MessageDigest
@@ -393,7 +400,8 @@ internal data class WakeCommandHandoffResult(
  *    keeps the session open across the cue-to-command handoff so the runner's
  *    command is captured in attempt 1 and no retry is needed on the normal path.
  *
- * The bounded retry still runs for genuine post-readiness recognition failures.
+ * The bounded retry still runs for genuine post-readiness recognition failures, but never when
+ * [capturePermitted] reports that the microphone was taken away in the meantime (#1502).
  * On cancellation the active recognizer is stopped so no microphone owner or
  * recognizer is left behind.  [rearmDetector] is invoked exactly once, after the
  * session is terminal (including on cancellation, matching the previous service
@@ -409,6 +417,7 @@ internal suspend fun runWakeCommandHandoff(
     routeTranscript: (String) -> Boolean,
     onSessionTerminal: () -> Unit,
     journal: WakeSessionJournal? = null,
+    capturePermitted: () -> Boolean = { true },
 ): WakeCommandHandoffResult {
     // #1433: a confirmed wake activation must not request live STT capture until the
     // wake detector has completed microphone-resource release.
@@ -421,6 +430,15 @@ internal suspend fun runWakeCommandHandoff(
 
     try {
         val sessionResult = runWakeCaptureSession { attempt ->
+            // #1502: the microphone can be yielded mid-session (Honor Camera taking the
+            // foreground). Starting another attempt would take it straight back and block
+            // camera recording again, so the retry loop is closed instead.
+            if (!capturePermitted()) {
+                throw WakeAttemptCollectionException(
+                    category = "wake_capture_suspended",
+                    cause = IllegalStateException("wake capture suspended before attempt $attempt"),
+                )
+            }
             runWakeAttempt(
                 voiceInputController = voiceInputController,
                 journal = sessionJournal,
@@ -473,6 +491,37 @@ internal suspend fun runWakeCommandHandoff(
 private const val TAG = "KernelAI"
 private const val CHANNEL_ID = "kernel_wake_word"
 private const val NOTIFICATION_ID = 9_500
+private const val NOTIFICATION_TEXT_LISTENING = "Listening for wake word…"
+private const val NOTIFICATION_TEXT_CAMERA_PAUSED = "Paused while Camera is in use"
+
+/** #1502: monitor cadence validated on the Honor BKQ-N49 (well below the measured detection need). */
+internal const val HONOR_CAMERA_POLL_INTERVAL_MS = 2_000L
+
+/**
+ * #1502: bounded lookback used only for the monitor's *initial* foreground state, so a service
+ * that starts while the camera is already foreground still releases the microphone. Every later
+ * poll reads only the window since the previous poll.
+ */
+internal const val HONOR_CAMERA_INITIAL_LOOKBACK_MS = 60_000L
+
+/**
+ * #1502: release every Jandal-owned microphone capture so the Honor Camera can record.
+ *
+ * The suspension latch is set *before* any capture is released: every re-arm path (voice-session
+ * event, wake-command handoff terminal, debug resume hook) checks that latch, so none of them can
+ * take the microphone back while the release is still in flight. On BKQ-N49 the wake detector is
+ * not the only Jandal-owned capture that can block the camera — a session left over from a
+ * wake→STT flow holds one too, hence [releaseVoiceCapture].
+ */
+internal fun releaseWakeCaptureForCamera(
+    suspendLatch: () -> Unit,
+    releaseWakeDetector: () -> Unit,
+    releaseVoiceCapture: () -> Unit,
+) {
+    suspendLatch()
+    releaseWakeDetector()
+    releaseVoiceCapture()
+}
 
 /**
  * Promote the service to the microphone foreground state without allowing Android's
@@ -532,8 +581,25 @@ class WakeWordService : Service() {
     @Inject lateinit var voiceInputController: VoiceInputController
     @Inject lateinit var cuePlayer: StartListeningCuePlayer
     @Inject lateinit var modelDownloadManager: ModelDownloadManager
+    @Inject lateinit var wakeWordPreferences: WakeWordPreferences
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var eventCollectorJob: Job? = null
+
+    /** #1502: exactly one Honor-camera foreground monitor per service lifetime. */
+    private var cameraMonitorJob: Job? = null
+
+    /**
+     * #1502: latch set while Jandal must not hold the microphone (Honor Camera foreground, or the
+     * camera-coexistence capability was lost). Re-arm paths refuse to take the microphone while it
+     * is set, so a camera-suspension cannot be undone by a concurrent voice-session event.
+     */
+    @Volatile private var isWakeCaptureSuspended = false
+
+    /** True while a Jandal voice session (push-to-talk, assistant, widget) owns the microphone. */
+    @Volatile private var isVoiceSessionActive = false
+
+    /** Last text pushed to the ongoing notification; avoids redundant updates on every re-arm. */
+    @Volatile private var notificationText = NOTIFICATION_TEXT_LISTENING
 
     /** True while [handleDetection] owns a live STT session; suppresses the observer's re-arm. */
     @Volatile private var isHandlingDetection = false
@@ -582,8 +648,26 @@ class WakeWordService : Service() {
             return START_NOT_STICKY
         }
 
+        // #1502: on the Honor device where the camera contends for the microphone, wake capture may
+        // only run with Usage Access — without it Jandal cannot learn that the camera needs the
+        // microphone and would silently block video recording. Refuse before promoting to the
+        // microphone foreground state so no misleading "listening" notification is ever posted.
+        if (!HonorCameraCoexistence.isWakeCaptureAllowed(this)) {
+            Log.w(
+                TAG,
+                "WakeWordService: Usage Access missing on ${Build.MANUFACTURER} ${Build.MODEL} " +
+                    "— refusing to start wake capture",
+            )
+            stopSelf(startId)
+            AcousticJournalBridge.record(
+                type = AcousticEventType.SERVICE_ERROR,
+                metadata = { mapOf("category" to "usage_access_missing") },
+            )
+            return START_NOT_STICKY
+        }
+
         val foregroundStarted = tryPromoteToMicrophoneForeground(
-            promote = { startForeground(NOTIFICATION_ID, buildNotification()) },
+            promote = { startForeground(NOTIFICATION_ID, buildNotification(NOTIFICATION_TEXT_LISTENING)) },
             onRejected = { error ->
                 Log.w(
                     TAG,
@@ -626,11 +710,13 @@ class WakeWordService : Service() {
             voiceInputController.events.collect { event ->
                 when (event) {
                     is VoiceInputEvent.ListeningStarted -> {
+                        isVoiceSessionActive = true
                         Log.i(TAG, "WakeWordService: yielding mic to voice session (${event.mode})")
                         wakeWordDetector.stop()
                     }
 
                     is VoiceInputEvent.ListeningStopped -> {
+                        isVoiceSessionActive = false
                         if (isHandlingDetection) return@collect
                         Log.i(TAG, "WakeWordService: re-arming after voice session (${event.mode})")
                         rearmDetector()
@@ -645,17 +731,116 @@ class WakeWordService : Service() {
             }
         }
 
+        startHonorCameraMonitor()
+
         return START_STICKY
     }
 
     override fun onDestroy() {
         instance = null
+        cameraMonitorJob = null
         wakeWordDetector.stop()
         serviceScope.cancel()
         super.onDestroy()
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    // ── Honor camera coexistence (#1502) ───────────────────────────────────────
+
+    /**
+     * #1502: start the single Honor-camera foreground monitor.
+     *
+     * Only runs on the proven affected device (Usage Access is already verified by the refusal
+     * above), inside [serviceScope] so it never blocks the main thread and is cancelled with the
+     * service. Guarded so repeated `onStartCommand` deliveries cannot create a second monitor.
+     */
+    private fun startHonorCameraMonitor() {
+        if (!HonorCameraCoexistence.isAffectedDevice(this)) return
+        if (cameraMonitorJob?.isActive == true) return
+        cameraMonitorJob = serviceScope.launch {
+            CameraForegroundMonitor(
+                source = UsageStatsForegroundEventSource(applicationContext),
+                targetPackage = HonorCameraCoexistence.CAMERA_PACKAGE,
+                pollIntervalMs = HONOR_CAMERA_POLL_INTERVAL_MS,
+                initialLookbackMillis = HONOR_CAMERA_INITIAL_LOOKBACK_MS,
+                isReady = { HonorCameraCoexistence.hasUsageAccess(this@WakeWordService) },
+                onCameraEntered = { suspendForHonorCamera() },
+                onCameraExited = { resumeAfterHonorCamera() },
+                onUnavailable = { onHonorCameraCoexistenceUnavailable() },
+            ).run()
+        }
+    }
+
+    /**
+     * #1502: the Honor Camera took the foreground — hand the microphone over before it records.
+     *
+     * The service and its foreground notification stay alive; only Jandal-owned captures are
+     * released.
+     */
+    private fun suspendForHonorCamera() {
+        Log.i(TAG, "WakeWordService: ${HonorCameraCoexistence.CAMERA_PACKAGE} foreground — releasing microphone")
+        releaseWakeCaptureForCamera(
+            suspendLatch = { isWakeCaptureSuspended = true },
+            releaseWakeDetector = { wakeWordDetector.stop() },
+            releaseVoiceCapture = { voiceInputController.stopListening() },
+        )
+        AcousticJournalBridge.record(
+            type = AcousticEventType.SERVICE_ERROR,
+            metadata = { mapOf("category" to "camera_foreground_yield") },
+        )
+        updateNotification(NOTIFICATION_TEXT_CAMERA_PAUSED)
+    }
+
+    /**
+     * #1502: the Honor Camera left the foreground — re-arm, but only when every condition that
+     * permits wake listening still holds.
+     */
+    private suspend fun resumeAfterHonorCamera() {
+        isWakeCaptureSuspended = false
+        val heyJandalEnabled = try {
+            wakeWordPreferences.heyJandalEnabled.first()
+        } catch (e: Exception) {
+            Log.w(TAG, "WakeWordService: could not read Hey Jandal preference", e)
+            true
+        }
+        val mayArm = mayRearmAfterCamera(
+            heyJandalEnabled = heyJandalEnabled,
+            recordAudioGranted = ContextCompat.checkSelfPermission(
+                this,
+                android.Manifest.permission.RECORD_AUDIO,
+            ) == android.content.pm.PackageManager.PERMISSION_GRANTED,
+            captureSuspended = isWakeCaptureSuspended,
+            voiceSessionActive = isVoiceSessionActive || isHandlingDetection,
+            captureAllowed = HonorCameraCoexistence.isWakeCaptureAllowed(this),
+        )
+        if (!mayArm) {
+            Log.i(TAG, "WakeWordService: camera left foreground but wake capture may not re-arm yet")
+            return
+        }
+        Log.i(TAG, "WakeWordService: camera left foreground — re-arming wake capture")
+        rearmDetector()
+    }
+
+    /**
+     * #1502: Usage Access was revoked while the monitor was running, so Jandal can no longer yield
+     * the microphone to the camera. Release every Jandal-owned capture and stop: listening must
+     * not continue indefinitely without the capability that protects the camera. Voice settings
+     * turns Hey Jandal off and explains what is needed the next time it is opened.
+     */
+    private fun onHonorCameraCoexistenceUnavailable() {
+        Log.w(TAG, "WakeWordService: Usage Access lost — releasing microphone and stopping")
+        AcousticJournalBridge.record(
+            type = AcousticEventType.SERVICE_ERROR,
+            metadata = { mapOf("category" to "usage_access_revoked") },
+        )
+        releaseWakeCaptureForCamera(
+            suspendLatch = { isWakeCaptureSuspended = true },
+            releaseWakeDetector = { wakeWordDetector.stop() },
+            releaseVoiceCapture = { voiceInputController.stopListening() },
+        )
+        stopSelf()
+    }
 
     // ── Detection handoff ──────────────────────────────────────────────────────
 
@@ -675,6 +860,8 @@ class WakeWordService : Service() {
                         isHandlingDetection = false
                         rearmDetector()
                     },
+                    // #1502: a camera-driven yield must not be undone by the session's retry.
+                    capturePermitted = { !isWakeCaptureSuspended },
                 )
             } catch (e: CancellationException) {
                 isHandlingDetection = false
@@ -691,6 +878,12 @@ class WakeWordService : Service() {
 
     /** Re-arms [wakeWordDetector] with the standard callbacks. */
     private fun rearmDetector() {
+        // #1502: a camera-driven suspension is a latch — no re-arm path may take the microphone
+        // back while the Honor Camera needs it.
+        if (isWakeCaptureSuspended) {
+            Log.i(TAG, "WakeWordService: wake capture suspended — not re-arming")
+            return
+        }
         ensureWakeVerifierModels()
         if (!wakeWordDetector.isAvailable) {
             AcousticJournalBridge.record(
@@ -735,6 +928,7 @@ class WakeWordService : Service() {
             type = AcousticEventType.DETECTOR_REARMED,
             generationId = generationId,
         )
+        updateNotification(NOTIFICATION_TEXT_LISTENING)
     }
 
     private fun routeTranscript(transcript: String): Boolean {
@@ -774,7 +968,7 @@ class WakeWordService : Service() {
         nm.createNotificationChannel(channel)
     }
 
-    private fun buildNotification(): Notification {
+    private fun buildNotification(text: String): Notification {
         val tapIntent = PendingIntent.getActivity(
             this,
             0,
@@ -784,10 +978,23 @@ class WakeWordService : Service() {
         return Notification.Builder(this, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_btn_speak_now)
             .setContentTitle("Hey Jandal")
-            .setContentText("Listening for wake word…")
+            .setContentText(text)
             .setContentIntent(tapIntent)
             .setOngoing(true)
+            .setOnlyAlertOnce(true)
             .build()
+    }
+
+    /**
+     * #1502: keep the ongoing notification truthful about whether Jandal is actually listening —
+     * it must not claim to listen while wake capture is suspended for the Honor Camera. No-op when
+     * the text is unchanged, so repeated re-arms do not churn the notification.
+     */
+    private fun updateNotification(text: String) {
+        if (notificationText == text) return
+        notificationText = text
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager ?: return
+        nm.notify(NOTIFICATION_ID, buildNotification(text))
     }
 
     companion object {

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -533,26 +533,23 @@ internal fun releaseWakeCaptureForCamera(
 }
 
 /**
- * #1502: release Jandal's captures and stop the wake service, even when a release throws.
+ * #1502: release Jandal's captures, then stop the wake service — but only once they were released.
  *
- * Losing the camera-coexistence capability means Jandal can no longer yield the microphone, so
- * listening must not continue — and a service that keeps running after that loss is a worse
- * outcome than a release that has to be retried. The release failure is re-thrown after the stop
- * so callers that retry cleanup (the camera monitor) still see it.
+ * Stopping the service cancels the scope the camera monitor runs in, and that monitor owns the
+ * only retry cadence for this cleanup. Stopping after a *failed* release therefore destroys the one
+ * mechanism that can hand a capture back: on BKQ-N49 a recognizer-held capture would keep blocking
+ * the camera while nothing was left to release it. The failure propagates instead, so the monitor
+ * stays alive and repeats the whole release — latch, wake detector, voice capture — on its next
+ * tick. Only a completed release stops the service.
  */
-internal fun releaseWakeCaptureAndStop(
-    releaseCaptures: () -> Unit,
+internal fun releaseWakeCaptureThenStop(
+    suspendLatch: () -> Unit,
+    releaseWakeDetector: () -> Unit,
+    releaseVoiceCapture: () -> Unit,
     stopService: () -> Unit,
 ) {
-    var failure: Exception? = null
-    try {
-        releaseCaptures()
-    } catch (e: Exception) {
-        Log.w(TAG, "WakeWordService: releasing microphone captures failed", e)
-        failure = e
-    }
+    releaseWakeCaptureForCamera(suspendLatch, releaseWakeDetector, releaseVoiceCapture)
     stopService()
-    failure?.let { throw it }
 }
 
 /**
@@ -877,9 +874,14 @@ class WakeWordService : Service() {
 
     /**
      * #1502: Usage Access was revoked while the monitor was running, so Jandal can no longer yield
-     * the microphone to the camera. Release every Jandal-owned capture and stop: listening must
-     * not continue indefinitely without the capability that protects the camera. Voice settings
-     * turns Hey Jandal off and explains what is needed the next time it is opened.
+     * the microphone to the camera. Release every Jandal-owned capture and then stop: listening
+     * must not continue indefinitely without the capability that protects the camera.
+     *
+     * The stop is conditional on the release completing. A failed release is reported to the
+     * monitor, which keeps this service alive and retries the whole release on its next cadence;
+     * stopping here instead would cancel that retry along with the monitor and could leave a
+     * capture holding the microphone with no one left to release it. Voice settings turns Hey
+     * Jandal off and explains what is needed the next time it is opened.
      */
     private fun onHonorCameraCoexistenceUnavailable() {
         Log.w(TAG, "WakeWordService: Usage Access lost — releasing microphone and stopping")
@@ -887,14 +889,10 @@ class WakeWordService : Service() {
             type = AcousticEventType.SERVICE_ERROR,
             metadata = { mapOf("category" to "usage_access_revoked") },
         )
-        releaseWakeCaptureAndStop(
-            releaseCaptures = {
-                releaseWakeCaptureForCamera(
-                    suspendLatch = { isWakeCaptureSuspended = true },
-                    releaseWakeDetector = { wakeWordDetector.stop() },
-                    releaseVoiceCapture = { voiceInputController.stopListening() },
-                )
-            },
+        releaseWakeCaptureThenStop(
+            suspendLatch = { isWakeCaptureSuspended = true },
+            releaseWakeDetector = { wakeWordDetector.stop() },
+            releaseVoiceCapture = { voiceInputController.stopListening() },
             stopService = { stopSelf() },
         )
     }

--- a/app/src/test/java/com/kernel/ai/assistant/HonorCameraWakeReleaseTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/HonorCameraWakeReleaseTest.kt
@@ -1,0 +1,28 @@
+package com.kernel.ai.assistant
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * #1502: yielding the microphone to the Honor Camera must latch the suspension before any capture
+ * is released. A re-arm path (voice-session event, wake-command handoff terminal, debug resume
+ * hook) that ran in between would hand the microphone straight back to Jandal and the camera would
+ * fail to record — the failure mode the feasibility spike hit.
+ */
+class HonorCameraWakeReleaseTest {
+
+    @Test
+    fun `suspension is latched before the wake detector and voice captures are released`() {
+        val order = mutableListOf<String>()
+
+        releaseWakeCaptureForCamera(
+            suspendLatch = { order += "latch" },
+            releaseWakeDetector = { order += "wake-detector" },
+            releaseVoiceCapture = { order += "voice-capture" },
+        )
+
+        // Both Jandal-owned captures are released, and the latch goes first so no re-arm can slip
+        // in while they are being torn down.
+        assertEquals(listOf("latch", "wake-detector", "voice-capture"), order)
+    }
+}

--- a/app/src/test/java/com/kernel/ai/assistant/HonorCameraWakeReleaseTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/HonorCameraWakeReleaseTest.kt
@@ -1,6 +1,8 @@
 package com.kernel.ai.assistant
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
@@ -8,6 +10,9 @@ import org.junit.jupiter.api.Test
  * is released. A re-arm path (voice-session event, wake-command handoff terminal, debug resume
  * hook) that ran in between would hand the microphone straight back to Jandal and the camera would
  * fail to record — the failure mode the feasibility spike hit.
+ *
+ * The release is also the fail-safe path taken when the camera-coexistence capability is lost, so
+ * one failing lifecycle call must never skip the remaining cleanup.
  */
 class HonorCameraWakeReleaseTest {
 
@@ -24,5 +29,54 @@ class HonorCameraWakeReleaseTest {
         // Both Jandal-owned captures are released, and the latch goes first so no re-arm can slip
         // in while they are being torn down.
         assertEquals(listOf("latch", "wake-detector", "voice-capture"), order)
+    }
+
+    @Test
+    fun `a failed wake detector release still releases the voice capture and reports the failure`() {
+        val order = mutableListOf<String>()
+
+        assertThrows(IllegalStateException::class.java) {
+            releaseWakeCaptureForCamera(
+                suspendLatch = { order += "latch" },
+                releaseWakeDetector = {
+                    order += "wake-detector"
+                    throw IllegalStateException("AudioRecord release failed")
+                },
+                releaseVoiceCapture = { order += "voice-capture" },
+            )
+        }
+
+        // A recognizer-held capture left behind would keep blocking the camera on BKQ-N49, so the
+        // second release must still be attempted — and the caller must hear about the first, so it
+        // can retry the whole release.
+        assertEquals(listOf("latch", "wake-detector", "voice-capture"), order)
+    }
+
+    @Test
+    fun `a failed wake detector release still stops the service`() {
+        var stopped = false
+
+        assertThrows(IllegalStateException::class.java) {
+            releaseWakeCaptureAndStop(
+                releaseCaptures = { throw IllegalStateException("AudioRecord release failed") },
+                stopService = { stopped = true },
+            )
+        }
+
+        // Listening must not continue without the capability that protects the camera, even when a
+        // release failed; the exception is reported afterwards so the monitor can retry cleanup.
+        assertTrue(stopped, "stopSelf must run even when a release throws")
+    }
+
+    @Test
+    fun `a successful release stops the service without reporting a failure`() {
+        var stopped = false
+
+        releaseWakeCaptureAndStop(
+            releaseCaptures = {},
+            stopService = { stopped = true },
+        )
+
+        assertTrue(stopped)
     }
 }

--- a/app/src/test/java/com/kernel/ai/assistant/HonorCameraWakeReleaseTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/HonorCameraWakeReleaseTest.kt
@@ -1,6 +1,20 @@
 package com.kernel.ai.assistant
 
+import com.kernel.ai.core.voice.CameraForegroundMonitor
+import com.kernel.ai.core.voice.ForegroundEventSource
+import com.kernel.ai.core.voice.ForegroundPackageSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -11,9 +25,11 @@ import org.junit.jupiter.api.Test
  * hook) that ran in between would hand the microphone straight back to Jandal and the camera would
  * fail to record — the failure mode the feasibility spike hit.
  *
- * The release is also the fail-safe path taken when the camera-coexistence capability is lost, so
- * one failing lifecycle call must never skip the remaining cleanup.
+ * The same release is the fail-safe path taken when the camera-coexistence capability is lost, and
+ * there the ordering is stricter still: the service may stop only after every capture was actually
+ * released, because the stop cancels the monitor that retries the release.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class HonorCameraWakeReleaseTest {
 
     @Test
@@ -53,30 +69,109 @@ class HonorCameraWakeReleaseTest {
     }
 
     @Test
-    fun `a failed wake detector release still stops the service`() {
+    fun `a failed release does not stop the service`() {
         var stopped = false
 
         assertThrows(IllegalStateException::class.java) {
-            releaseWakeCaptureAndStop(
-                releaseCaptures = { throw IllegalStateException("AudioRecord release failed") },
+            releaseWakeCaptureThenStop(
+                suspendLatch = {},
+                releaseWakeDetector = { throw IllegalStateException("AudioRecord release failed") },
+                releaseVoiceCapture = {},
                 stopService = { stopped = true },
             )
         }
 
-        // Listening must not continue without the capability that protects the camera, even when a
-        // release failed; the exception is reported afterwards so the monitor can retry cleanup.
-        assertTrue(stopped, "stopSelf must run even when a release throws")
+        // Stopping the service cancels the monitor that owns the retry cadence, so a failed
+        // release must leave it running: the microphone may still be held, and only the monitor
+        // can ask for it back. The failure is reported instead — see the lifecycle regression.
+        assertFalse(stopped, "a failed release must not stop the service")
     }
 
     @Test
     fun `a successful release stops the service without reporting a failure`() {
         var stopped = false
 
-        releaseWakeCaptureAndStop(
-            releaseCaptures = {},
+        releaseWakeCaptureThenStop(
+            suspendLatch = {},
+            releaseWakeDetector = {},
+            releaseVoiceCapture = {},
             stopService = { stopped = true },
         )
 
         assertTrue(stopped)
     }
+
+    /**
+     * The production lifecycle: the monitor runs inside the service scope and the service stop
+     * cancels that scope, so the monitor can only retry a failed cleanup while the service is
+     * still alive. This wires the real monitor to the real service-side cleanup and drives the
+     * sequence `fail -> remain alive -> retry -> succeed -> stop`.
+     */
+    @Test
+    fun `a failed cleanup leaves the service running so the monitor retries it to completion`() =
+        runTest {
+            val serviceScope =
+                CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+            var usageAccess = true
+            val latches = mutableListOf<String>()
+            var detectorReleases = 0
+            var voiceReleases = 0
+            var detectorFailures = 1
+            var stops = 0
+            val monitor = CameraForegroundMonitor(
+                source = ForegroundEventSource { _, _ -> emptyList() },
+                targetPackage = "com.hihonor.camera",
+                pollIntervalMs = 1_000,
+                currentForegroundPackage = ForegroundPackageSource { "com.hihonor.android.launcher" },
+                isReady = { usageAccess },
+                onCameraEntered = {},
+                onCameraExited = {},
+                onUnavailable = {
+                    releaseWakeCaptureThenStop(
+                        suspendLatch = { latches += "attempt ${detectorReleases + 1}" },
+                        releaseWakeDetector = {
+                            detectorReleases++
+                            if (detectorFailures-- > 0) {
+                                throw IllegalStateException("AudioRecord release failed")
+                            }
+                        },
+                        releaseVoiceCapture = { voiceReleases++ },
+                        stopService = {
+                            stops++
+                            serviceScope.cancel()
+                        },
+                    )
+                },
+            )
+            val monitorJob = serviceScope.launch { monitor.run() }
+            runCurrent()
+
+            usageAccess = false
+            advanceTimeBy(1_001)
+            runCurrent()
+
+            // First attempt: suspended, both captures attempted, one failed.
+            assertEquals(listOf("attempt 1"), latches)
+            assertEquals(1, detectorReleases)
+            assertEquals(1, voiceReleases, "the second release is attempted even when the first fails")
+            assertEquals(0, stops, "a failed release must not stop the service")
+            assertTrue(serviceScope.isActive, "the monitor has to survive to retry the cleanup")
+            assertFalse(monitorJob.isCancelled)
+
+            // Next cadence retries the whole cleanup, which now succeeds.
+            advanceTimeBy(1_001)
+            runCurrent()
+
+            assertEquals(listOf("attempt 1", "attempt 2"), latches)
+            assertEquals(2, detectorReleases)
+            assertEquals(2, voiceReleases)
+            assertEquals(1, stops, "the service stops only once the release completed")
+            assertFalse(serviceScope.isActive, "stopping the service cancels the monitor's scope")
+
+            advanceTimeBy(5_000)
+            runCurrent()
+
+            assertEquals(2, detectorReleases, "monitoring ends after the cleanup succeeds")
+            serviceScope.cancel()
+        }
 }

--- a/app/src/test/java/com/kernel/ai/assistant/WakeCommandHandoffTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/WakeCommandHandoffTest.kt
@@ -537,4 +537,54 @@ class WakeCommandHandoffTest {
             assertEquals(1, rearmCount)
         }
     }
+
+    // ── #1502: a yielded microphone closes the retry loop ─────────────────────
+
+    @Test
+    fun `no retry attempt is started once the microphone was yielded`() = runTest {
+        val order = mutableListOf<String>()
+        val detector = OrderingDetector(order)
+        val controller = RecordingController(
+            detectorReleased = { detector.released },
+            startResults = mutableListOf(
+                VoiceInputStartResult.Started(1L),
+                // Present so a retry would be observable as a second capture session.
+                VoiceInputStartResult.Started(2L),
+            ),
+            sharedOrder = order,
+        )
+        val journalEvents = mutableListOf<Pair<String, Long>>()
+        var capturePermitted = true
+        var rearmCount = 0
+
+        val job = launch {
+            runWakeCommandHandoff(
+                wakeWordDetector = detector,
+                voiceInputController = controller,
+                cuePlayer = cuePlayer(),
+                generationId = 7L,
+                sessionId = 9L,
+                journal = journal(journalEvents),
+                routeTranscript = { true },
+                onSessionTerminal = { rearmCount++ },
+                capturePermitted = { capturePermitted },
+            )
+        }
+        runCurrent()
+
+        // Attempt 1 reaches readiness, then fails without a transcript — normally a retry.
+        controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId = 1L))
+        controller.emit(VoiceInputEvent.Error(VoiceCaptureMode.AlertCommand, "recognition failed", captureSessionId = 1L))
+        // The Honor Camera takes the microphone while that attempt is still open.
+        capturePermitted = false
+        runCurrent()
+        job.join()
+
+        assertEquals(
+            listOf(1L),
+            controller.startCalls,
+            "the retry must not take the microphone back from the camera",
+        )
+        assertEquals(1, rearmCount, "the terminal handoff is still reported exactly once")
+    }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/CameraForegroundMonitor.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/CameraForegroundMonitor.kt
@@ -1,0 +1,159 @@
+package com.kernel.ai.core.voice
+
+import android.app.usage.UsageEvents
+import android.app.usage.UsageStatsManager
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+
+private const val TAG = "CameraMonitor"
+
+/** Whether a usage event put a package in front of the user or took it away. */
+enum class ForegroundTransition { ENTER, EXIT }
+
+/**
+ * One foreground-activity transition, decoupled from [UsageEvents] so tracking logic stays
+ * testable without the platform.
+ */
+data class ForegroundEvent(val transition: ForegroundTransition, val packageName: String?)
+
+/** Platform seam for reading recent foreground-activity transitions (#1502). */
+fun interface ForegroundEventSource {
+    fun eventsBetween(startMillis: Long, endMillis: Long): List<ForegroundEvent>
+}
+
+/**
+ * #1502: watches for [targetPackage] becoming/leaving the foreground app and reports the
+ * transitions to [onCameraEntered] / [onCameraExited].
+ *
+ * Invariants:
+ * - **Transitions only.** Callbacks fire on a change of the target's foreground state, never once
+ *   per poll, so repeated events cannot duplicate a pause/resume operation.
+ * - **Failure isolated.** A failing query or a failing callback is logged and retried on the next
+ *   cadence; neither can terminate monitoring. Cancellation always propagates.
+ * - **Privacy minimal.** Only the current foreground package name is held in memory, for the
+ *   lifetime of the poll window. Nothing is persisted, exported, transmitted, or logged — the
+ *   only package name that may appear in a log is [targetPackage].
+ * - **Off the main thread.** [run] suspends; callers must launch it on a background dispatcher.
+ *
+ * The initial poll reads a bounded [initialLookbackMillis] window so a monitor that starts while
+ * the target is already foreground (for example a service restart) still reports it; every later
+ * poll reads only the window since the previous poll.
+ */
+class CameraForegroundMonitor(
+    private val source: ForegroundEventSource,
+    private val targetPackage: String,
+    private val pollIntervalMs: Long,
+    private val initialLookbackMillis: Long,
+    private val isReady: () -> Boolean = { true },
+    private val onCameraEntered: suspend () -> Unit,
+    private val onCameraExited: suspend () -> Unit,
+    private val onUnavailable: suspend () -> Unit = {},
+    private val clock: () -> Long = System::currentTimeMillis,
+) {
+
+    private var foregroundPackage: String? = null
+    private var appliedTargetForeground = false
+
+    /**
+     * Polls until cancelled. Returns early — after [onUnavailable] — when [isReady] reports that
+     * the capability the workaround depends on is gone.
+     */
+    suspend fun run() {
+        var windowStart = clock() - initialLookbackMillis
+        while (currentCoroutineContext().isActive) {
+            if (!isReady()) {
+                // Without Usage Access Jandal can no longer protect the camera: report once and
+                // stop polling rather than spinning against a revoked capability.
+                guard { onUnavailable() }
+                return
+            }
+            val now = clock()
+            if (poll(windowStart, now)) windowStart = now
+            reconcile()
+            delay(pollIntervalMs)
+        }
+    }
+
+    /** Returns true when the window was consumed, so the next poll can start after it. */
+    private fun poll(windowStart: Long, now: Long): Boolean = try {
+        for (event in source.eventsBetween(windowStart, now)) {
+            when (event.transition) {
+                ForegroundTransition.ENTER ->
+                    if (foregroundPackage != event.packageName) foregroundPackage = event.packageName
+
+                ForegroundTransition.EXIT ->
+                    if (foregroundPackage == event.packageName) foregroundPackage = null
+            }
+        }
+        true
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        // Recoverable: keep the unconsumed window so the events are re-read on the next cadence.
+        Log.w(TAG, "foreground query failed; retrying next tick", e)
+        false
+    }
+
+    /**
+     * Pushes the current target state if it differs from what was last applied. The applied state
+     * is recorded only after the callback succeeds, so a failed transition is retried on the next
+     * cadence instead of leaving the monitor believing it suspended when it did not.
+     */
+    private suspend fun reconcile() {
+        val desired = foregroundPackage == targetPackage
+        if (desired == appliedTargetForeground) return
+        try {
+            if (desired) onCameraEntered() else onCameraExited()
+            appliedTargetForeground = desired
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "foreground transition callback failed; retrying next tick", e)
+        }
+    }
+
+    private suspend fun guard(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "foreground transition callback failed", e)
+        }
+    }
+}
+
+/** Reads foreground-activity transitions from [UsageStatsManager] (requires Usage Access). */
+class UsageStatsForegroundEventSource(private val context: Context) : ForegroundEventSource {
+
+    override fun eventsBetween(startMillis: Long, endMillis: Long): List<ForegroundEvent> {
+        val manager = context.getSystemService(Context.USAGE_STATS_SERVICE) as? UsageStatsManager
+            ?: return emptyList()
+        val usageEvents = manager.queryEvents(startMillis, endMillis) ?: return emptyList()
+        // Events are converted immediately and the platform event object is reused; nothing is
+        // retained or copied beyond the transition and package name.
+        val transitions = ArrayList<ForegroundEvent>()
+        val event = UsageEvents.Event()
+        while (usageEvents.hasNextEvent()) {
+            usageEvents.getNextEvent(event)
+            val transition = when (event.eventType) {
+                UsageEvents.Event.ACTIVITY_RESUMED,
+                UsageEvents.Event.MOVE_TO_FOREGROUND,
+                -> ForegroundTransition.ENTER
+
+                UsageEvents.Event.ACTIVITY_PAUSED,
+                UsageEvents.Event.ACTIVITY_STOPPED,
+                UsageEvents.Event.MOVE_TO_BACKGROUND,
+                -> ForegroundTransition.EXIT
+
+                else -> null
+            } ?: continue
+            transitions += ForegroundEvent(transition, event.packageName)
+        }
+        return transitions
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/CameraForegroundMonitor.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/CameraForegroundMonitor.kt
@@ -26,6 +26,18 @@ fun interface ForegroundEventSource {
 }
 
 /**
+ * Platform seam for resolving the package that currently owns the foreground (#1502).
+ *
+ * Transitions cannot answer this after a service or process restart: a camera that has been in
+ * front since before the service started produced no recent transition at all, so the current
+ * state has to come from usage aggregation instead (see [UsageStatsCurrentForegroundSource]).
+ */
+fun interface ForegroundPackageSource {
+    /** The package in front of the user, or null when the platform cannot say. */
+    fun currentForegroundPackage(): String?
+}
+
+/**
  * Resolves which package is in front of the user from a stream of [ForegroundEvent]s: the last
  * package to enter the foreground wins, and an exit clears it only if that package was the one
  * held. Holds nothing but the current foreground package name (#1502).
@@ -51,6 +63,14 @@ class ForegroundPackageTracker(private val targetPackage: String) {
 
     /** True when [targetPackage] currently owns the foreground. */
     val isTargetForeground: Boolean get() = foregroundPackage == targetPackage
+
+    /**
+     * Starts from a package known to be in front right now, without replaying history (#1502).
+     * Used when a monitor starts while the target has already been foreground for a long time.
+     */
+    fun seed(packageName: String?) {
+        foregroundPackage = packageName
+    }
 }
 
 /**
@@ -58,24 +78,28 @@ class ForegroundPackageTracker(private val targetPackage: String) {
  * transitions to [onCameraEntered] / [onCameraExited].
  *
  * Invariants:
+ * - **State before capture.** [run] first establishes the current foreground package from
+ *   [currentForegroundPackage] and reports it, so a caller that arms wake capture only in response
+ *   to [onCameraExited] can never take the microphone while the target is already in front —
+ *   including a service/process restart after the target has been foreground for arbitrarily long,
+ *   which no transition window can see. While that state cannot be read, nothing is reported and
+ *   the monitor retries on the next cadence.
  * - **Transitions only.** Callbacks fire on a change of the target's foreground state, never once
  *   per poll, so repeated events cannot duplicate a pause/resume operation.
  * - **Failure isolated.** A failing query or a failing callback is logged and retried on the next
  *   cadence; neither can terminate monitoring. Cancellation always propagates.
+ * - **Fail-safe termination.** Monitoring ends only after [onUnavailable] completes; a cleanup
+ *   that threw is retried on the next cadence rather than dropping the fail-safe silently.
  * - **Privacy minimal.** Only the current foreground package name is held in memory, for the
  *   lifetime of the poll window. Nothing is persisted, exported, transmitted, or logged — the
  *   only package name that may appear in a log is [targetPackage].
  * - **Off the main thread.** [run] suspends; callers must launch it on a background dispatcher.
- *
- * The initial poll reads a bounded [initialLookbackMillis] window so a monitor that starts while
- * the target is already foreground (for example a service restart) still reports it; every later
- * poll reads only the window since the previous poll.
  */
 class CameraForegroundMonitor(
     private val source: ForegroundEventSource,
     private val targetPackage: String,
     private val pollIntervalMs: Long,
-    private val initialLookbackMillis: Long,
+    private val currentForegroundPackage: ForegroundPackageSource,
     private val isReady: () -> Boolean = { true },
     private val onCameraEntered: suspend () -> Unit,
     private val onCameraExited: suspend () -> Unit,
@@ -85,25 +109,65 @@ class CameraForegroundMonitor(
 
     private val tracker = ForegroundPackageTracker(targetPackage)
     private var appliedTargetForeground = false
+    private var windowStart = 0L
+    private var seeded = false
 
     /**
-     * Polls until cancelled. Returns early — after [onUnavailable] — when [isReady] reports that
-     * the capability the workaround depends on is gone.
+     * Polls until cancelled. Returns early — after [onUnavailable] succeeds — when [isReady]
+     * reports that the capability the workaround depends on is gone.
      */
     suspend fun run() {
-        var windowStart = clock() - initialLookbackMillis
         while (currentCoroutineContext().isActive) {
             if (!isReady()) {
-                // Without Usage Access Jandal can no longer protect the camera: report once and
-                // stop polling rather than spinning against a revoked capability.
-                guard { onUnavailable() }
-                return
+                // Without Usage Access Jandal can no longer protect the camera: clean up and stop
+                // polling rather than spinning against a revoked capability. The cleanup has to
+                // complete before monitoring ends — it is the only thing that releases the
+                // microphone and stops the service — so a failed attempt is retried, not dropped.
+                if (releaseAndStop()) return
+            } else if (seeded) {
+                val now = clock()
+                if (poll(windowStart, now)) windowStart = now
+                reconcile()
+            } else if (seed()) {
+                reconcile(force = true)
             }
-            val now = clock()
-            if (poll(windowStart, now)) windowStart = now
-            reconcile()
             delay(pollIntervalMs)
         }
+    }
+
+    /**
+     * Establishes the current foreground state, in place of replaying a transition window, and
+     * starts the event window at the moment it was resolved. Returns false — to be retried on the
+     * next cadence — while the platform cannot say which package is in front.
+     */
+    private fun seed(): Boolean {
+        val current = try {
+            currentForegroundPackage.currentForegroundPackage()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "current foreground package could not be read; retrying next tick", e)
+            return false
+        }
+        if (current == null) {
+            Log.w(TAG, "no current foreground package reported; retrying next tick")
+            return false
+        }
+        tracker.seed(current)
+        windowStart = clock()
+        seeded = true
+        return true
+    }
+
+    /** Returns true when the unavailable cleanup completed, so monitoring may end. */
+    private suspend fun releaseAndStop(): Boolean = try {
+        onUnavailable()
+        true
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Log.w(TAG, "camera-coexistence cleanup failed; retrying next tick", e)
+        false
     }
 
     /** Returns true when the window was consumed, so the next poll can start after it. */
@@ -119,13 +183,14 @@ class CameraForegroundMonitor(
     }
 
     /**
-     * Pushes the current target state if it differs from what was last applied. The applied state
-     * is recorded only after the callback succeeds, so a failed transition is retried on the next
-     * cadence instead of leaving the monitor believing it suspended when it did not.
+     * Pushes the current target state if it differs from what was last applied, or unconditionally
+     * when [force] is set so the caller learns the state the monitor started from. The applied
+     * state is recorded only after the callback succeeds, so a failed transition is retried on the
+     * next cadence instead of leaving the monitor believing it suspended when it did not.
      */
-    private suspend fun reconcile() {
+    private suspend fun reconcile(force: Boolean = false) {
         val desired = tracker.isTargetForeground
-        if (desired == appliedTargetForeground) return
+        if (!force && desired == appliedTargetForeground) return
         try {
             if (desired) onCameraEntered() else onCameraExited()
             appliedTargetForeground = desired
@@ -135,21 +200,10 @@ class CameraForegroundMonitor(
             Log.w(TAG, "foreground transition callback failed; retrying next tick", e)
         }
     }
-
-    private suspend fun guard(block: suspend () -> Unit) {
-        try {
-            block()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Log.w(TAG, "foreground transition callback failed", e)
-        }
-    }
 }
 
 /** Reads foreground-activity transitions from [UsageStatsManager] (requires Usage Access). */
 class UsageStatsForegroundEventSource(private val context: Context) : ForegroundEventSource {
-
     override fun eventsBetween(startMillis: Long, endMillis: Long): List<ForegroundEvent> {
         val manager = context.getSystemService(Context.USAGE_STATS_SERVICE) as? UsageStatsManager
             ?: return emptyList()
@@ -176,4 +230,53 @@ class UsageStatsForegroundEventSource(private val context: Context) : Foreground
         }
         return transitions
     }
+}
+
+/**
+ * How far back [UsageStatsCurrentForegroundSource] reads usage aggregation. The range only has to
+ * reach the moment the package now in front became visible; a day covers every foreground session
+ * a device that sleeps can produce, and the query returns one aggregated row per package per day
+ * bucket rather than raw events.
+ */
+private const val CURRENT_FOREGROUND_RANGE_MS = 24L * 60 * 60 * 1000
+
+/**
+ * Resolves the package in front of the user from usage aggregation (requires Usage Access).
+ *
+ * A transition query cannot answer this when the current package has been foreground for longer
+ * than the queried window — the window then contains no event for it at all — so the state comes
+ * from the aggregated `lastTimeVisible` timestamps instead: the package that became visible most
+ * recently is the one in front. Verified on the affected BKQ-N49: a camera in front for over
+ * 100 s is the most recently visible package, and the package that takes over from it replaces it
+ * within the monitor's cadence. Nothing is retained beyond the resolved package name.
+ */
+class UsageStatsCurrentForegroundSource(private val context: Context) : ForegroundPackageSource {
+
+    override fun currentForegroundPackage(): String? {
+        val manager = context.getSystemService(Context.USAGE_STATS_SERVICE) as? UsageStatsManager
+            ?: return null
+        val now = System.currentTimeMillis()
+        val stats = manager.queryUsageStats(
+            UsageStatsManager.INTERVAL_DAILY,
+            now - CURRENT_FOREGROUND_RANGE_MS,
+            now,
+        ) ?: return null
+        return mostRecentlyVisiblePackage(stats.map { it.packageName to it.lastTimeVisible })
+    }
+}
+
+/**
+ * The package that became visible most recently, or null when no package reports a visible
+ * timestamp — an unanswerable state, which callers must treat as "cannot confirm the foreground".
+ */
+internal fun mostRecentlyVisiblePackage(visibleSince: List<Pair<String, Long>>): String? {
+    var candidate: String? = null
+    var newest = 0L
+    for ((packageName, visibleAt) in visibleSince) {
+        if (visibleAt > newest) {
+            newest = visibleAt
+            candidate = packageName
+        }
+    }
+    return candidate
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/CameraForegroundMonitor.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/CameraForegroundMonitor.kt
@@ -26,6 +26,34 @@ fun interface ForegroundEventSource {
 }
 
 /**
+ * Resolves which package is in front of the user from a stream of [ForegroundEvent]s: the last
+ * package to enter the foreground wins, and an exit clears it only if that package was the one
+ * held. Holds nothing but the current foreground package name (#1502).
+ */
+class ForegroundPackageTracker(private val targetPackage: String) {
+
+    private var foregroundPackage: String? = null
+
+    /** Applies [events] in order. Returns true when the tracked target's foreground state changed. */
+    fun apply(events: List<ForegroundEvent>): Boolean {
+        val before = isTargetForeground
+        for (event in events) {
+            when (event.transition) {
+                ForegroundTransition.ENTER ->
+                    if (foregroundPackage != event.packageName) foregroundPackage = event.packageName
+
+                ForegroundTransition.EXIT ->
+                    if (foregroundPackage == event.packageName) foregroundPackage = null
+            }
+        }
+        return before != isTargetForeground
+    }
+
+    /** True when [targetPackage] currently owns the foreground. */
+    val isTargetForeground: Boolean get() = foregroundPackage == targetPackage
+}
+
+/**
  * #1502: watches for [targetPackage] becoming/leaving the foreground app and reports the
  * transitions to [onCameraEntered] / [onCameraExited].
  *
@@ -55,7 +83,7 @@ class CameraForegroundMonitor(
     private val clock: () -> Long = System::currentTimeMillis,
 ) {
 
-    private var foregroundPackage: String? = null
+    private val tracker = ForegroundPackageTracker(targetPackage)
     private var appliedTargetForeground = false
 
     /**
@@ -80,15 +108,7 @@ class CameraForegroundMonitor(
 
     /** Returns true when the window was consumed, so the next poll can start after it. */
     private fun poll(windowStart: Long, now: Long): Boolean = try {
-        for (event in source.eventsBetween(windowStart, now)) {
-            when (event.transition) {
-                ForegroundTransition.ENTER ->
-                    if (foregroundPackage != event.packageName) foregroundPackage = event.packageName
-
-                ForegroundTransition.EXIT ->
-                    if (foregroundPackage == event.packageName) foregroundPackage = null
-            }
-        }
+        tracker.apply(source.eventsBetween(windowStart, now))
         true
     } catch (e: CancellationException) {
         throw e
@@ -104,7 +124,7 @@ class CameraForegroundMonitor(
      * cadence instead of leaving the monitor believing it suspended when it did not.
      */
     private suspend fun reconcile() {
-        val desired = foregroundPackage == targetPackage
+        val desired = tracker.isTargetForeground
         if (desired == appliedTargetForeground) return
         try {
             if (desired) onCameraEntered() else onCameraExited()

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/CameraForegroundMonitor.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/CameraForegroundMonitor.kt
@@ -30,10 +30,15 @@ fun interface ForegroundEventSource {
  *
  * Transitions cannot answer this after a service or process restart: a camera that has been in
  * front since before the service started produced no recent transition at all, so the current
- * state has to come from usage aggregation instead (see [UsageStatsCurrentForegroundSource]).
+ * state (or, at least, null when nothing has been in front at all) has to be reconstructed from a
+ * window wide enough to contain that session — see [UsageStatsCurrentForegroundSource].
  */
 fun interface ForegroundPackageSource {
-    /** The package in front of the user, or null when the platform cannot say. */
+    /**
+     * The package in front of the user, or null when the source's window contains no foreground
+     * activity at all. Implementations must throw rather than return null when they cannot read
+     * the state, so a fail-safe caller never mistakes "unreadable" for "nothing in front".
+     */
     fun currentForegroundPackage(): String?
 }
 
@@ -49,15 +54,7 @@ class ForegroundPackageTracker(private val targetPackage: String) {
     /** Applies [events] in order. Returns true when the tracked target's foreground state changed. */
     fun apply(events: List<ForegroundEvent>): Boolean {
         val before = isTargetForeground
-        for (event in events) {
-            when (event.transition) {
-                ForegroundTransition.ENTER ->
-                    if (foregroundPackage != event.packageName) foregroundPackage = event.packageName
-
-                ForegroundTransition.EXIT ->
-                    if (foregroundPackage == event.packageName) foregroundPackage = null
-            }
-        }
+        foregroundPackage = applyForegroundTransitions(foregroundPackage, events)
         return before != isTargetForeground
     }
 
@@ -74,6 +71,26 @@ class ForegroundPackageTracker(private val targetPackage: String) {
 }
 
 /**
+ * Applies foreground transitions in order to [from] and returns the package left in front, or null
+ * when none is (#1502). The last package to enter wins; an exit clears the state only when the
+ * package leaving is the one currently held. Shared by the incremental tracker and by callers that
+ * reconstruct the current state from a window of events.
+ */
+internal fun applyForegroundTransitions(from: String?, events: List<ForegroundEvent>): String? {
+    var foregroundPackage = from
+    for (event in events) {
+        when (event.transition) {
+            ForegroundTransition.ENTER ->
+                if (foregroundPackage != event.packageName) foregroundPackage = event.packageName
+
+            ForegroundTransition.EXIT ->
+                if (foregroundPackage == event.packageName) foregroundPackage = null
+        }
+    }
+    return foregroundPackage
+}
+
+/**
  * #1502: watches for [targetPackage] becoming/leaving the foreground app and reports the
  * transitions to [onCameraEntered] / [onCameraExited].
  *
@@ -81,9 +98,10 @@ class ForegroundPackageTracker(private val targetPackage: String) {
  * - **State before capture.** [run] first establishes the current foreground package from
  *   [currentForegroundPackage] and reports it, so a caller that arms wake capture only in response
  *   to [onCameraExited] can never take the microphone while the target is already in front —
- *   including a service/process restart after the target has been foreground for arbitrarily long,
- *   which no transition window can see. While that state cannot be read, nothing is reported and
- *   the monitor retries on the next cadence.
+ *   including a service/process restart during a target session that is already running, which the
+ *   monitor's own poll window alone cannot see. How far back that reconstruction reaches is the
+ *   source's lookback (see [SEED_LOOKBACK_MS]); while the state cannot be read, nothing is
+ *   reported and the monitor retries on the next cadence.
  * - **Transitions only.** Callbacks fire on a change of the target's foreground state, never once
  *   per poll, so repeated events cannot duplicate a pause/resume operation.
  * - **Failure isolated.** A failing query or a failing callback is logged and retried on the next
@@ -136,9 +154,10 @@ class CameraForegroundMonitor(
     }
 
     /**
-     * Establishes the current foreground state, in place of replaying a transition window, and
-     * starts the event window at the moment it was resolved. Returns false — to be retried on the
-     * next cadence — while the platform cannot say which package is in front.
+     * Establishes the current foreground state by replaying the events that are still readable,
+     * and starts the event window at the moment it was resolved. An empty replay is a valid
+     * answer — nothing was in front within the source's lookback — but a source that cannot be
+     * read returns false so the state is retried on the next cadence rather than assumed.
      */
     private fun seed(): Boolean {
         val current = try {
@@ -147,10 +166,6 @@ class CameraForegroundMonitor(
             throw e
         } catch (e: Exception) {
             Log.w(TAG, "current foreground package could not be read; retrying next tick", e)
-            return false
-        }
-        if (current == null) {
-            Log.w(TAG, "no current foreground package reported; retrying next tick")
             return false
         }
         tracker.seed(current)
@@ -205,9 +220,13 @@ class CameraForegroundMonitor(
 /** Reads foreground-activity transitions from [UsageStatsManager] (requires Usage Access). */
 class UsageStatsForegroundEventSource(private val context: Context) : ForegroundEventSource {
     override fun eventsBetween(startMillis: Long, endMillis: Long): List<ForegroundEvent> {
+        // Unreadable has to look different from "no events": callers treat an empty window as
+        // "the target is not in front", so a query that cannot run at all must throw and let them
+        // fall back to their fail-safe.
         val manager = context.getSystemService(Context.USAGE_STATS_SERVICE) as? UsageStatsManager
-            ?: return emptyList()
-        val usageEvents = manager.queryEvents(startMillis, endMillis) ?: return emptyList()
+            ?: error("usage stats service is unavailable")
+        val usageEvents = manager.queryEvents(startMillis, endMillis)
+            ?: error("usage events could not be read")
         // Events are converted immediately and the platform event object is reused; nothing is
         // retained or copied beyond the transition and package name.
         val transitions = ArrayList<ForegroundEvent>()
@@ -233,50 +252,38 @@ class UsageStatsForegroundEventSource(private val context: Context) : Foreground
 }
 
 /**
- * How far back [UsageStatsCurrentForegroundSource] reads usage aggregation. The range only has to
- * reach the moment the package now in front became visible; a day covers every foreground session
- * a device that sleeps can produce, and the query returns one aggregated row per package per day
- * bucket rather than raw events.
+ * How far back [UsageStatsCurrentForegroundSource] replays foreground events when a monitor
+ * starts. It only has to reach the moment the package now in front became visible, so it has to
+ * outlast the foreground session that is already running — hours, not seconds. It is deliberately
+ * bounded: a package that entered the foreground earlier than this and produced no event since
+ * cannot be reconstructed from any public API.
  */
-private const val CURRENT_FOREGROUND_RANGE_MS = 24L * 60 * 60 * 1000
+internal const val SEED_LOOKBACK_MS = 6L * 60 * 60 * 1000
 
 /**
- * Resolves the package in front of the user from usage aggregation (requires Usage Access).
+ * Resolves the package in front of the user by replaying recent foreground events (requires Usage
+ * Access).
  *
- * A transition query cannot answer this when the current package has been foreground for longer
- * than the queried window — the window then contains no event for it at all — so the state comes
- * from the aggregated `lastTimeVisible` timestamps instead: the package that became visible most
- * recently is the one in front. Verified on the affected BKQ-N49: a camera in front for over
- * 100 s is the most recently visible package, and the package that takes over from it replaces it
- * within the monitor's cadence. Nothing is retained beyond the resolved package name.
+ * Usage *aggregation* (`queryUsageStats`) is not usable for this: measured on the affected BKQ-N49,
+ * the platform's aggregated view lags the device — with the camera in the foreground it reported a
+ * package that had not been visible for minutes, and after the camera left it kept reporting the
+ * camera. Activity *events* (`queryEvents`) are delivered live on the same device (sub-second), so
+ * the current state is reconstructed from them with the monitor's own transition rule.
+ *
+ * A missing or unreadable usage-stats service throws, so callers fall back to their fail-safe
+ * instead of mistaking an unanswerable query for "nothing in front". Nothing is retained beyond
+ * the resolved package name.
  */
-class UsageStatsCurrentForegroundSource(private val context: Context) : ForegroundPackageSource {
+class UsageStatsCurrentForegroundSource(
+    private val context: Context,
+    private val lookbackMillis: Long = SEED_LOOKBACK_MS,
+    private val clock: () -> Long = System::currentTimeMillis,
+    private val eventSource: (Context) -> ForegroundEventSource = ::UsageStatsForegroundEventSource,
+) : ForegroundPackageSource {
 
     override fun currentForegroundPackage(): String? {
-        val manager = context.getSystemService(Context.USAGE_STATS_SERVICE) as? UsageStatsManager
-            ?: return null
-        val now = System.currentTimeMillis()
-        val stats = manager.queryUsageStats(
-            UsageStatsManager.INTERVAL_DAILY,
-            now - CURRENT_FOREGROUND_RANGE_MS,
-            now,
-        ) ?: return null
-        return mostRecentlyVisiblePackage(stats.map { it.packageName to it.lastTimeVisible })
+        val now = clock()
+        val events = eventSource(context).eventsBetween(now - lookbackMillis, now)
+        return applyForegroundTransitions(from = null, events = events)
     }
-}
-
-/**
- * The package that became visible most recently, or null when no package reports a visible
- * timestamp — an unanswerable state, which callers must treat as "cannot confirm the foreground".
- */
-internal fun mostRecentlyVisiblePackage(visibleSince: List<Pair<String, Long>>): String? {
-    var candidate: String? = null
-    var newest = 0L
-    for ((packageName, visibleAt) in visibleSince) {
-        if (visibleAt > newest) {
-            newest = visibleAt
-            candidate = packageName
-        }
-    }
-    return candidate
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/HonorCameraCoexistence.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/HonorCameraCoexistence.kt
@@ -12,12 +12,6 @@ import android.util.Log
 private const val TAG = "HonorCamera"
 
 /**
- * How far back the immediate re-arm guard looks. One poll interval (plus slack) is enough: a
- * camera launch older than that has already been seen by the monitor and latched.
- */
-internal const val CAMERA_JUST_ENTERED_LOOKBACK_MS = 3_000L
-
-/**
  * #1502: on the Honor Magic 8 Pro (BKQ-N49), MagicOS refuses to start stock camera video
  * recording while a background app holds a `VOICE_RECOGNITION` capture. Jandal's wake detector
  * holds exactly such a capture, and the camera app receives no platform callback that could warn
@@ -86,27 +80,20 @@ object HonorCameraCoexistence {
         !isAffectedDevice(context) || hasUsageAccess(context)
 
     /**
-     * True when the camera is (or has just become) the foreground app on an affected device, so
-     * wake capture must be withheld (#1502).
+     * True when wake capture must be withheld because the Honor Camera is (or may be) the app in
+     * front of the user (#1502).
      *
-     * The monitor's suspension latch normally covers this, but a voice session can end in the gap
-     * between the camera taking the foreground and the monitor's next poll — and that session end
-     * is itself a re-arm trigger. This bounded, immediate check closes that gap; the window only
-     * needs to span one poll interval, and an older camera launch is already covered by the latch.
+     * This asks for the *current* foreground package instead of a recent-transition window: after
+     * a service or process restart the in-memory suspension latch is gone, and a camera that has
+     * been in front for longer than any window produces no transition at all. Usage aggregation
+     * still reports it (verified on BKQ-N49 with the camera foreground for over 100 s), and the
+     * package that takes over from the camera is reported within the same sub-cadence delay, so
+     * this also covers a voice session ending between the camera appearing and the monitor's next
+     * poll.
      */
-    fun shouldWithholdWakeCapture(
-        context: Context,
-        lookbackMillis: Long = CAMERA_JUST_ENTERED_LOOKBACK_MS,
-    ): Boolean {
+    fun shouldWithholdWakeCapture(context: Context): Boolean {
         if (!isAffectedDevice(context)) return false
-        val now = System.currentTimeMillis()
-        val source = UsageStatsForegroundEventSource(context)
-        return cameraForegroundWithin(
-            source = source,
-            nowMillis = now,
-            lookbackMillis = lookbackMillis,
-            targetPackage = CAMERA_PACKAGE,
-        )
+        return mustWithholdWakeCapture(UsageStatsCurrentForegroundSource(context), CAMERA_PACKAGE)
     }
 
     /**
@@ -148,18 +135,20 @@ fun mayRearmAfterCamera(
 ): Boolean = heyJandalEnabled && recordAudioGranted && !captureSuspended && !voiceSessionActive && captureAllowed
 
 /**
- * Whether [targetPackage] became the foreground app within the last [lookbackMillis].
+ * Whether wake capture must be withheld because [targetPackage] may own the foreground.
  *
- * Only the window's events are read, resolved in memory and discarded; nothing is retained beyond
- * the current foreground package name.
+ * A state that cannot be read — no package reported, or the query threw — withholds capture. The
+ * two costs are not symmetric: withholding leaves the wake word quiet until the next foreground
+ * transition, while taking the microphone blocks the camera, which is the defect #1502 exists to
+ * prevent.
  */
-internal fun cameraForegroundWithin(
-    source: ForegroundEventSource,
-    nowMillis: Long,
-    lookbackMillis: Long,
+internal fun mustWithholdWakeCapture(
+    source: ForegroundPackageSource,
     targetPackage: String,
-): Boolean {
-    val tracker = ForegroundPackageTracker(targetPackage)
-    tracker.apply(source.eventsBetween(nowMillis - lookbackMillis, nowMillis))
-    return tracker.isTargetForeground
+): Boolean = try {
+    val current = source.currentForegroundPackage()
+    current == null || current == targetPackage
+} catch (e: Exception) {
+    Log.w(TAG, "current foreground package could not be read — withholding wake capture", e)
+    true
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/HonorCameraCoexistence.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/HonorCameraCoexistence.kt
@@ -12,6 +12,12 @@ import android.util.Log
 private const val TAG = "HonorCamera"
 
 /**
+ * How far back the immediate re-arm guard looks. One poll interval (plus slack) is enough: a
+ * camera launch older than that has already been seen by the monitor and latched.
+ */
+internal const val CAMERA_JUST_ENTERED_LOOKBACK_MS = 3_000L
+
+/**
  * #1502: on the Honor Magic 8 Pro (BKQ-N49), MagicOS refuses to start stock camera video
  * recording while a background app holds a `VOICE_RECOGNITION` capture. Jandal's wake detector
  * holds exactly such a capture, and the camera app receives no platform callback that could warn
@@ -80,6 +86,30 @@ object HonorCameraCoexistence {
         !isAffectedDevice(context) || hasUsageAccess(context)
 
     /**
+     * True when the camera is (or has just become) the foreground app on an affected device, so
+     * wake capture must be withheld (#1502).
+     *
+     * The monitor's suspension latch normally covers this, but a voice session can end in the gap
+     * between the camera taking the foreground and the monitor's next poll — and that session end
+     * is itself a re-arm trigger. This bounded, immediate check closes that gap; the window only
+     * needs to span one poll interval, and an older camera launch is already covered by the latch.
+     */
+    fun shouldWithholdWakeCapture(
+        context: Context,
+        lookbackMillis: Long = CAMERA_JUST_ENTERED_LOOKBACK_MS,
+    ): Boolean {
+        if (!isAffectedDevice(context)) return false
+        val now = System.currentTimeMillis()
+        val source = UsageStatsForegroundEventSource(context)
+        return cameraForegroundWithin(
+            source = source,
+            nowMillis = now,
+            lookbackMillis = lookbackMillis,
+            targetPackage = CAMERA_PACKAGE,
+        )
+    }
+
+    /**
      * Usage Access settings surface, package-scoped where the OEM supports it so the user lands
      * on Jandal's own row rather than the full app list.
      */
@@ -116,3 +146,20 @@ fun mayRearmAfterCamera(
     voiceSessionActive: Boolean,
     captureAllowed: Boolean,
 ): Boolean = heyJandalEnabled && recordAudioGranted && !captureSuspended && !voiceSessionActive && captureAllowed
+
+/**
+ * Whether [targetPackage] became the foreground app within the last [lookbackMillis].
+ *
+ * Only the window's events are read, resolved in memory and discarded; nothing is retained beyond
+ * the current foreground package name.
+ */
+internal fun cameraForegroundWithin(
+    source: ForegroundEventSource,
+    nowMillis: Long,
+    lookbackMillis: Long,
+    targetPackage: String,
+): Boolean {
+    val tracker = ForegroundPackageTracker(targetPackage)
+    tracker.apply(source.eventsBetween(nowMillis - lookbackMillis, nowMillis))
+    return tracker.isTargetForeground
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/HonorCameraCoexistence.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/HonorCameraCoexistence.kt
@@ -1,0 +1,118 @@
+package com.kernel.ai.core.voice
+
+import android.app.AppOpsManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Process
+import android.provider.Settings
+import android.util.Log
+
+private const val TAG = "HonorCamera"
+
+/**
+ * #1502: on the Honor Magic 8 Pro (BKQ-N49), MagicOS refuses to start stock camera video
+ * recording while a background app holds a `VOICE_RECOGNITION` capture. Jandal's wake detector
+ * holds exactly such a capture, and the camera app receives no platform callback that could warn
+ * Jandal before it gives up — audio configuration/audio-focus/camera callbacks were all evaluated
+ * on device and provide no usable pre-recording signal.
+ *
+ * The approved workaround is deliberately narrow: on the proven device only, Jandal watches for
+ * [CAMERA_PACKAGE] becoming the foreground app and proactively releases its own microphone
+ * capture, then re-arms when the camera leaves. Detecting the camera needs Usage Access, which on
+ * this device is therefore a prerequisite for running the wake word at all.
+ *
+ * Scope rules — everything here applies to the `HONOR` + `BKQ-N49` pair only:
+ * - other devices never require Usage Access, never poll for foreground apps, and keep the
+ *   existing wake path unchanged;
+ * - the workaround is not generalised to other Honor models, other MagicOS releases, or other
+ *   camera applications without separate physical evidence.
+ */
+object HonorCameraCoexistence {
+
+    /** Stock Honor camera package proven to contend for the microphone on BKQ-N49. */
+    const val CAMERA_PACKAGE = "com.hihonor.camera"
+
+    internal const val AFFECTED_MANUFACTURER = "honor"
+    internal const val AFFECTED_MODEL = "BKQ-N49"
+
+    /**
+     * True only for the device class where MagicOS microphone arbitration was proven.
+     * Model-exact on purpose: manufacturer-wide matching would claim support that has not been
+     * validated on any other Honor device.
+     */
+    fun isAffectedDevice(manufacturer: String?, model: String?): Boolean =
+        manufacturer?.trim()?.equals(AFFECTED_MANUFACTURER, ignoreCase = true) == true &&
+            model?.trim()?.equals(AFFECTED_MODEL, ignoreCase = true) == true
+
+    /** True when this device needs the camera-coexistence workaround. */
+    fun isAffectedDevice(context: Context): Boolean =
+        isAffectedDevice(Build.MANUFACTURER, Build.MODEL)
+
+    /**
+     * Whether Usage Access is currently granted.
+     *
+     * `PACKAGE_USAGE_STATS` is a special (AppOps) access: declaring the permission grants
+     * nothing, the user grants it from system settings, and they can revoke it again at any time.
+     * Never assume that declaring the permission means access exists.
+     */
+    fun hasUsageAccess(context: Context): Boolean = try {
+        val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as? AppOpsManager
+        appOps?.unsafeCheckOpNoThrow(
+            AppOpsManager.OPSTR_GET_USAGE_STATS,
+            Process.myUid(),
+            context.packageName,
+        ) == AppOpsManager.MODE_ALLOWED
+    } catch (e: Exception) {
+        Log.w(TAG, "Usage Access state could not be determined", e)
+        false
+    }
+
+    /**
+     * Whether Jandal may hold the wake microphone right now.
+     *
+     * Unaffected devices: always. Affected device: only with Usage Access — without it Jandal
+     * cannot learn that the camera needs the microphone and would silently block video recording,
+     * so listening must not run at all.
+     */
+    fun isWakeCaptureAllowed(context: Context): Boolean =
+        !isAffectedDevice(context) || hasUsageAccess(context)
+
+    /**
+     * Usage Access settings surface, package-scoped where the OEM supports it so the user lands
+     * on Jandal's own row rather than the full app list.
+     */
+    fun usageAccessSettingsIntent(context: Context): Intent {
+        val packageScoped = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS)
+            .setData(Uri.fromParts("package", context.packageName, null))
+        return if (context.packageManager.resolveActivity(packageScoped, 0) != null) {
+            packageScoped
+        } else {
+            Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS)
+        }
+    }
+}
+
+/**
+ * Whether the wake detector may be re-armed after the Honor Camera leaves the foreground.
+ *
+ * Every condition the workaround depends on is re-checked here, because any of them can change
+ * while the camera is in front of the user:
+ *
+ * - [heyJandalEnabled] — the user may have disabled Hey Jandal while the camera was open.
+ * - [recordAudioGranted] — microphone permission can be revoked while Jandal is suspended.
+ * - [captureSuspended] — Jandal's own microphone latch; still set means something else (the
+ *   camera, or a lost camera-coexistence capability) is holding the microphone.
+ * - [voiceSessionActive] — another Jandal voice session (push-to-talk, assistant, widget) owns the
+ *   microphone; re-arming would contend with it.
+ * - [captureAllowed] — the device-level capability to run wake capture at all, which on the
+ *   affected device requires Usage Access (see [HonorCameraCoexistence.isWakeCaptureAllowed]).
+ */
+fun mayRearmAfterCamera(
+    heyJandalEnabled: Boolean,
+    recordAudioGranted: Boolean,
+    captureSuspended: Boolean,
+    voiceSessionActive: Boolean,
+    captureAllowed: Boolean,
+): Boolean = heyJandalEnabled && recordAudioGranted && !captureSuspended && !voiceSessionActive && captureAllowed

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/HonorCameraCoexistence.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/HonorCameraCoexistence.kt
@@ -83,17 +83,21 @@ object HonorCameraCoexistence {
      * True when wake capture must be withheld because the Honor Camera is (or may be) the app in
      * front of the user (#1502).
      *
-     * This asks for the *current* foreground package instead of a recent-transition window: after
-     * a service or process restart the in-memory suspension latch is gone, and a camera that has
-     * been in front for longer than any window produces no transition at all. Usage aggregation
-     * still reports it (verified on BKQ-N49 with the camera foreground for over 100 s), and the
-     * package that takes over from the camera is reported within the same sub-cadence delay, so
-     * this also covers a voice session ending between the camera appearing and the monitor's next
-     * poll.
+     * This answers "is the camera in front *now*" from foreground events rather than from a
+     * transition that happened to land in a window. It is the guard for re-arm paths that the
+     * monitor does not drive itself (a voice session ending, the wake handoff finishing): the
+     * camera may have resumed since the monitor's last poll, and the window covers that gap.
+     *
+     * Usage *aggregation* was tried here first and removed: measured on the affected BKQ-N49 it
+     * lags the device, reporting a package that had not been visible for minutes while the camera
+     * was in front, and still reporting the camera after it had left. Events are live on the same
+     * device. A camera held in front for longer than the poll cadence is covered by the suspension
+     * latch instead, which the monitor sets and clears.
      */
     fun shouldWithholdWakeCapture(context: Context): Boolean {
         if (!isAffectedDevice(context)) return false
-        return mustWithholdWakeCapture(UsageStatsCurrentForegroundSource(context), CAMERA_PACKAGE)
+        val source = UsageStatsCurrentForegroundSource(context, REARM_GUARD_LOOKBACK_MS)
+        return mustWithholdWakeCapture(source, CAMERA_PACKAGE)
     }
 
     /**
@@ -135,19 +139,26 @@ fun mayRearmAfterCamera(
 ): Boolean = heyJandalEnabled && recordAudioGranted && !captureSuspended && !voiceSessionActive && captureAllowed
 
 /**
- * Whether wake capture must be withheld because [targetPackage] may own the foreground.
+ * How much recent foreground activity the re-arm guard replays. It only has to span the interval
+ * between the camera resuming and the monitor applying that event — one poll cadence plus platform
+ * event-delivery latency — because a camera that has been in front for longer than that is already
+ * covered by the suspension latch, and an exit inside the window clears the guard again.
+ */
+internal const val REARM_GUARD_LOOKBACK_MS = 5_000L
+
+/**
+ * Whether wake capture must be withheld because [targetPackage] owns the foreground.
  *
- * A state that cannot be read — no package reported, or the query threw — withholds capture. The
- * two costs are not symmetric: withholding leaves the wake word quiet until the next foreground
- * transition, while taking the microphone blocks the camera, which is the defect #1502 exists to
- * prevent.
+ * "No foreground activity in the window" clears the guard — the camera would have produced an
+ * event — while a state that cannot be read at all withholds capture. The two costs are not
+ * symmetric: withholding leaves the wake word quiet until the next foreground transition, while
+ * taking the microphone blocks the camera, which is the defect #1502 exists to prevent.
  */
 internal fun mustWithholdWakeCapture(
     source: ForegroundPackageSource,
     targetPackage: String,
 ): Boolean = try {
-    val current = source.currentForegroundPackage()
-    current == null || current == targetPackage
+    source.currentForegroundPackage() == targetPackage
 } catch (e: Exception) {
     Log.w(TAG, "current foreground package could not be read — withholding wake capture", e)
     true

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/CameraForegroundMonitorTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/CameraForegroundMonitorTest.kt
@@ -19,7 +19,6 @@ class CameraForegroundMonitorTest {
     private val camera = HonorCameraCoexistence.CAMERA_PACKAGE
     private val otherApp = "com.example.other"
     private val pollIntervalMs = 2_000L
-    private val lookbackMs = 60_000L
 
     /** Foreground source whose responses are scripted per query. */
     private class FakeSource(private val responses: List<() -> List<ForegroundEvent>>) :
@@ -47,6 +46,25 @@ class CameraForegroundMonitorTest {
         }
     }
 
+    /**
+     * Current foreground state as usage aggregation reports it. A null response stands for a state
+     * that cannot be read — the same thing a failing aggregation query produces.
+     */
+    private class FakeCurrent(private val responses: List<String?>) : ForegroundPackageSource {
+        var queries = 0
+            private set
+
+        override fun currentForegroundPackage(): String? {
+            val response = responses[queries.coerceAtMost(responses.size - 1)]
+            queries += 1
+            return response ?: throw IllegalStateException("usage aggregation unavailable")
+        }
+
+        companion object {
+            fun of(vararg responses: String?): FakeCurrent = FakeCurrent(responses.toList())
+        }
+    }
+
     private class Recorder {
         var entered = 0
         var exited = 0
@@ -56,19 +74,22 @@ class CameraForegroundMonitorTest {
     private fun monitor(
         source: ForegroundEventSource,
         recorder: Recorder,
+        current: ForegroundPackageSource = FakeCurrent.of(otherApp),
         isReady: () -> Boolean = { true },
         onCameraEntered: suspend () -> Unit = { recorder.entered += 1 },
         onCameraExited: suspend () -> Unit = { recorder.exited += 1 },
+        onUnavailable: suspend () -> Unit = { recorder.unavailable += 1 },
+        clock: () -> Long = { NOW },
     ) = CameraForegroundMonitor(
         source = source,
         targetPackage = camera,
         pollIntervalMs = pollIntervalMs,
-        initialLookbackMillis = lookbackMs,
+        currentForegroundPackage = current,
         isReady = isReady,
         onCameraEntered = onCameraEntered,
         onCameraExited = onCameraExited,
-        onUnavailable = { recorder.unavailable += 1 },
-        clock = { NOW },
+        onUnavailable = onUnavailable,
+        clock = clock,
     )
 
     private fun enter(packageName: String) = ForegroundEvent(ForegroundTransition.ENTER, packageName)
@@ -85,7 +106,7 @@ class CameraForegroundMonitorTest {
         runCurrent()
 
         assertEquals(1, recorder.entered)
-        assertEquals(0, recorder.exited)
+        assertEquals(1, recorder.exited, "the startup state alone is already a clean, armable state")
         job.cancel()
     }
 
@@ -115,7 +136,7 @@ class CameraForegroundMonitorTest {
         runCurrent()
 
         assertEquals(1, recorder.entered)
-        assertEquals(1, recorder.exited)
+        assertEquals(2, recorder.exited, "the startup report, then the camera leaving")
         job.cancel()
     }
 
@@ -130,36 +151,102 @@ class CameraForegroundMonitorTest {
         runCurrent()
 
         assertEquals(1, recorder.entered)
-        assertEquals(1, recorder.exited)
+        assertEquals(2, recorder.exited, "the startup report, then the camera leaving")
         job.cancel()
     }
 
+    // ── Startup state: a service or process restart must not take the microphone first ─────────
+
     @Test
-    fun `a monitor started while the camera is already foreground suspends immediately`() = runTest {
-        // The initial lookback window is the only poll that can see an earlier camera launch.
-        val source = FakeSource.of(listOf(enter(otherApp), enter(camera)))
+    fun `a camera in front before the monitor started keeps wake capture suspended until it leaves`() =
+        runTest {
+            // The camera has been foreground since well before this monitor existed, so its launch
+            // is in none of the polls' windows — the state can only come from usage aggregation.
+            val source = FakeSource.of(
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                listOf(exit(camera)),
+            )
+            val recorder = Recorder()
+            var armed = false
+            val job = launch {
+                monitor(
+                    source = source,
+                    recorder = recorder,
+                    current = FakeCurrent.of(camera),
+                    onCameraExited = { armed = true },
+                ).run()
+            }
+
+            runCurrent()
+            assertEquals(1, recorder.entered, "the startup state suspends capture before anything arms")
+            assertEquals(0, source.queries, "no event window is consulted before the state is known")
+
+            advanceTimeBy(pollIntervalMs * 3)
+            runCurrent()
+            assertFalse(armed, "no poll may arm capture while the camera is still in front")
+
+            advanceTimeBy(pollIntervalMs * 6)
+            runCurrent()
+            assertTrue(armed, "the camera leaving is what releases capture to arm")
+            job.cancel()
+        }
+
+    @Test
+    fun `a clean startup reports the state so the caller may arm`() = runTest {
+        val source = FakeSource.of(emptyList())
         val recorder = Recorder()
         val job = launch { monitor(source, recorder).run() }
 
         runCurrent()
 
-        assertEquals(1, recorder.entered, "no poll interval may pass before the microphone is released")
-        assertEquals(NOW - lookbackMs, source.windows.first().first)
+        assertEquals(1, recorder.exited, "the caller arms from the startup report, not from a window")
+        assertEquals(0, recorder.entered)
         job.cancel()
     }
 
     @Test
-    fun `later polls read only the window since the previous poll`() = runTest {
-        val source = FakeSource.of(listOf(enter(camera)))
+    fun `an unreadable startup state is retried and arms nothing until it can be read`() = runTest {
+        val source = FakeSource.of(emptyList())
+        val recorder = Recorder()
+        val current = FakeCurrent.of(null, null, otherApp)
+        val job = launch { monitor(source, recorder, current = current).run() }
+
+        runCurrent()
+        assertEquals(0, recorder.exited, "an unanswerable state must not arm wake capture")
+        assertEquals(0, source.queries, "and must not be patched up from a stale window")
+
+        advanceTimeBy(pollIntervalMs * 4)
+        runCurrent()
+
+        assertTrue(current.queries >= 3, "the state is re-read on every cadence until it is known")
+        assertEquals(1, recorder.exited, "the first answerable state is what arms, exactly once")
+        assertTrue(source.queries <= 2, "event polling starts only once the state is known")
+        job.cancel()
+    }
+
+    // ── Failure handling ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `later polls read only the window since the state was resolved`() = runTest {
+        val source = FakeSource.of(emptyList())
         val recorder = Recorder()
         val job = launch { monitor(source, recorder).run() }
 
         runCurrent()
-        advanceTimeBy(pollIntervalMs * 2)
+        advanceTimeBy(pollIntervalMs * 3)
         runCurrent()
 
-        assertEquals(NOW - lookbackMs to NOW, source.windows.first())
-        assertEquals(listOf(NOW to NOW, NOW to NOW), source.windows.drop(1))
+        assertTrue(source.windows.isNotEmpty())
+        assertEquals(
+            List(source.windows.size) { NOW to NOW },
+            source.windows,
+            "no poll reaches back before the moment the state was resolved",
+        )
         job.cancel()
     }
 
@@ -224,6 +311,40 @@ class CameraForegroundMonitorTest {
     }
 
     @Test
+    fun `a failed unavailable cleanup is retried instead of dropping the fail-safe`() = runTest {
+        val source = FakeSource.of(emptyList())
+        val recorder = Recorder()
+        var ready = true
+        var attempts = 0
+        val job = launch {
+            monitor(
+                source = source,
+                recorder = recorder,
+                isReady = { ready },
+                onUnavailable = {
+                    attempts += 1
+                    if (attempts < 3) throw IllegalStateException("release failed")
+                    recorder.unavailable += 1
+                },
+            ).run()
+        }
+
+        runCurrent()
+        ready = false
+        advanceTimeBy(pollIntervalMs * 2)
+        runCurrent()
+        assertTrue(attempts >= 1, "the cleanup is attempted as soon as the capability is gone")
+        assertFalse(job.isCompleted, "a failed cleanup must not end monitoring")
+
+        advanceTimeBy(pollIntervalMs * 4)
+        runCurrent()
+
+        assertTrue(attempts >= 3, "the cleanup is retried on the next cadence until it succeeds")
+        assertEquals(1, recorder.unavailable, "cleanup is reported once, when it succeeds")
+        assertTrue(job.isCompleted, "monitoring ends once the cleanup has succeeded")
+    }
+
+    @Test
     fun `cancelling the monitor stops polling`() = runTest {
         val source = FakeSource.of(listOf(enter(camera)))
         val recorder = Recorder()
@@ -242,7 +363,7 @@ class CameraForegroundMonitorTest {
     }
 
     @Test
-    fun `cancellation is not swallowed by the transition guard`() = runTest {
+    fun `cancellation is not swallowed by the transition callback`() = runTest {
         val source = FakeSource.of(listOf(enter(camera)))
         val recorder = Recorder()
         val job = launch {
@@ -258,6 +379,28 @@ class CameraForegroundMonitorTest {
         runCurrent()
 
         assertTrue(job.isCancelled, "CancellationException must propagate out of the monitor")
+    }
+
+    @Test
+    fun `cancellation is not swallowed while cleaning up after lost usage access`() = runTest {
+        val source = FakeSource.of(emptyList())
+        val recorder = Recorder()
+        var ready = true
+        val job = launch {
+            monitor(
+                source = source,
+                recorder = recorder,
+                isReady = { ready },
+                onUnavailable = { throw CancellationException("cancelled") },
+            ).run()
+        }
+
+        runCurrent()
+        ready = false
+        advanceTimeBy(pollIntervalMs)
+        runCurrent()
+
+        assertTrue(job.isCancelled, "CancellationException must propagate out of the cleanup")
     }
 
     private companion object {

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/CameraForegroundMonitorTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/CameraForegroundMonitorTest.kt
@@ -174,7 +174,8 @@ class CameraForegroundMonitorTest {
     fun `a camera in front before the monitor started keeps wake capture suspended until it leaves`() =
         runTest {
             // The camera has been foreground since well before this monitor existed, so its launch
-            // is in none of the polls' windows — the state can only come from usage aggregation.
+            // is in none of the polls' windows — the state can only come from the lookback the
+            // current-foreground source replays.
             val source = FakeSource.of(
                 emptyList(),
                 emptyList(),
@@ -262,8 +263,12 @@ class CameraForegroundMonitorTest {
             source.currentForegroundPackage(),
             "a camera that resumed earlier and never left is still the package in front",
         )
-        assertEquals(NOW - SEED_LOOKBACK_MS, windowStart, "the window has to outlast a camera session")
-        assertEquals(NOW, windowEnd)
+        assertEquals(NOW, windowEnd, "the window always ends at the moment of the query")
+        assertTrue(
+            windowStart <= NOW - 60L * 60 * 1000,
+            "the window has to outlast a camera session that started hours earlier, not a poll; " +
+                "it was only ${NOW - windowStart}ms",
+        )
     }
 
     @Test

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/CameraForegroundMonitorTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/CameraForegroundMonitorTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -261,5 +262,23 @@ class CameraForegroundMonitorTest {
 
     private companion object {
         const val NOW = 1_700_000_000_000L
+    }
+
+    // ── Foreground tracking semantics (shared by the monitor and the re-arm guard) ─────────────
+
+    @Test
+    fun `the tracker follows the last package that entered the foreground`() {
+        val tracker = ForegroundPackageTracker(camera)
+
+        assertFalse(tracker.isTargetForeground)
+        assertTrue(tracker.apply(listOf(enter(otherApp), enter(camera))), "entering the target flips state")
+        assertTrue(tracker.isTargetForeground)
+        assertFalse(tracker.apply(listOf(exit(otherApp))), "a non-target exit does not disturb the target")
+        assertTrue(tracker.isTargetForeground)
+        assertTrue(tracker.apply(listOf(enter(otherApp))), "another app taking over clears the target")
+        assertFalse(tracker.isTargetForeground)
+        assertTrue(tracker.apply(listOf(enter(camera))), "re-entering the target flips state back")
+        assertFalse(tracker.apply(listOf(enter(camera))), "repeated events are idempotent")
+        assertTrue(tracker.isTargetForeground)
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/CameraForegroundMonitorTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/CameraForegroundMonitorTest.kt
@@ -1,0 +1,265 @@
+package com.kernel.ai.core.voice
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * #1502: transition behaviour of the Honor camera foreground monitor — the mechanism that decides
+ * when Jandal yields the microphone and when it takes it back.
+ */
+class CameraForegroundMonitorTest {
+
+    private val camera = HonorCameraCoexistence.CAMERA_PACKAGE
+    private val otherApp = "com.example.other"
+    private val pollIntervalMs = 2_000L
+    private val lookbackMs = 60_000L
+
+    /** Foreground source whose responses are scripted per query. */
+    private class FakeSource(private val responses: List<() -> List<ForegroundEvent>>) :
+        ForegroundEventSource {
+        val windows = mutableListOf<Pair<Long, Long>>()
+        var queries = 0
+            private set
+
+        override fun eventsBetween(startMillis: Long, endMillis: Long): List<ForegroundEvent> {
+            val index = queries.coerceAtMost(responses.size - 1)
+            queries += 1
+            windows += startMillis to endMillis
+            return responses[index]()
+        }
+
+        companion object {
+            fun of(vararg responses: List<ForegroundEvent>): FakeSource =
+                FakeSource(responses.map { response -> { response } })
+
+            fun throwingFirst(vararg responses: List<ForegroundEvent>): FakeSource = FakeSource(
+                listOf<() -> List<ForegroundEvent>>(
+                    { throw IllegalStateException("usage stats unavailable") },
+                ) + responses.map { response -> { response } },
+            )
+        }
+    }
+
+    private class Recorder {
+        var entered = 0
+        var exited = 0
+        var unavailable = 0
+    }
+
+    private fun monitor(
+        source: ForegroundEventSource,
+        recorder: Recorder,
+        isReady: () -> Boolean = { true },
+        onCameraEntered: suspend () -> Unit = { recorder.entered += 1 },
+        onCameraExited: suspend () -> Unit = { recorder.exited += 1 },
+    ) = CameraForegroundMonitor(
+        source = source,
+        targetPackage = camera,
+        pollIntervalMs = pollIntervalMs,
+        initialLookbackMillis = lookbackMs,
+        isReady = isReady,
+        onCameraEntered = onCameraEntered,
+        onCameraExited = onCameraExited,
+        onUnavailable = { recorder.unavailable += 1 },
+        clock = { NOW },
+    )
+
+    private fun enter(packageName: String) = ForegroundEvent(ForegroundTransition.ENTER, packageName)
+    private fun exit(packageName: String) = ForegroundEvent(ForegroundTransition.EXIT, packageName)
+
+    @Test
+    fun `camera entering the foreground suspends wake capture exactly once`() = runTest {
+        val source = FakeSource.of(listOf(enter(camera)))
+        val recorder = Recorder()
+        val job = launch { monitor(source, recorder).run() }
+
+        runCurrent()
+        advanceTimeBy(pollIntervalMs * 5)
+        runCurrent()
+
+        assertEquals(1, recorder.entered)
+        assertEquals(0, recorder.exited)
+        job.cancel()
+    }
+
+    @Test
+    fun `repeated foreground events do not duplicate the suspend`() = runTest {
+        val source = FakeSource.of(listOf(enter(camera)))
+        val recorder = Recorder()
+        val job = launch { monitor(source, recorder).run() }
+
+        runCurrent()
+        advanceTimeBy(pollIntervalMs * 6)
+        runCurrent()
+
+        assertEquals(1, recorder.entered, "one suspend for any number of camera foreground events")
+        assertTrue(source.queries > 3, "the monitor keeps polling while suspended")
+        job.cancel()
+    }
+
+    @Test
+    fun `camera leaving the foreground re-arms once`() = runTest {
+        val source = FakeSource.of(listOf(enter(camera)), listOf(exit(camera)))
+        val recorder = Recorder()
+        val job = launch { monitor(source, recorder).run() }
+
+        runCurrent()
+        advanceTimeBy(pollIntervalMs * 3)
+        runCurrent()
+
+        assertEquals(1, recorder.entered)
+        assertEquals(1, recorder.exited)
+        job.cancel()
+    }
+
+    @Test
+    fun `another app taking the foreground counts as the camera leaving`() = runTest {
+        val source = FakeSource.of(listOf(enter(camera)), listOf(enter(otherApp)))
+        val recorder = Recorder()
+        val job = launch { monitor(source, recorder).run() }
+
+        runCurrent()
+        advanceTimeBy(pollIntervalMs * 3)
+        runCurrent()
+
+        assertEquals(1, recorder.entered)
+        assertEquals(1, recorder.exited)
+        job.cancel()
+    }
+
+    @Test
+    fun `a monitor started while the camera is already foreground suspends immediately`() = runTest {
+        // The initial lookback window is the only poll that can see an earlier camera launch.
+        val source = FakeSource.of(listOf(enter(otherApp), enter(camera)))
+        val recorder = Recorder()
+        val job = launch { monitor(source, recorder).run() }
+
+        runCurrent()
+
+        assertEquals(1, recorder.entered, "no poll interval may pass before the microphone is released")
+        assertEquals(NOW - lookbackMs, source.windows.first().first)
+        job.cancel()
+    }
+
+    @Test
+    fun `later polls read only the window since the previous poll`() = runTest {
+        val source = FakeSource.of(listOf(enter(camera)))
+        val recorder = Recorder()
+        val job = launch { monitor(source, recorder).run() }
+
+        runCurrent()
+        advanceTimeBy(pollIntervalMs * 2)
+        runCurrent()
+
+        assertEquals(NOW - lookbackMs to NOW, source.windows.first())
+        assertEquals(listOf(NOW to NOW, NOW to NOW), source.windows.drop(1))
+        job.cancel()
+    }
+
+    @Test
+    fun `a failing query does not stop monitoring`() = runTest {
+        val source = FakeSource.throwingFirst(listOf(enter(camera)))
+        val recorder = Recorder()
+        val job = launch { monitor(source, recorder).run() }
+
+        runCurrent()
+        advanceTimeBy(pollIntervalMs * 2)
+        runCurrent()
+
+        assertEquals(1, recorder.entered)
+        job.cancel()
+    }
+
+    @Test
+    fun `a failing transition callback is retried on the next poll`() = runTest {
+        val source = FakeSource.of(listOf(enter(camera)))
+        val recorder = Recorder()
+        var attempts = 0
+        val job = launch {
+            monitor(
+                source = source,
+                recorder = recorder,
+                onCameraEntered = {
+                    attempts += 1
+                    if (attempts == 1) throw IllegalStateException("release failed")
+                    recorder.entered += 1
+                },
+            ).run()
+        }
+
+        runCurrent()
+        advanceTimeBy(pollIntervalMs * 4)
+        runCurrent()
+
+        assertEquals(2, attempts, "the failed release is retried, then stops retrying")
+        assertEquals(1, recorder.entered)
+        job.cancel()
+    }
+
+    @Test
+    fun `losing usage access reports once and stops polling`() = runTest {
+        val source = FakeSource.of(emptyList())
+        val recorder = Recorder()
+        var ready = true
+        val job = launch { monitor(source, recorder, isReady = { ready }).run() }
+
+        runCurrent()
+        ready = false
+        advanceTimeBy(pollIntervalMs)
+        runCurrent()
+        val queriesWhenReported = source.queries
+        advanceTimeBy(pollIntervalMs * 5)
+        runCurrent()
+
+        assertEquals(1, recorder.unavailable)
+        assertEquals(queriesWhenReported, source.queries, "polling stops once the capability is gone")
+        job.cancel()
+    }
+
+    @Test
+    fun `cancelling the monitor stops polling`() = runTest {
+        val source = FakeSource.of(listOf(enter(camera)))
+        val recorder = Recorder()
+        val job = launch { monitor(source, recorder).run() }
+
+        runCurrent()
+        advanceTimeBy(pollIntervalMs)
+        runCurrent()
+        val queriesBeforeCancel = source.queries
+        job.cancel()
+        advanceTimeBy(pollIntervalMs * 5)
+        runCurrent()
+
+        assertEquals(queriesBeforeCancel, source.queries)
+        assertEquals(1, recorder.entered)
+    }
+
+    @Test
+    fun `cancellation is not swallowed by the transition guard`() = runTest {
+        val source = FakeSource.of(listOf(enter(camera)))
+        val recorder = Recorder()
+        val job = launch {
+            monitor(
+                source = source,
+                recorder = recorder,
+                onCameraEntered = { throw CancellationException("cancelled") },
+            ).run()
+        }
+
+        runCurrent()
+        advanceTimeBy(pollIntervalMs * 3)
+        runCurrent()
+
+        assertTrue(job.isCancelled, "CancellationException must propagate out of the monitor")
+    }
+
+    private companion object {
+        const val NOW = 1_700_000_000_000L
+    }
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/CameraForegroundMonitorTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/CameraForegroundMonitorTest.kt
@@ -1,5 +1,7 @@
 package com.kernel.ai.core.voice
 
+import android.content.Context
+import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
@@ -47,21 +49,32 @@ class CameraForegroundMonitorTest {
     }
 
     /**
-     * Current foreground state as usage aggregation reports it. A null response stands for a state
-     * that cannot be read — the same thing a failing aggregation query produces.
+     * Current foreground state as the monitor's [ForegroundPackageSource] reports it. A null
+     * response stands for a lookback that contains no foreground activity at all; an unreadable
+     * source throws instead, which is what a revoked or failing query looks like.
      */
-    private class FakeCurrent(private val responses: List<String?>) : ForegroundPackageSource {
+    private class FakeCurrent(
+        private val responses: List<String?>,
+        private val unreadable: Boolean = false,
+    ) : ForegroundPackageSource {
         var queries = 0
             private set
 
         override fun currentForegroundPackage(): String? {
             val response = responses[queries.coerceAtMost(responses.size - 1)]
             queries += 1
-            return response ?: throw IllegalStateException("usage aggregation unavailable")
+            if (unreadable && response == null) {
+                throw IllegalStateException("foreground events unavailable")
+            }
+            return response
         }
 
         companion object {
             fun of(vararg responses: String?): FakeCurrent = FakeCurrent(responses.toList())
+
+            /** Every null response throws, standing for a state that cannot be read at all. */
+            fun unreadable(vararg responses: String?): FakeCurrent =
+                FakeCurrent(responses.toList(), unreadable = true)
         }
     }
 
@@ -210,10 +223,54 @@ class CameraForegroundMonitorTest {
     }
 
     @Test
+    fun `a startup whose lookback holds no foreground activity arms`() = runTest {
+        val source = FakeSource.of(emptyList())
+        val recorder = Recorder()
+        val current = FakeCurrent.of(null)
+        val job = launch { monitor(source, recorder, current = current).run() }
+
+        runCurrent()
+
+        assertEquals(
+            1,
+            recorder.exited,
+            "an empty lookback means the camera produced no event and is not in front",
+        )
+        assertEquals(0, recorder.entered)
+        job.cancel()
+    }
+
+    @Test
+    fun `the current package is replayed from the events that are still readable`() {
+        var windowStart = -1L
+        var windowEnd = -1L
+        val source = UsageStatsCurrentForegroundSource(
+            context = mockk(relaxed = true),
+            lookbackMillis = SEED_LOOKBACK_MS,
+            clock = { NOW },
+            eventSource = {
+                ForegroundEventSource { start, end ->
+                    windowStart = start
+                    windowEnd = end
+                    listOf(enter(otherApp), enter(camera))
+                }
+            },
+        )
+
+        assertEquals(
+            camera,
+            source.currentForegroundPackage(),
+            "a camera that resumed earlier and never left is still the package in front",
+        )
+        assertEquals(NOW - SEED_LOOKBACK_MS, windowStart, "the window has to outlast a camera session")
+        assertEquals(NOW, windowEnd)
+    }
+
+    @Test
     fun `an unreadable startup state is retried and arms nothing until it can be read`() = runTest {
         val source = FakeSource.of(emptyList())
         val recorder = Recorder()
-        val current = FakeCurrent.of(null, null, otherApp)
+        val current = FakeCurrent.unreadable(null, null, otherApp)
         val job = launch { monitor(source, recorder, current = current).run() }
 
         runCurrent()

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/HonorCameraCoexistenceTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/HonorCameraCoexistenceTest.kt
@@ -4,7 +4,9 @@ import android.app.AppOpsManager
 import android.content.Context
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -75,48 +77,76 @@ class HonorCameraCoexistenceTest {
         assertFalse(HonorCameraCoexistence.hasUsageAccess(context))
     }
 
-    // ── Re-arm guard: the camera must also withhold capture immediately after it appears ──────
+    // ── Re-arm guard: capture is withheld while the camera may own the foreground ─────────────
 
-    private fun windowedSource(vararg stamped: Pair<Long, ForegroundEvent>) =
-        ForegroundEventSource { start, end ->
-            stamped.filter { (at, _) -> at in start..end }.map { it.second }
-        }
+    private fun currentPackage(packageName: String?) = ForegroundPackageSource { packageName }
 
     @Test
-    fun `camera entering the foreground within the window withholds wake capture`() {
-        val now = 1_700_000_000_000L
-        val source = windowedSource(
-            (now - 500) to ForegroundEvent(ForegroundTransition.ENTER, HonorCameraCoexistence.CAMERA_PACKAGE),
-        )
-
+    fun `a camera already in the foreground withholds wake capture`() {
         assertTrue(
-            cameraForegroundWithin(source, now, 3_000, HonorCameraCoexistence.CAMERA_PACKAGE),
+            mustWithholdWakeCapture(
+                currentPackage(HonorCameraCoexistence.CAMERA_PACKAGE),
+                HonorCameraCoexistence.CAMERA_PACKAGE,
+            ),
         )
     }
 
     @Test
     fun `another app in the foreground does not withhold wake capture`() {
-        val now = 1_700_000_000_000L
-        val source = windowedSource(
-            (now - 200) to ForegroundEvent(ForegroundTransition.ENTER, "com.example.other"),
-            (now - 800) to ForegroundEvent(ForegroundTransition.ENTER, HonorCameraCoexistence.CAMERA_PACKAGE),
-            (now - 400) to ForegroundEvent(ForegroundTransition.EXIT, HonorCameraCoexistence.CAMERA_PACKAGE),
-        )
-
         assertFalse(
-            cameraForegroundWithin(source, now, 3_000, HonorCameraCoexistence.CAMERA_PACKAGE),
+            mustWithholdWakeCapture(currentPackage("com.example.other"), HonorCameraCoexistence.CAMERA_PACKAGE),
         )
     }
 
     @Test
-    fun `a camera launch older than the window is left to the suspension latch`() {
-        val now = 1_700_000_000_000L
-        val source = windowedSource(
-            (now - 60_000) to ForegroundEvent(ForegroundTransition.ENTER, HonorCameraCoexistence.CAMERA_PACKAGE),
+    fun `an unreadable foreground state withholds wake capture`() {
+        assertTrue(
+            mustWithholdWakeCapture(currentPackage(null), HonorCameraCoexistence.CAMERA_PACKAGE),
+            "an unknown state must not risk blocking the camera",
         )
+    }
 
-        assertFalse(
-            cameraForegroundWithin(source, now, 3_000, HonorCameraCoexistence.CAMERA_PACKAGE),
+    @Test
+    fun `a failing foreground query withholds wake capture`() {
+        val throwing = ForegroundPackageSource { throw SecurityException("usage access lost") }
+
+        assertTrue(
+            mustWithholdWakeCapture(throwing, HonorCameraCoexistence.CAMERA_PACKAGE),
+            "a query that cannot answer must not risk blocking the camera",
         )
+    }
+
+    // ── Current-foreground resolution: a long camera session must still be resolvable ─────────
+
+    @Test
+    fun `the most recently visible package is the one in front`() {
+        assertEquals(
+            HonorCameraCoexistence.CAMERA_PACKAGE,
+            mostRecentlyVisiblePackage(
+                listOf(
+                    "com.hihonor.android.launcher" to 1_700_000_000_000L,
+                    HonorCameraCoexistence.CAMERA_PACKAGE to 1_700_000_600_000L,
+                ),
+            ),
+            "a camera in front since long before any window must still resolve as the current app",
+        )
+    }
+
+    @Test
+    fun `a package that took over after the camera is the one in front`() {
+        assertEquals(
+            "com.hihonor.android.launcher",
+            mostRecentlyVisiblePackage(
+                listOf(
+                    HonorCameraCoexistence.CAMERA_PACKAGE to 1_700_000_600_000L,
+                    "com.hihonor.android.launcher" to 1_700_000_900_000L,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `no visible timestamp means the state cannot be resolved`() {
+        assertNull(mostRecentlyVisiblePackage(listOf("com.example.other" to 0L)))
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/HonorCameraCoexistenceTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/HonorCameraCoexistenceTest.kt
@@ -99,10 +99,10 @@ class HonorCameraCoexistenceTest {
     }
 
     @Test
-    fun `an unreadable foreground state withholds wake capture`() {
-        assertTrue(
+    fun `no foreground activity in the window does not withhold wake capture`() {
+        assertFalse(
             mustWithholdWakeCapture(currentPackage(null), HonorCameraCoexistence.CAMERA_PACKAGE),
-            "an unknown state must not risk blocking the camera",
+            "an empty window means the camera produced no event, so it is not in front",
         )
     }
 
@@ -118,17 +118,21 @@ class HonorCameraCoexistenceTest {
 
     // ── Current-foreground resolution: a long camera session must still be resolvable ─────────
 
+    private fun enter(packageName: String) =
+        ForegroundEvent(ForegroundTransition.ENTER, packageName)
+
+    private fun exit(packageName: String) =
+        ForegroundEvent(ForegroundTransition.EXIT, packageName)
+
     @Test
-    fun `the most recently visible package is the one in front`() {
+    fun `a camera in front since before the lookback is still resolved as the current app`() {
         assertEquals(
             HonorCameraCoexistence.CAMERA_PACKAGE,
-            mostRecentlyVisiblePackage(
-                listOf(
-                    "com.hihonor.android.launcher" to 1_700_000_000_000L,
-                    HonorCameraCoexistence.CAMERA_PACKAGE to 1_700_000_600_000L,
-                ),
+            applyForegroundTransitions(
+                from = null,
+                events = listOf(enter("com.hihonor.android.launcher"), enter(HonorCameraCoexistence.CAMERA_PACKAGE)),
             ),
-            "a camera in front since long before any window must still resolve as the current app",
+            "a camera that resumed earlier and never left must still resolve as the current app",
         )
     }
 
@@ -136,17 +140,15 @@ class HonorCameraCoexistenceTest {
     fun `a package that took over after the camera is the one in front`() {
         assertEquals(
             "com.hihonor.android.launcher",
-            mostRecentlyVisiblePackage(
-                listOf(
-                    HonorCameraCoexistence.CAMERA_PACKAGE to 1_700_000_600_000L,
-                    "com.hihonor.android.launcher" to 1_700_000_900_000L,
-                ),
+            applyForegroundTransitions(
+                from = null,
+                events = listOf(enter(HonorCameraCoexistence.CAMERA_PACKAGE), exit(HonorCameraCoexistence.CAMERA_PACKAGE), enter("com.hihonor.android.launcher")),
             ),
         )
     }
 
     @Test
-    fun `no visible timestamp means the state cannot be resolved`() {
-        assertNull(mostRecentlyVisiblePackage(listOf("com.example.other" to 0L)))
+    fun `no foreground activity resolves to no package`() {
+        assertNull(applyForegroundTransitions(from = null, events = emptyList()))
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/HonorCameraCoexistenceTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/HonorCameraCoexistenceTest.kt
@@ -74,4 +74,49 @@ class HonorCameraCoexistenceTest {
 
         assertFalse(HonorCameraCoexistence.hasUsageAccess(context))
     }
+
+    // ── Re-arm guard: the camera must also withhold capture immediately after it appears ──────
+
+    private fun windowedSource(vararg stamped: Pair<Long, ForegroundEvent>) =
+        ForegroundEventSource { start, end ->
+            stamped.filter { (at, _) -> at in start..end }.map { it.second }
+        }
+
+    @Test
+    fun `camera entering the foreground within the window withholds wake capture`() {
+        val now = 1_700_000_000_000L
+        val source = windowedSource(
+            (now - 500) to ForegroundEvent(ForegroundTransition.ENTER, HonorCameraCoexistence.CAMERA_PACKAGE),
+        )
+
+        assertTrue(
+            cameraForegroundWithin(source, now, 3_000, HonorCameraCoexistence.CAMERA_PACKAGE),
+        )
+    }
+
+    @Test
+    fun `another app in the foreground does not withhold wake capture`() {
+        val now = 1_700_000_000_000L
+        val source = windowedSource(
+            (now - 200) to ForegroundEvent(ForegroundTransition.ENTER, "com.example.other"),
+            (now - 800) to ForegroundEvent(ForegroundTransition.ENTER, HonorCameraCoexistence.CAMERA_PACKAGE),
+            (now - 400) to ForegroundEvent(ForegroundTransition.EXIT, HonorCameraCoexistence.CAMERA_PACKAGE),
+        )
+
+        assertFalse(
+            cameraForegroundWithin(source, now, 3_000, HonorCameraCoexistence.CAMERA_PACKAGE),
+        )
+    }
+
+    @Test
+    fun `a camera launch older than the window is left to the suspension latch`() {
+        val now = 1_700_000_000_000L
+        val source = windowedSource(
+            (now - 60_000) to ForegroundEvent(ForegroundTransition.ENTER, HonorCameraCoexistence.CAMERA_PACKAGE),
+        )
+
+        assertFalse(
+            cameraForegroundWithin(source, now, 3_000, HonorCameraCoexistence.CAMERA_PACKAGE),
+        )
+    }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/HonorCameraCoexistenceTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/HonorCameraCoexistenceTest.kt
@@ -1,0 +1,77 @@
+package com.kernel.ai.core.voice
+
+import android.app.AppOpsManager
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+/**
+ * #1502: the workaround must stay scoped to the device where MagicOS microphone arbitration was
+ * physically proven, and the Usage Access prerequisite must reflect the *actual* grant.
+ */
+class HonorCameraCoexistenceTest {
+
+    @Test
+    fun `Honor BKQ-N49 is the affected device`() {
+        assertTrue(HonorCameraCoexistence.isAffectedDevice("HONOR", "BKQ-N49"))
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            // other Honor models are not covered by the physical evidence
+            "'HONOR','ANY-NX1'",
+            "'HONOR','BKQ-N50'",
+            "'HONOR','ELP-NX9'",
+            // the reference and tracked foreground-input devices keep the existing wake path
+            "'samsung','SM-S918B'",
+            "'samsung','SM-G991B'",
+            "'Google','sdk_gphone64_x86_64'",
+            // partial matches must not qualify
+            "'',''",
+            "'HONOR',''",
+            "'','BKQ-N49'",
+        ],
+    )
+    fun `other devices are unaffected`(manufacturer: String, model: String) {
+        assertFalse(HonorCameraCoexistence.isAffectedDevice(manufacturer, model))
+    }
+
+    @Test
+    fun `device match tolerates case and surrounding whitespace`() {
+        assertTrue(HonorCameraCoexistence.isAffectedDevice(" honor ", " bkq-n49 "))
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            // mode, expected
+            "0, true", // MODE_ALLOWED
+            "1, false", // MODE_IGNORED
+            "3, false", // MODE_DEFAULT — declaring the permission grants nothing
+            "4, false", // MODE_FOREGROUND — not the grant this workaround needs
+        ],
+    )
+    fun `usage access is granted only for MODE_ALLOWED`(mode: Int, expected: Boolean) {
+        val appOps = mockk<AppOpsManager>()
+        every { appOps.unsafeCheckOpNoThrow(any(), any(), any()) } returns mode
+        val context = mockk<Context>()
+        every { context.getSystemService(Context.APP_OPS_SERVICE) } returns appOps
+        every { context.packageName } returns "com.kernel.ai.debug"
+
+        assertTrue(HonorCameraCoexistence.hasUsageAccess(context) == expected)
+    }
+
+    @Test
+    fun `missing usage stats service means no access`() {
+        val context = mockk<Context>()
+        every { context.getSystemService(Context.APP_OPS_SERVICE) } returns null
+
+        assertFalse(HonorCameraCoexistence.hasUsageAccess(context))
+    }
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/WakeCaptureRearmPolicyTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/WakeCaptureRearmPolicyTest.kt
@@ -1,0 +1,56 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * #1502: every condition that must still hold before Jandal takes the microphone back after the
+ * Honor Camera leaves the foreground.
+ */
+class WakeCaptureRearmPolicyTest {
+
+    private fun mayRearm(
+        heyJandalEnabled: Boolean = true,
+        recordAudioGranted: Boolean = true,
+        captureSuspended: Boolean = false,
+        voiceSessionActive: Boolean = false,
+        captureAllowed: Boolean = true,
+    ) = mayRearmAfterCamera(
+        heyJandalEnabled = heyJandalEnabled,
+        recordAudioGranted = recordAudioGranted,
+        captureSuspended = captureSuspended,
+        voiceSessionActive = voiceSessionActive,
+        captureAllowed = captureAllowed,
+    )
+
+    @Test
+    fun `re-arms when every condition still holds`() {
+        assertTrue(mayRearm())
+    }
+
+    @Test
+    fun `does not re-arm when Hey Jandal was disabled while the camera was foreground`() {
+        assertFalse(mayRearm(heyJandalEnabled = false))
+    }
+
+    @Test
+    fun `does not re-arm when the microphone permission was removed while suspended`() {
+        assertFalse(mayRearm(recordAudioGranted = false))
+    }
+
+    @Test
+    fun `does not re-arm while Usage Access is gone on the affected device`() {
+        assertFalse(mayRearm(captureAllowed = false))
+    }
+
+    @Test
+    fun `does not re-arm while the camera still holds the microphone`() {
+        assertFalse(mayRearm(captureSuspended = true))
+    }
+
+    @Test
+    fun `does not re-arm into an active Jandal voice session`() {
+        assertFalse(mayRearm(voiceSessionActive = true))
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.voice.HonorCameraCoexistence
 import com.kernel.ai.core.voice.KokoroSpeakerGroup
 import com.kernel.ai.core.voice.SemaineSpeakerMetadata
 import com.kernel.ai.core.voice.SherpaKokoroVoice
@@ -85,6 +86,7 @@ import com.kernel.ai.core.model.availability.UnavailableReason
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.util.Log
 import android.provider.Settings
 import android.Manifest
 import android.app.role.RoleManager
@@ -115,7 +117,24 @@ fun VoiceScreen(
     var showMicRepairDialog by remember { mutableStateOf(false) }
     var showMicDurableRequiredDialog by remember { mutableStateOf(false) }
     var awaitingMicSettingsReturn by remember { mutableStateOf(false) }
-    
+    var showUsageAccessDialog by remember { mutableStateOf(false) }
+    var awaitingUsageAccessReturn by remember { mutableStateOf(false) }
+
+    /**
+     * #1502: on the Honor device whose camera contends for the microphone, Hey Jandal can only
+     * listen with Usage Access. Cached per resume (the check costs an AppOps query) and refreshed
+     * on ON_RESUME and on every enable attempt.
+     */
+    var needsUsageAccess by remember { mutableStateOf(false) }
+    val requiresUsageAccess = {
+        HonorCameraCoexistence.isAffectedDevice(context) &&
+            !HonorCameraCoexistence.hasUsageAccess(context)
+    }
+    val enableHeyJandal = {
+        needsUsageAccess = requiresUsageAccess()
+        if (needsUsageAccess) showUsageAccessDialog = true else viewModel.setHeyJandalEnabled(true)
+    }
+
     val micDenialClassifier = remember { PermissionDenialClassifier() }
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -123,6 +142,21 @@ fun VoiceScreen(
                 viewModel.refreshAssistantStatus(
                     roleManager?.isRoleHeld(RoleManager.ROLE_ASSISTANT) == true,
                 )
+                needsUsageAccess = requiresUsageAccess()
+
+                // 0. Settings-return handling: Usage Access round-trip (#1502). Continue the
+                // enable flow only when access was actually granted.
+                if (awaitingUsageAccessReturn) {
+                    awaitingUsageAccessReturn = false
+                    if (needsUsageAccess) {
+                        Log.i(
+                            "VoiceScreen",
+                            "Usage Access still not granted — Hey Jandal left inactive",
+                        )
+                    } else {
+                        viewModel.setHeyJandalEnabled(true)
+                    }
+                }
 
                 // 1. Settings-return handling: explicit mic repair round-trip.
                 if (awaitingMicSettingsReturn) {
@@ -136,7 +170,7 @@ fun VoiceScreen(
                         if (micReadiness == MicrophoneReadiness.Granted) {
                             showMicRepairDialog = false
                             micDenialClassifier.clear(Manifest.permission.RECORD_AUDIO)
-                            viewModel.setHeyJandalEnabled(true)
+                            enableHeyJandal()
                         } else {
                             showMicDurableRequiredDialog = true
                         }
@@ -153,6 +187,14 @@ fun VoiceScreen(
                     viewModel.enforceHeyJandalMicReadiness(micReadiness)
                     showMicDurableRequiredDialog = true
                 }
+
+                // 2b. #1502 enforcement: Hey Jandal cannot listen without Usage Access on the
+                // affected device (revoked externally, or enabled before this build) — turn it off
+                // rather than let the UI claim it is listening.
+                if (wasHeyJandalEnabled && needsUsageAccess) {
+                    viewModel.setHeyJandalEnabled(false)
+                    showUsageAccessDialog = true
+                }
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -166,11 +208,14 @@ fun VoiceScreen(
     // the ON_RESUME lifecycle observer runs, so the durability check at (2)
     // saw wasHeyJandalEnabled = false and did not trigger.
     LaunchedEffect(uiState.heyJandalEnabled) {
-        if (uiState.heyJandalEnabled && !awaitingMicSettingsReturn) {
+        if (uiState.heyJandalEnabled && !awaitingMicSettingsReturn && !awaitingUsageAccessReturn) {
             val micReadiness = MicrophonePermissionReadiness.evaluate(context)
             if (micReadiness != MicrophoneReadiness.Granted) {
                 viewModel.enforceHeyJandalMicReadiness(micReadiness)
                 showMicDurableRequiredDialog = true
+            } else if (needsUsageAccess) {
+                viewModel.setHeyJandalEnabled(false)
+                showUsageAccessDialog = true
             }
         }
     }
@@ -206,7 +251,7 @@ fun VoiceScreen(
         } else {
             val micReadiness = MicrophonePermissionReadiness.evaluate(context)
             if (micReadiness == MicrophoneReadiness.Granted) {
-                viewModel.setHeyJandalEnabled(true)
+                enableHeyJandal()
             } else {
                 showMicDurableRequiredDialog = true
             }
@@ -226,7 +271,7 @@ fun VoiceScreen(
                     == PackageManager.PERMISSION_GRANTED) {
                 val micReadiness = MicrophonePermissionReadiness.evaluate(context)
                 if (micReadiness == MicrophoneReadiness.Granted) {
-                    viewModel.setHeyJandalEnabled(true)
+                    enableHeyJandal()
                 } else {
                     showMicDurableRequiredDialog = true
                 }
@@ -334,6 +379,46 @@ fun VoiceScreen(
         )
     }
 
+
+    // #1502 Usage Access prompt: only reachable on the affected Honor device, and only when the
+    // user chose to enable Hey Jandal (or when Jandal was already enabled without the access).
+    if (showUsageAccessDialog) {
+        PermissionOverlayDialog(
+            title = "Allow Usage Access for Hey Jandal?",
+            body = "On this Honor device, Jandal needs Usage Access so it can pause wake-word " +
+                "listening while the Camera is in use. App usage information is processed only " +
+                "on this device and is not stored or sent anywhere.",
+            actions = listOf(
+                PermissionDialogAction(
+                    label = "Open Usage Access",
+                    testTag = "hey_jandal_usage_access_open_settings",
+                    onClick = {
+                        showUsageAccessDialog = false
+                        awaitingUsageAccessReturn = true
+                        runCatching {
+                            context.startActivity(HonorCameraCoexistence.usageAccessSettingsIntent(context))
+                        }.onFailure {
+                            Log.w("VoiceScreen", "Could not open Usage Access settings", it)
+                        }
+                    },
+                    isPrimary = true,
+                ),
+                PermissionDialogAction(
+                    label = "Not now",
+                    testTag = "hey_jandal_usage_access_not_now",
+                    onClick = {
+                        showUsageAccessDialog = false
+                        awaitingUsageAccessReturn = false
+                    },
+                ),
+            ),
+            dialogTestTag = "hey_jandal_usage_access_dialog",
+            onDismissRequest = {
+                showUsageAccessDialog = false
+                awaitingUsageAccessReturn = false
+            },
+        )
+    }
 
     // Default-assistant role setup prompt (separate from microphone permission).
     if (showDefaultAssistantPrompt) {


### PR DESCRIPTION
Fixes #1502

## Root cause

On the HONOR BKQ-N49 (Magic 8 Pro, MagicOS 10.0.0.199, Android 16), MagicOS refuses to start stock
camera video recording while **any background app holds a `VOICE_RECOGNITION` capture**:

> "A recording app is already running in the background (Recorder, Call). To record a video, close
> the app first."

Hey Jandal's wake detector holds exactly such a capture continuously, so "Hey Jandal" and stock
camera video recording were mutually exclusive. The camera app receives no platform callback that
could warn Jandal in time — audio recording-configuration callbacks, audio focus, audio mode and
routing changes, and `CameraManager` callbacks were all evaluated on device during the
investigation and provide no usable pre-recording signal. Asserting Jandal as the Android
assistant/VoiceInteractionService does not change the OEM policy either (re-tested: the camera was
still blocked 2/2), and the only audio-source alternative that allows coexistence
(`VOICE_PERFORMANCE`) destroys wake detection on this device (0/9 activations vs 5/9 with
`VOICE_RECOGNITION`), so the source is unchanged.

The one mechanism proven to work is to learn that the camera is coming **before** it needs the
microphone, and release Jandal's captures proactively.

## Approved product decision

Use `UsageStatsManager` foreground detection to yield the microphone, scoped to the exact device
class proven by physical evidence — **HONOR + model `BKQ-N49`, camera package
`com.hihonor.camera`**. No generalisation to other Honor models, other MagicOS releases, other
camera apps, or arbitrary microphone users. Usage Access is an accepted requirement for Hey Jandal
on that device; every other device keeps today's behaviour (no special access, no prompt, no
polling, unchanged wake lifecycle).

## Implementation

`core/voice` (new):

- `HonorCameraCoexistence` — device/package predicate, Usage Access (AppOps) readiness, the
  "may this device hold the wake microphone at all" gate, the packaged Usage Access settings intent,
  and `mayRearmAfterCamera(...)` encoding every re-arm condition.
- `CameraForegroundMonitor` + `ForegroundPackageTracker` + `UsageStatsForegroundEventSource` —
  polls foreground-activity transitions at the proven 2 s cadence, reports only transitions of the
  camera in/out of the foreground, isolates failures (a failing query or callback is logged and
  retried on the next cadence, never terminating monitoring), propagates cancellation, and holds
  only the current foreground package name.

`WakeWordService` (new behaviour):

- Refuses to run wake capture at all when Usage Access is missing on the affected device
  (refusal happens after the foreground promotion, because a service started with
  `startForegroundService()` must reach `startForeground()` or Android kills the process with
  `ForegroundServiceDidNotStartInTimeException` — a defect the first physical build exposed).
- Starts exactly one camera monitor when the service is active on the affected device.
- Camera foreground → latch suspension, then release **all** Jandal-owned microphone captures: the
  wake detector *and* any voice capture left over from a wake→STT or push-to-talk session (whose
  capture is actually held by the recognizer process). The service and its ongoing notification
  stay alive; the notification text becomes "Paused while Camera is in use" and returns to
  "Listening for wake word…" when the detector is armed again.
- Camera background → re-arm only when Hey Jandal is still enabled, microphone permission and
  Usage Access remain, no voice session or wake handoff is active, and the camera is gone.
  The wake-session retry loop is closed while suspended, so a yield cannot be undone by attempt 2.
- Usage Access revoked while running → release the microphone and stop; the Voice settings screen
  turns Hey Jandal off and explains what is needed.

`feature:settings` — new Usage Access prompt on the affected device only
(`hey_jandal_usage_access_dialog`), with the specified copy, an `Open Usage Access` action that
opens MagicOS's Usage Access surface for Jandal AI, a `Not now` action, re-check on return, and an
enforcement path that disables an already-enabled Hey Jandal rather than letting the UI claim it is
listening. The AppOps check is cached per resume, not per recomposition.

## Privacy

Only the camera's foreground state is evaluated. The current foreground package name is held in
memory for the poll window, unrelated usage events are discarded immediately, and nothing is
persisted, exported, added to diagnostics/memories/analytics, or transmitted. Production logging
never records unrelated package names. The bounded lookback windows are the 60 s initial-state
window and the 3 s immediate re-arm window.

## Automated tests

1578 unit tests pass (0 failures), lint clean with no issues in the changed files.

- `HonorCameraCoexistenceTest` (19) — device predicate incl. other Honor models and the S23U/S21,
  Usage Access mapping (`MODE_ALLOWED` only), exception paths, and the bounded immediate re-arm
  window.
- `CameraForegroundMonitorTest` (12) — one suspension per foreground transition, idempotent
  repeated events, re-arm on exit, another app taking over counts as an exit, immediate suspension
  when the monitor starts with the camera already foreground, window discipline, query-failure and
  callback-failure recovery, revocation fail-safe, cancellation stops polling, cancellation is not
  swallowed, and tracker semantics.
- `WakeCaptureRearmPolicyTest` (6) — each re-arm condition independently blocks re-arm.
- `HonorCameraWakeReleaseTest` — the suspension latch is set before any capture is released.
- `WakeCommandHandoffTest` — a yielded microphone closes the STT retry loop (verified to fail
  without the guard).

## Physical validation — HONOR BKQ-N49, MagicOS 10.0.0.199, Android 16

Source `218cf29a`, APK `110771c1…e110788`, Usage Access granted, Hey Jandal enabled.
Logcat is not readable on this device (buffers show 0 B readable over adb), so evidence comes from
`dumpsys activity services`, `dumpsys media.audio_policy` capture ownership, the debug target-event
journal, UI dumps and the recorded media itself.

| Check | Result |
|---|---|
| A. First-time setup | Prompt shown with the specified copy and test tags; `Open Usage Access` opened `com.android.settings/.Settings$AppUsageAccessSettingsActivity` for Jandal AI; after granting and returning, Hey Jandal auto-enabled itself (pref true, service running, capture active). An already-enabled Hey Jandal without Usage Access was disabled and the prompt shown — the update path. |
| B. Camera happy path | Stock camera recorded 128 s / 1.1 GB with **no contention dialog**; AAC 48 kHz stereo, mean −41.7 dB, max −17.1 dB (real audio); Jandal re-armed after the camera exited. |
| C. Immediate-record race | 3/3 runs with Record tapped ~1.1 s after the camera activity resumed: no dialog, all finalised (~115 MB), audio verified (mean −44.6 / −42.8 dB). Measured suspend latency 1.8 s after the camera takes the foreground; **no cadence change needed**. |
| D. Repeated cycles | 4/4 cycles: recording started, no dialog, real audio, detector re-armed, single service/detector instance throughout. |
| E. Wake recovery after camera | Control 2/4 vs after-camera 4/4 (confidence 0.54–0.85) with full `ACTIVATION_CANDIDATE → VERIFIED_ACTIVATION → WAKE_CALLBACK_INVOKED → VOICE_SESSION_STARTED → STT_READY → CUE_PLAYBACK_STARTED`; one trial completed the whole command path to `SESSION_COMPLETED → DETECTOR_REARMED → STAGE3_READY`. |
| F. Wake/STT session then camera | With a Jandal voice session active whose capture was held by the recognizer process (`com.google.android.tts`, uid 10190), the camera recorded 68.6 MB with real audio (mean −44.0 dB) and the recognizer's capture was gone during recording — the lingering-recognizer case from the spike. |
| G. Manual PTT then camera | PTT active → wake detector yielded; camera recorded 50.9 MB with real audio (mean −45.6 dB); PTT released; detector re-armed after the camera. |
| H. Disable while suspended | Hey Jandal disabled → camera cycle still recorded (122.5 MB) → service stayed stopped, zero captures, stored preference unchanged, and **no detector journal events at all** (no re-arm). |
| I. Usage Access revocation | Revoked externally while listening: within 4 s the service stopped and the microphone was released, no crash; Voice settings showed the Usage Access prompt and corrected the stored preference. Re-granting via `Open Usage Access` restored wake listening. |
| J. Microphone permission regression | Revoke → service stopped, capture released, no crash. Grant → recovered (service running, capture active). |
| CPU/polling | Isolated monitor-on vs monitor-off over 120 s windows with the camera foreground: **0.249% vs 0.150% of one core → the monitor costs ~0.10% of one core** (one `queryEvents` per 2 s), matching the spike's ~2 ms/query. |

Regression checks: normal listening, wake detection, wake→STT, command completion → re-arm, manual
PTT, enable/disable, microphone revoke/restore, service restart and an already-enabled update were
all exercised above.

## Limitations

- The **sideloaded debug APK** is subject to Android 13+ restricted settings, so MagicOS blocks the
  Usage Access toggle in system settings until "Remove restriction" is confirmed with the
  lock-screen password ("Controlled by restricted setting"). A Play-installed release build is not
  subject to restricted settings. To keep validating the product behaviour, Usage Access was granted
  via the equivalent AppOps grant; the app-side flow (prompt, settings surface, re-check on return,
  enable, enforcement, revocation fail-safe) was exercised unchanged.
- Lock-screen camera is not reachable over ADB on this device (Honor's double-power gesture opens
  Wallet, and launching the camera under a secure keyguard resumes then immediately stops), so the
  workaround was not exercised from the lock screen. The monitor is foreground-package based and is
  not expected to depend on unlock state, but that is unverified.
- The Honor acoustic wake fixture is marginal on this device (~50% detection), so rates above are
  directional; the comparison is control vs after-camera on the same day, not a reliability
  qualification. Wake trials ran with Bluetooth temporarily disabled because the fixture harness
  refuses to play through a Bluetooth output route; Bluetooth was restored afterwards.

## Store/privacy follow-up

Narrow factual comments were added to #1260 (privacy policy / Data Safety / in-app summary) and
#1261 (App content declarations and reviewer access) recording the new special access, its purpose,
the device scope, local-only processing and the reviewer step.

Do not merge — wait for review.
