### PR TITLE
fix(voice): remove Inflect Micro selection/download deadlock

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManager.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManager.kt
@@ -301,11 +301,17 @@ class SherpaVoicePackDownloadManager @Inject constructor(
                     }
 
                     WorkInfo.State.SUCCEEDED -> {
-                        val dir = withContext(Dispatchers.IO) { voice.voiceDir(context) }
-                        Log.i(TAG, "Voice pack download succeeded: ${dir.absolutePath}")
-                        // Notify the TTS controller so it can re-init without a voice change
-                        sherpaController.markVoiceAvailable(voice)
-                        VoicePackDownloadState.Downloaded(dir.absolutePath)
+                        val isPresent = withContext(Dispatchers.IO) { voice.isDownloaded(context) }
+                        if (isPresent) {
+                            val dir = withContext(Dispatchers.IO) { voice.voiceDir(context) }
+                            Log.i(TAG, "Voice pack download succeeded: ${dir.absolutePath}")
+                            // Notify the TTS controller so it can re-init without a voice change
+                            sherpaController.markVoiceAvailable(voice)
+                            VoicePackDownloadState.Downloaded(dir.absolutePath)
+                        } else {
+                            Log.w(TAG, "Voice worker succeeded but pack is missing for ${voice.displayName}")
+                            VoicePackDownloadState.NotDownloaded
+                        }
                     }
 
                     WorkInfo.State.FAILED -> {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -826,42 +826,29 @@ private fun VoiceScreenContent(
                 uiState.selectedOutputEngine == VoiceOutputEngine.InflectMicroExperimental
             val sherpaSelected =
                 uiState.selectedOutputEngine == VoiceOutputEngine.SherpaExperimental
-            val showSherpaVoiceControls = sherpaSelected || inflectSelected
+            val showSherpaVoiceControls = sherpaSelected
             if (showSherpaVoiceControls) {
                 Text(
-                    text = if (inflectSelected) "Inflect Micro frontend voice" else "Sherpa Piper voice",
+                    text = "Sherpa Piper voice",
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
 
                 val sherpaHelpText = when {
-                    !uiState.hasDownloadedSherpaVoice -> {
-                        if (inflectSelected) {
-                            "Download a Sherpa voice pack below before Inflect Micro can use its frontend."
-                        } else {
-                            "Download a Sherpa voice pack below before Sherpa Piper can speak."
-                        }
-                    }
-                    !uiState.isSelectedSherpaVoiceDownloaded -> {
-                        if (inflectSelected) {
-                            "Your selected Sherpa frontend pack is not downloaded. Download it below to enable Inflect Micro."
-                        } else {
-                            "Your saved Sherpa voice is not downloaded on this device. Download it again or choose another installed voice below."
-                        }
-                    }
-                    inflectSelected ->
-                        "Inflect Micro uses the selected Sherpa voice pack for its frontend."
+                    !uiState.hasDownloadedSherpaVoice ->
+                        "Download a Sherpa voice pack below before Sherpa Piper can speak."
+                    !uiState.isSelectedSherpaVoiceDownloaded ->
+                        "Your saved Sherpa voice is not downloaded on this device. Download it again or choose another installed voice below."
                     else ->
                         "Only downloaded voices can be selected. Android TTS is disabled while Sherpa Piper is selected above."
                 }
                 VoiceInfoCard(
-                    title = if (inflectSelected) "Inflect Micro frontend voice" else "Sherpa Piper is active",
+                    title = "Sherpa Piper is active",
                     message = sherpaHelpText,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
 
-                if (sherpaSelected) {
                 // Speech rate slider — range 0.5–1.5 in steps of 0.05 (19 discrete steps)
                 Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
                     SliderRow(
@@ -1019,55 +1006,6 @@ private fun VoiceScreenContent(
                         }
                     }
                 }
-                } else {
-                    val selectedVoiceRow = uiState.sherpaVoices.firstOrNull {
-                        it.voice == uiState.selectedSherpaVoice
-                    }
-                    if (selectedVoiceRow != null) {
-                        ModelCardCompact(
-                            title = selectedVoiceRow.voice.displayName,
-                            description = selectedVoiceRow.voice.description,
-                            state = uiState.sherpaVoiceAvailability[selectedVoiceRow.voice]
-                                ?: ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
-                        )
-                        when (val voiceRowState = selectedVoiceRow.downloadState) {
-                            is VoicePackDownloadState.NotDownloaded -> {
-                                Button(
-                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
-                                    onClick = { onDownloadSherpaVoice(selectedVoiceRow.voice) },
-                                ) {
-                                    Text("Download")
-                                }
-                            }
-                            is VoicePackDownloadState.Downloading -> {
-                                OutlinedButton(
-                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
-                                    onClick = { onCancelSherpaVoice(selectedVoiceRow.voice) },
-                                ) {
-                                    Text("Cancel")
-                                }
-                            }
-                            is VoicePackDownloadState.Downloaded -> {
-                                OutlinedButton(
-                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
-                                    onClick = { onDeleteSherpaVoice(selectedVoiceRow.voice) },
-                                ) {
-                                    Text("Delete")
-                                }
-                            }
-                            is VoicePackDownloadState.Error -> {
-                                OutlinedButton(
-                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
-                                    onClick = { onDownloadSherpaVoice(selectedVoiceRow.voice) },
-                                ) {
-                                    Text("Retry")
-                                }
-                            }
-                        }
-                        HorizontalDivider()
-                    }
-                }
             }
 
             val inflectModelState = uiState.inflectMicroAvailability
@@ -1093,19 +1031,17 @@ private fun VoiceScreenContent(
                     },
                     message = when {
                         inflectReady ->
-                            "This higher-quality local path uses the selected Sherpa eSpeak frontend and Inflect Micro model bundle and is ready to speak."
-                        inflectSelected && inflectModelState is ModelAvailabilityState.Ready ->
-                            "Inflect Micro is selected. Download the selected Sherpa voice pack to enable this higher-quality local speech path."
+                            "Inflect Micro is ready to speak. Android TTS remains the fallback if synthesis is unavailable."
                         inflectSelected ->
-                            "Inflect Micro is selected. Download Inflect Micro and the selected Sherpa voice pack to enable this higher-quality local speech path."
+                            "Inflect Micro is selected — setup required. Download the Inflect setup below before it can speak."
                         else ->
-                            "Download Inflect Micro and the selected Sherpa voice pack to enable this higher-quality local speech path."
+                            "Download Inflect Micro to enable this higher-quality local speech path."
                     },
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
                 ModelCardCompact(
                     title = "Inflect Micro",
-                    description = "Higher-quality local TTS model; uses the selected Sherpa voice pack for its frontend.",
+                    description = "Higher-quality local TTS with all required setup assets.",
                     state = inflectModelState,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
@@ -1608,9 +1544,9 @@ private fun VoiceOutputSelectionCard(
             "Kokoro (Experimental) is currently the only engine that will speak. Android TTS is inactive until you switch back."
         VoiceOutputEngine.InflectMicroExperimental ->
             if (selectedEngineReady) {
-                "Inflect Micro is selected. It uses the downloaded Inflect graphs and Sherpa eSpeak data, with Android TTS fallback if setup is unavailable."
+                "Inflect Micro is selected and ready to speak. Android TTS remains the fallback if synthesis is unavailable."
             } else {
-                "Inflect Micro is selected — setup required. Download the Inflect graphs and selected Sherpa frontend pack before it can speak."
+                "Inflect Micro is selected — setup required. Download the Inflect setup below before it can speak."
             }
     }
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -774,10 +774,15 @@ private fun VoiceScreenContent(
 
             VoiceOutputSelectionCard(
                 selectedEngine = uiState.selectedOutputEngine,
+                inflectMicroReady = uiState.isInflectMicroReady,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
             )
 
             uiState.availableOutputEngines.forEach { engine ->
+                val engineSelected = uiState.selectedOutputEngine == engine
+                val engineActive = engineSelected &&
+                    (engine != VoiceOutputEngine.InflectMicroExperimental ||
+                        uiState.isInflectMicroReady)
                 ListItem(
                     modifier = Modifier.fillMaxWidth(),
                     headlineContent = { Text(engine.displayName) },
@@ -785,13 +790,13 @@ private fun VoiceScreenContent(
                         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                             Text(engine.description)
                             Text(
-                                text = if (uiState.selectedOutputEngine == engine) {
-                                    "Currently active"
-                                } else {
-                                    "Inactive"
+                                text = when {
+                                    engineActive -> "Currently active"
+                                    engineSelected -> "Selected — setup required"
+                                    else -> "Inactive"
                                 },
                                 style = MaterialTheme.typography.bodySmall,
-                                color = if (uiState.selectedOutputEngine == engine) {
+                                color = if (engineActive) {
                                     MaterialTheme.colorScheme.primary
                                 } else {
                                     MaterialTheme.colorScheme.onSurfaceVariant
@@ -801,7 +806,7 @@ private fun VoiceScreenContent(
                     },
                     trailingContent = {
                         RadioButton(
-                            selected = uiState.selectedOutputEngine == engine,
+                            selected = engineSelected,
                             enabled = true,
                             onClick = { onVoiceOutputEngineSelected(engine) },
                         )
@@ -819,12 +824,12 @@ private fun VoiceScreenContent(
 
             val inflectSelected =
                 uiState.selectedOutputEngine == VoiceOutputEngine.InflectMicroExperimental
-            val showSherpaVoiceControls =
-                uiState.selectedOutputEngine == VoiceOutputEngine.SherpaExperimental ||
-                    inflectSelected
+            val sherpaSelected =
+                uiState.selectedOutputEngine == VoiceOutputEngine.SherpaExperimental
+            val showSherpaVoiceControls = sherpaSelected || inflectSelected
             if (showSherpaVoiceControls) {
                 Text(
-                    text = "Sherpa Piper voice",
+                    text = if (inflectSelected) "Inflect Micro frontend voice" else "Sherpa Piper voice",
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
@@ -838,8 +843,13 @@ private fun VoiceScreenContent(
                             "Download a Sherpa voice pack below before Sherpa Piper can speak."
                         }
                     }
-                    !uiState.isSelectedSherpaVoiceDownloaded ->
-                        "Your saved Sherpa voice is not downloaded on this device. Download it again or choose another installed voice below."
+                    !uiState.isSelectedSherpaVoiceDownloaded -> {
+                        if (inflectSelected) {
+                            "Your selected Sherpa frontend pack is not downloaded. Download it below to enable Inflect Micro."
+                        } else {
+                            "Your saved Sherpa voice is not downloaded on this device. Download it again or choose another installed voice below."
+                        }
+                    }
                     inflectSelected ->
                         "Inflect Micro uses the selected Sherpa voice pack for its frontend."
                     else ->
@@ -851,6 +861,7 @@ private fun VoiceScreenContent(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
 
+                if (sherpaSelected) {
                 // Speech rate slider — range 0.5–1.5 in steps of 0.05 (19 discrete steps)
                 Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
                     SliderRow(
@@ -1008,6 +1019,55 @@ private fun VoiceScreenContent(
                         }
                     }
                 }
+                } else {
+                    val selectedVoiceRow = uiState.sherpaVoices.firstOrNull {
+                        it.voice == uiState.selectedSherpaVoice
+                    }
+                    if (selectedVoiceRow != null) {
+                        ModelCardCompact(
+                            title = selectedVoiceRow.voice.displayName,
+                            description = selectedVoiceRow.voice.description,
+                            state = uiState.sherpaVoiceAvailability[selectedVoiceRow.voice]
+                                ?: ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                        )
+                        when (val voiceRowState = selectedVoiceRow.downloadState) {
+                            is VoicePackDownloadState.NotDownloaded -> {
+                                Button(
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+                                    onClick = { onDownloadSherpaVoice(selectedVoiceRow.voice) },
+                                ) {
+                                    Text("Download")
+                                }
+                            }
+                            is VoicePackDownloadState.Downloading -> {
+                                OutlinedButton(
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+                                    onClick = { onCancelSherpaVoice(selectedVoiceRow.voice) },
+                                ) {
+                                    Text("Cancel")
+                                }
+                            }
+                            is VoicePackDownloadState.Downloaded -> {
+                                OutlinedButton(
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+                                    onClick = { onDeleteSherpaVoice(selectedVoiceRow.voice) },
+                                ) {
+                                    Text("Delete")
+                                }
+                            }
+                            is VoicePackDownloadState.Error -> {
+                                OutlinedButton(
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+                                    onClick = { onDownloadSherpaVoice(selectedVoiceRow.voice) },
+                                ) {
+                                    Text("Retry")
+                                }
+                            }
+                        }
+                        HorizontalDivider()
+                    }
+                }
             }
 
             val inflectModelState = uiState.inflectMicroAvailability
@@ -1018,8 +1078,7 @@ private fun VoiceScreenContent(
                         uiState.selectedOutputEngine == VoiceOutputEngine.InflectMicroExperimental
                     )
             ) {
-                val inflectActive =
-                    uiState.selectedOutputEngine == VoiceOutputEngine.InflectMicroExperimental
+                val inflectReady = inflectSelected && uiState.isInflectMicroReady
                 Text(
                     text = "Inflect Micro model",
                     style = MaterialTheme.typography.labelMedium,
@@ -1027,15 +1086,20 @@ private fun VoiceScreenContent(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
                 VoiceInfoCard(
-                    title = if (inflectActive) {
-                        "Inflect Micro is active"
-                    } else {
-                        "Inflect Micro is available"
+                    title = when {
+                        inflectReady -> "Inflect Micro is active"
+                        inflectSelected -> "Inflect Micro selected — setup required"
+                        else -> "Inflect Micro is available"
                     },
-                    message = if (inflectActive) {
-                        "This higher-quality local path uses the selected Sherpa eSpeak frontend and Inflect Micro model bundle. It remains available while the model bundle and selected Sherpa voice pack are downloaded."
-                    } else {
-                        "Download Inflect Micro and the selected Sherpa voice pack to enable this higher-quality local speech path."
+                    message = when {
+                        inflectReady ->
+                            "This higher-quality local path uses the selected Sherpa eSpeak frontend and Inflect Micro model bundle and is ready to speak."
+                        inflectSelected && inflectModelState is ModelAvailabilityState.Ready ->
+                            "Inflect Micro is selected. Download the selected Sherpa voice pack to enable this higher-quality local speech path."
+                        inflectSelected ->
+                            "Inflect Micro is selected. Download Inflect Micro and the selected Sherpa voice pack to enable this higher-quality local speech path."
+                        else ->
+                            "Download Inflect Micro and the selected Sherpa voice pack to enable this higher-quality local speech path."
                     },
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
@@ -1530,8 +1594,11 @@ private fun VoiceInfoCard(
 @Composable
 private fun VoiceOutputSelectionCard(
     selectedEngine: VoiceOutputEngine,
+    inflectMicroReady: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val inflectSelected = selectedEngine == VoiceOutputEngine.InflectMicroExperimental
+    val selectedEngineReady = !inflectSelected || inflectMicroReady
     val message = when (selectedEngine) {
         VoiceOutputEngine.AndroidTts ->
             "Android TTS is currently the only engine that will speak. Sherpa voices below stay inactive until you switch engines."
@@ -1540,11 +1607,19 @@ private fun VoiceOutputSelectionCard(
         VoiceOutputEngine.KokoroExperimental ->
             "Kokoro (Experimental) is currently the only engine that will speak. Android TTS is inactive until you switch back."
         VoiceOutputEngine.InflectMicroExperimental ->
-            "Inflect Micro is selected. It uses the downloaded Inflect graphs and Sherpa eSpeak data, with Android TTS fallback if setup is unavailable."
+            if (selectedEngineReady) {
+                "Inflect Micro is selected. It uses the downloaded Inflect graphs and Sherpa eSpeak data, with Android TTS fallback if setup is unavailable."
+            } else {
+                "Inflect Micro is selected — setup required. Download the Inflect graphs and selected Sherpa frontend pack before it can speak."
+            }
     }
 
     VoiceInfoCard(
-        title = "Active engine: ${selectedEngine.displayName}",
+        title = if (selectedEngineReady) {
+            "Active engine: ${selectedEngine.displayName}"
+        } else {
+            "Selected engine: ${selectedEngine.displayName}"
+        },
         message = message,
         modifier = modifier,
     )

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -778,8 +778,6 @@ private fun VoiceScreenContent(
             )
 
             uiState.availableOutputEngines.forEach { engine ->
-                val engineSelectable = engine != VoiceOutputEngine.InflectMicroExperimental ||
-                    uiState.isInflectMicroReady
                 ListItem(
                     modifier = Modifier.fillMaxWidth(),
                     headlineContent = { Text(engine.displayName) },
@@ -787,20 +785,16 @@ private fun VoiceScreenContent(
                         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                             Text(engine.description)
                             Text(
-                                text = when {
-                                    !engineSelectable ->
-                                        "Download Inflect Micro and the selected Sherpa voice pack first."
-                                    uiState.selectedOutputEngine == engine ->
-                                        "Currently active"
-                                    else ->
-                                        "Inactive"
+                                text = if (uiState.selectedOutputEngine == engine) {
+                                    "Currently active"
+                                } else {
+                                    "Inactive"
                                 },
                                 style = MaterialTheme.typography.bodySmall,
-                                color = when {
-                                    !engineSelectable -> MaterialTheme.colorScheme.onSurfaceVariant
-                                    uiState.selectedOutputEngine == engine ->
-                                        MaterialTheme.colorScheme.primary
-                                    else -> MaterialTheme.colorScheme.onSurfaceVariant
+                                color = if (uiState.selectedOutputEngine == engine) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
                                 },
                             )
                         }
@@ -808,7 +802,7 @@ private fun VoiceScreenContent(
                     trailingContent = {
                         RadioButton(
                             selected = uiState.selectedOutputEngine == engine,
-                            enabled = engineSelectable,
+                            enabled = true,
                             onClick = { onVoiceOutputEngineSelected(engine) },
                         )
                     },
@@ -823,7 +817,12 @@ private fun VoiceScreenContent(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             )
 
-            if (uiState.selectedOutputEngine == VoiceOutputEngine.SherpaExperimental) {
+            val inflectSelected =
+                uiState.selectedOutputEngine == VoiceOutputEngine.InflectMicroExperimental
+            val showSherpaVoiceControls =
+                uiState.selectedOutputEngine == VoiceOutputEngine.SherpaExperimental ||
+                    inflectSelected
+            if (showSherpaVoiceControls) {
                 Text(
                     text = "Sherpa Piper voice",
                     style = MaterialTheme.typography.labelMedium,
@@ -832,15 +831,22 @@ private fun VoiceScreenContent(
                 )
 
                 val sherpaHelpText = when {
-                    !uiState.hasDownloadedSherpaVoice ->
-                        "Download a Sherpa voice pack below before Sherpa Piper can speak."
+                    !uiState.hasDownloadedSherpaVoice -> {
+                        if (inflectSelected) {
+                            "Download a Sherpa voice pack below before Inflect Micro can use its frontend."
+                        } else {
+                            "Download a Sherpa voice pack below before Sherpa Piper can speak."
+                        }
+                    }
                     !uiState.isSelectedSherpaVoiceDownloaded ->
                         "Your saved Sherpa voice is not downloaded on this device. Download it again or choose another installed voice below."
+                    inflectSelected ->
+                        "Inflect Micro uses the selected Sherpa voice pack for its frontend."
                     else ->
                         "Only downloaded voices can be selected. Android TTS is disabled while Sherpa Piper is selected above."
                 }
                 VoiceInfoCard(
-                    title = "Sherpa Piper is active",
+                    title = if (inflectSelected) "Inflect Micro frontend voice" else "Sherpa Piper is active",
                     message = sherpaHelpText,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -221,8 +221,6 @@ class VoiceViewModel @Inject constructor(
             KernelModel.entries.first { it.fileName == required.fileName }
         }
 
-    private var sherpaVoiceDownloadStatesLoaded = false
-    private var inflectModelDownloadStatesLoaded = false
     private val _uiState = MutableStateFlow(
         VoiceUiState(
             availableOutputEngines = VoiceOutputEngine.entriesForBuild(
@@ -270,7 +268,6 @@ class VoiceViewModel @Inject constructor(
                 if (effectiveEngine != engine) {
                     voiceOutputPreferences.setSelectedEngine(effectiveEngine)
                 }
-                persistInflectDemotionIfNeeded()
             }
         }
         viewModelScope.launch {
@@ -284,7 +281,6 @@ class VoiceViewModel @Inject constructor(
                         isInflectMicroReady = state.hasAllInflectModelsDownloaded() && selectedVoiceDownloaded,
                     )
                 }
-                persistInflectDemotionIfNeeded()
             }
         }
         viewModelScope.launch {
@@ -314,7 +310,6 @@ class VoiceViewModel @Inject constructor(
         }
         viewModelScope.launch {
             sherpaVoicePackDownloadManager.downloadStates.collect { states ->
-                sherpaVoiceDownloadStatesLoaded = true
                 _uiState.update {
                     val sherpaRows = visibleSherpaVoices.map { voice ->
                         SherpaVoiceRowUiState(
@@ -338,7 +333,6 @@ class VoiceViewModel @Inject constructor(
                         },
                     )
                 }
-                persistInflectDemotionIfNeeded()
             }
         }
         viewModelScope.launch {
@@ -411,7 +405,6 @@ class VoiceViewModel @Inject constructor(
                 val inflectStates = inflectModels.associateWith { model ->
                     states[model] ?: DownloadState.NotDownloaded
                 }
-                inflectModelDownloadStatesLoaded = true
                 _uiState.update {
                     val inflectReady = inflectStates.allModelsDownloaded() &&
                         it.isSelectedSherpaVoiceDownloaded
@@ -428,29 +421,10 @@ class VoiceViewModel @Inject constructor(
                         },
                     )
                 }
-                persistInflectDemotionIfNeeded()
             }
         }
     }
 
-    private suspend fun persistInflectDemotionIfNeeded() {
-        if (!sherpaVoiceDownloadStatesLoaded || !inflectModelDownloadStatesLoaded) return
-        var demoted = false
-        _uiState.update { state ->
-            if (
-                state.selectedOutputEngine == VoiceOutputEngine.InflectMicroExperimental &&
-                !state.isInflectMicroReady
-            ) {
-                demoted = true
-                state.copy(selectedOutputEngine = VoiceOutputEngine.AndroidTts)
-            } else {
-                state
-            }
-        }
-        if (demoted) {
-            voiceOutputPreferences.setSelectedEngine(VoiceOutputEngine.AndroidTts)
-        }
-    }
     private fun Map<KernelModel, DownloadState>.allModelsDownloaded(): Boolean =
         inflectModels.all { model -> this[model] is DownloadState.Downloaded }
 
@@ -595,11 +569,6 @@ class VoiceViewModel @Inject constructor(
                 inflectEligible = inflectReleaseEligible,
             )
         ) return
-        if (engine == VoiceOutputEngine.InflectMicroExperimental &&
-            !_uiState.value.isInflectMicroReady
-        ) {
-            return
-        }
         _uiState.update { it.copy(selectedOutputEngine = engine) }
         viewModelScope.launch {
             voiceOutputPreferences.setSelectedEngine(engine)

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -139,37 +139,49 @@ internal fun VoicePackDownloadState.toModelAvailability(): ModelAvailabilityStat
 }
 
 /**
- * Aggregates the two Inflect graph states into one logical model-management state.
+ * Aggregates the Inflect graph states and the shared eSpeak frontend pack into one
+ * logical model-management state.
  *
  * A partial bundle is never ready. Downloading takes precedence over an error so that the
- * single Cancel action remains available while either graph is still in progress.
+ * single Cancel action remains available while any prerequisite is still in progress.
  */
 internal fun aggregateInflectMicroAvailability(
     requiredModels: List<KernelModel>,
     states: Map<KernelModel, DownloadState>,
+    frontendState: VoicePackDownloadState,
+    frontendApproxDownloadBytes: Long,
 ): ModelAvailabilityState {
     val resolvedStates = requiredModels.map { model ->
         model to (states[model] ?: DownloadState.NotDownloaded)
     }
-    if (
-        resolvedStates.isNotEmpty() &&
+    val allGraphsDownloaded = resolvedStates.isNotEmpty() &&
         resolvedStates.all { (_, state) -> state is DownloadState.Downloaded }
-    ) {
+    if (allGraphsDownloaded && frontendState is VoicePackDownloadState.Downloaded) {
         return ModelAvailabilityState.Ready
     }
 
-    if (resolvedStates.any { (_, state) -> state is DownloadState.Downloading }) {
-        val totalBytes = resolvedStates.sumOf { (model, _) -> model.approxSizeBytes }.toFloat()
-        val downloadedBytes = resolvedStates.fold(0f) { total, (model, state) ->
-            total + when (state) {
-                is DownloadState.Downloaded -> model.approxSizeBytes.toFloat()
-                is DownloadState.Downloading -> model.approxSizeBytes * state.progress
-                else -> 0f
+    val frontendDownloading = frontendState as? VoicePackDownloadState.Downloading
+    if (
+        resolvedStates.any { (_, state) -> state is DownloadState.Downloading } ||
+        frontendDownloading != null
+    ) {
+        val totalBytes = resolvedStates.sumOf { (model, _) -> model.approxSizeBytes } +
+            frontendApproxDownloadBytes
+        val downloadedBytes = resolvedStates.sumOf { (model, state) ->
+            when (state) {
+                is DownloadState.Downloaded -> model.approxSizeBytes
+                is DownloadState.Downloading -> (model.approxSizeBytes * state.progress).toLong()
+                else -> 0L
             }
+        } + when (frontendState) {
+            is VoicePackDownloadState.Downloaded -> frontendApproxDownloadBytes
+            is VoicePackDownloadState.Downloading ->
+                (frontendApproxDownloadBytes * frontendState.progress).toLong()
+            else -> 0L
         }
         return ModelAvailabilityState.Preparing(
-            progress = if (totalBytes > 0f) {
-                (downloadedBytes / totalBytes).coerceIn(0f, 1f)
+            progress = if (totalBytes > 0L) {
+                (downloadedBytes.toFloat() / totalBytes).coerceIn(0f, 1f)
             } else {
                 0f
             },
@@ -177,13 +189,19 @@ internal fun aggregateInflectMicroAvailability(
         )
     }
 
-    val error = resolvedStates.firstOrNull { (_, state) -> state is DownloadState.Error }
-    if (error != null) {
-        val (model, state) = error
+    val graphError = resolvedStates.firstOrNull { (_, state) -> state is DownloadState.Error }
+    if (graphError != null) {
+        val (model, state) = graphError
         return (state as DownloadState.Error).toAvailability(model, hfAuth = false)
     }
+    val frontendError = frontendState as? VoicePackDownloadState.Error
+    if (frontendError != null) {
+        return ModelAvailabilityState.ActionRequired(
+            ActionReason.DownloadFailed(frontendError.message),
+        )
+    }
 
-    return ModelAvailabilityState.NotDisplayed
+    return ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled)
 }
 
 /**
@@ -273,12 +291,21 @@ class VoiceViewModel @Inject constructor(
         viewModelScope.launch {
             voiceOutputPreferences.selectedSherpaVoice.collect { voice ->
                 _uiState.update { state ->
-                    val selectedVoiceDownloaded =
-                        sherpaVoicePackDownloadManager.downloadStates.value[voice] is VoicePackDownloadState.Downloaded
+                    val selectedVoiceState =
+                        sherpaVoicePackDownloadManager.downloadStates.value[voice]
+                            ?: VoicePackDownloadState.NotDownloaded
+                    val inflectAvailability = aggregateInflectMicroAvailability(
+                        requiredModels = inflectModels,
+                        states = state.inflectMicroStates,
+                        frontendState = selectedVoiceState,
+                        frontendApproxDownloadBytes = voice.approxDownloadBytes,
+                    )
                     state.copy(
                         selectedSherpaVoice = voice,
-                        isSelectedSherpaVoiceDownloaded = selectedVoiceDownloaded,
-                        isInflectMicroReady = state.hasAllInflectModelsDownloaded() && selectedVoiceDownloaded,
+                        isSelectedSherpaVoiceDownloaded =
+                            selectedVoiceState is VoicePackDownloadState.Downloaded,
+                        inflectMicroAvailability = inflectAvailability,
+                        isInflectMicroReady = inflectAvailability is ModelAvailabilityState.Ready,
                     )
                 }
             }
@@ -317,19 +344,26 @@ class VoiceViewModel @Inject constructor(
                             downloadState = states[voice] ?: VoicePackDownloadState.NotDownloaded,
                         )
                     }
-                    val selectedVoiceDownloaded =
-                        states[it.selectedSherpaVoice] is VoicePackDownloadState.Downloaded
-                    val inflectReady = it.inflectMicroStates.allModelsDownloaded() &&
-                        selectedVoiceDownloaded
+                    val selectedVoiceState =
+                        states[it.selectedSherpaVoice] ?: VoicePackDownloadState.NotDownloaded
+                    val inflectAvailability = aggregateInflectMicroAvailability(
+                        requiredModels = inflectModels,
+                        states = it.inflectMicroStates,
+                        frontendState = selectedVoiceState,
+                        frontendApproxDownloadBytes = it.selectedSherpaVoice.approxDownloadBytes,
+                    )
                     it.copy(
                         sherpaVoices = sherpaRows,
                         hasDownloadedSherpaVoice = sherpaRows.any { row ->
                             row.downloadState is VoicePackDownloadState.Downloaded
                         },
-                        isSelectedSherpaVoiceDownloaded = selectedVoiceDownloaded,
-                        isInflectMicroReady = inflectReady,
+                        isSelectedSherpaVoiceDownloaded =
+                            selectedVoiceState is VoicePackDownloadState.Downloaded,
+                        inflectMicroAvailability = inflectAvailability,
+                        isInflectMicroReady = inflectAvailability is ModelAvailabilityState.Ready,
                         sherpaVoiceAvailability = visibleSherpaVoices.associateWith { voice ->
-                            (states[voice] ?: VoicePackDownloadState.NotDownloaded).toModelAvailability()
+                            (states[voice] ?: VoicePackDownloadState.NotDownloaded)
+                                .toModelAvailability()
                         },
                     )
                 }
@@ -406,15 +440,19 @@ class VoiceViewModel @Inject constructor(
                     states[model] ?: DownloadState.NotDownloaded
                 }
                 _uiState.update {
-                    val inflectReady = inflectStates.allModelsDownloaded() &&
-                        it.isSelectedSherpaVoiceDownloaded
+                    val selectedVoiceState =
+                        sherpaVoicePackDownloadManager.downloadStates.value[it.selectedSherpaVoice]
+                            ?: VoicePackDownloadState.NotDownloaded
+                    val inflectAvailability = aggregateInflectMicroAvailability(
+                        requiredModels = inflectModels,
+                        states = inflectStates,
+                        frontendState = selectedVoiceState,
+                        frontendApproxDownloadBytes = it.selectedSherpaVoice.approxDownloadBytes,
+                    )
                     it.copy(
                         inflectMicroStates = inflectStates,
-                        inflectMicroAvailability = aggregateInflectMicroAvailability(
-                            requiredModels = inflectModels,
-                            states = states,
-                        ),
-                        isInflectMicroReady = inflectReady,
+                        inflectMicroAvailability = inflectAvailability,
+                        isInflectMicroReady = inflectAvailability is ModelAvailabilityState.Ready,
                         sherpaSttStates = perFamilyStates,
                         sherpaSttAvailability = perFamilyStates.mapValues { (_, state) ->
                             state.toModelAvailability()
@@ -425,12 +463,6 @@ class VoiceViewModel @Inject constructor(
         }
     }
 
-    private fun Map<KernelModel, DownloadState>.allModelsDownloaded(): Boolean =
-        inflectModels.all { model -> this[model] is DownloadState.Downloaded }
-
-    private fun VoiceUiState.hasAllInflectModelsDownloaded(): Boolean =
-        inflectMicroStates.size == inflectModels.size &&
-            inflectMicroStates.values.all { it is DownloadState.Downloaded }
     /**
      * Computes a [SherpaSttDownloadState] from the download states of the required models.
      */
@@ -491,7 +523,29 @@ class VoiceViewModel @Inject constructor(
     }
 
     fun downloadInflectMicro() {
-        inflectModels.forEach { modelDownloadManager.startDownload(it) }
+        val currentStates = modelDownloadManager.downloadStates.value
+        inflectModels
+            .filter { model ->
+                when (currentStates[model] ?: DownloadState.NotDownloaded) {
+                    is DownloadState.NotDownloaded,
+                    is DownloadState.Error,
+                    -> true
+                    is DownloadState.Downloading,
+                    is DownloadState.Downloaded,
+                    -> false
+                }
+            }
+            .forEach { modelDownloadManager.startDownload(it) }
+
+        val selectedVoice = _uiState.value.selectedSherpaVoice
+        val frontendState =
+            sherpaVoicePackDownloadManager.downloadStates.value[selectedVoice]
+                ?: VoicePackDownloadState.NotDownloaded
+        if (frontendState is VoicePackDownloadState.NotDownloaded ||
+            frontendState is VoicePackDownloadState.Error
+        ) {
+            sherpaVoicePackDownloadManager.startDownload(selectedVoice)
+        }
     }
 
     fun cancelInflectMicroDownload() {
@@ -499,9 +553,18 @@ class VoiceViewModel @Inject constructor(
         inflectModels
             .filter { currentStates[it] is DownloadState.Downloading }
             .forEach { modelDownloadManager.cancelDownload(it) }
+
+        val selectedVoice = _uiState.value.selectedSherpaVoice
+        if (
+            sherpaVoicePackDownloadManager.downloadStates.value[selectedVoice] is
+                VoicePackDownloadState.Downloading
+        ) {
+            sherpaVoicePackDownloadManager.cancelDownload(selectedVoice)
+        }
     }
 
     fun deleteInflectMicro() {
+        // Inflect owns only graph files; the Sherpa pack is shared with Sherpa Piper and stays installed.
         viewModelScope.launch(Dispatchers.IO) {
             inflectModels.forEach { model ->
                 if (modelDownloadManager.downloadStates.value[model] is DownloadState.Downloading) {

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -23,6 +23,7 @@ import com.kernel.ai.core.voice.VoicePackDownloadState
 import com.kernel.ai.core.permissions.MicrophoneReadiness
 import com.kernel.ai.core.model.availability.ActionReason
 import com.kernel.ai.core.model.availability.ModelAvailabilityState
+import com.kernel.ai.core.model.availability.UnavailableReason
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -427,7 +428,7 @@ class VoiceViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
-            ModelAvailabilityState.NotDisplayed,
+            ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
             viewModel.uiState.value.inflectMicroAvailability,
         )
     }
@@ -463,7 +464,7 @@ class VoiceViewModelTest {
     }
 
     @Test
-    fun `both Inflect graphs downloaded map to available but readiness still requires Sherpa`() =
+    fun `both Inflect graphs downloaded still require shared frontend for readiness`() =
         runTest {
             modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
                 put(
@@ -478,11 +479,62 @@ class VoiceViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             assertEquals(
-                ModelAvailabilityState.Ready,
+                ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
                 viewModel.uiState.value.inflectMicroAvailability,
             )
             assertFalse(viewModel.uiState.value.isInflectMicroReady)
         }
+    @Test
+    fun `downloaded graphs and downloading frontend map to Preparing`() = runTest {
+        modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
+            InflectMicroModelSpec.requiredModels.forEach { required ->
+                put(
+                    KernelModel.entries.first { it.fileName == required.fileName },
+                    DownloadState.Downloaded("/models/${required.fileName}"),
+                )
+            }
+        }
+        sherpaDownloadStates.value = sherpaDownloadStates.value.toMutableMap().apply {
+            put(
+                SherpaPiperVoice.JennyDioco,
+                VoicePackDownloadState.Downloading(progress = 0.5f),
+            )
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(
+            viewModel.uiState.value.inflectMicroAvailability
+                is ModelAvailabilityState.Preparing,
+        )
+        assertFalse(viewModel.uiState.value.isInflectMicroReady)
+    }
+
+    @Test
+    fun `frontend failure maps to retryable logical model`() = runTest {
+        modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
+            InflectMicroModelSpec.requiredModels.forEach { required ->
+                put(
+                    KernelModel.entries.first { it.fileName == required.fileName },
+                    DownloadState.Downloaded("/models/${required.fileName}"),
+                )
+            }
+        }
+        sherpaDownloadStates.value = sherpaDownloadStates.value.toMutableMap().apply {
+            put(
+                SherpaPiperVoice.JennyDioco,
+                VoicePackDownloadState.Error("frontend extraction failed"),
+            )
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            ModelAvailabilityState.ActionRequired(
+                ActionReason.DownloadFailed("frontend extraction failed"),
+            ),
+            viewModel.uiState.value.inflectMicroAvailability,
+        )
+        assertFalse(viewModel.uiState.value.isInflectMicroReady)
+    }
 
     @Test
     fun `partial Inflect graph availability never maps to ready`() = runTest {
@@ -496,7 +548,7 @@ class VoiceViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
-            ModelAvailabilityState.NotDisplayed,
+            ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
             viewModel.uiState.value.inflectMicroAvailability,
         )
         assertFalse(viewModel.uiState.value.isInflectMicroReady)
@@ -575,7 +627,7 @@ class VoiceViewModelTest {
     }
 
     @Test
-    fun `selected Inflect exposes missing Sherpa frontend pack without engine switching`() = runTest {
+    fun `Inflect logical download retries missing frontend when graphs are ready`() = runTest {
         modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
             InflectMicroModelSpec.requiredModels.forEach { required ->
                 put(
@@ -586,7 +638,10 @@ class VoiceViewModelTest {
         }
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(ModelAvailabilityState.Ready, viewModel.uiState.value.inflectMicroAvailability)
+        assertEquals(
+            ModelAvailabilityState.Unavailable(UnavailableReason.NotBundled),
+            viewModel.uiState.value.inflectMicroAvailability,
+        )
         assertFalse(viewModel.uiState.value.isInflectMicroReady)
         viewModel.setVoiceOutputEngine(VoiceOutputEngine.InflectMicroExperimental)
         testDispatcher.scheduler.advanceUntilIdle()
@@ -595,18 +650,16 @@ class VoiceViewModelTest {
             VoiceOutputEngine.InflectMicroExperimental,
             viewModel.uiState.value.selectedOutputEngine,
         )
-        assertEquals(
-            VoicePackDownloadState.NotDownloaded,
-            viewModel.uiState.value.sherpaVoices
-                .first { it.voice == SherpaPiperVoice.JennyDioco }
-                .downloadState,
-        )
         io.mockk.verify(exactly = 0) {
+            modelDownloadManager.startDownload(any())
             sherpaVoicePackDownloadManager.startDownload(any())
         }
 
-        viewModel.downloadSherpaVoice(SherpaPiperVoice.JennyDioco)
+        viewModel.downloadInflectMicro()
 
+        io.mockk.verify(exactly = 0) {
+            modelDownloadManager.startDownload(any())
+        }
         io.mockk.verify(exactly = 1) {
             sherpaVoicePackDownloadManager.startDownload(SherpaPiperVoice.JennyDioco)
         }
@@ -628,6 +681,7 @@ class VoiceViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(viewModel.uiState.value.isInflectMicroReady)
+        assertEquals(ModelAvailabilityState.Ready, viewModel.uiState.value.inflectMicroAvailability)
         viewModel.setVoiceOutputEngine(VoiceOutputEngine.InflectMicroExperimental)
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -847,29 +901,54 @@ class VoiceViewModelTest {
     }
 
 
+
     @Test
-    fun `downloadInflectMicro delegates both graph downloads`() = runTest {
+    fun `downloadInflectMicro starts each missing graph and frontend exactly once`() = runTest {
         viewModel.downloadInflectMicro()
 
         io.mockk.verify(exactly = 1) {
             modelDownloadManager.startDownload(KernelModel.INFLECT_MICRO_DURATION)
-        }
-        io.mockk.verify(exactly = 1) {
             modelDownloadManager.startDownload(KernelModel.INFLECT_MICRO_DECODE)
+            sherpaVoicePackDownloadManager.startDownload(SherpaPiperVoice.JennyDioco)
         }
     }
 
     @Test
-    fun `cancelInflectMicroDownload cancels only active graph downloads`() = runTest {
+    fun `downloadInflectMicro skips downloaded frontend and starts missing graphs`() = runTest {
+        sherpaDownloadStates.value = sherpaDownloadStates.value.toMutableMap().apply {
+            put(SherpaPiperVoice.JennyDioco, VoicePackDownloadState.Downloaded("/voices/jenny"))
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.downloadInflectMicro()
+
+        io.mockk.verify(exactly = 1) {
+            modelDownloadManager.startDownload(KernelModel.INFLECT_MICRO_DURATION)
+            modelDownloadManager.startDownload(KernelModel.INFLECT_MICRO_DECODE)
+        }
+        io.mockk.verify(exactly = 0) {
+            sherpaVoicePackDownloadManager.startDownload(any())
+        }
+    }
+
+    @Test
+    fun `cancelInflectMicroDownload cancels active graphs and selected frontend`() = runTest {
         modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
             put(KernelModel.INFLECT_MICRO_DURATION, DownloadState.Downloading(progress = 0.4f))
             put(KernelModel.INFLECT_MICRO_DECODE, DownloadState.Downloaded("/models/decode.onnx"))
+        }
+        sherpaDownloadStates.value = sherpaDownloadStates.value.toMutableMap().apply {
+            put(
+                SherpaPiperVoice.JennyDioco,
+                VoicePackDownloadState.Downloading(progress = 0.2f),
+            )
         }
 
         viewModel.cancelInflectMicroDownload()
 
         io.mockk.verify(exactly = 1) {
             modelDownloadManager.cancelDownload(KernelModel.INFLECT_MICRO_DURATION)
+            sherpaVoicePackDownloadManager.cancelDownload(SherpaPiperVoice.JennyDioco)
         }
         io.mockk.verify(exactly = 0) {
             modelDownloadManager.cancelDownload(KernelModel.INFLECT_MICRO_DECODE)

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -517,18 +517,98 @@ class VoiceViewModelTest {
 
 
     @Test
-    fun `setVoiceOutputEngine ignores Inflect until graphs and selected voice are downloaded`() = runTest {
+    fun `setVoiceOutputEngine accepts Inflect before prerequisites and starts no downloads`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         viewModel.setVoiceOutputEngine(VoiceOutputEngine.InflectMicroExperimental)
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
-            VoiceOutputEngine.AndroidTts,
+            VoiceOutputEngine.InflectMicroExperimental,
             viewModel.uiState.value.selectedOutputEngine,
         )
-        coVerify(exactly = 0) {
-            voiceOutputPreferences.setSelectedEngine(VoiceOutputEngine.InflectMicroExperimental)
+        assertFalse(viewModel.uiState.value.isInflectMicroReady)
+        coVerify { voiceOutputPreferences.setSelectedEngine(VoiceOutputEngine.InflectMicroExperimental) }
+        io.mockk.verify(exactly = 0) {
+            modelDownloadManager.startDownload(any())
+            sherpaVoicePackDownloadManager.startDownload(any())
+        }
+    }
+
+    @Test
+    fun `selecting Inflect while its bundle downloads keeps Inflect selected`() = runTest {
+        modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
+            put(KernelModel.INFLECT_MICRO_DURATION, DownloadState.Downloading(progress = 0.4f))
+            put(KernelModel.INFLECT_MICRO_DECODE, DownloadState.Error("stale partial file"))
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.setVoiceOutputEngine(VoiceOutputEngine.InflectMicroExperimental)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            VoiceOutputEngine.InflectMicroExperimental,
+            viewModel.uiState.value.selectedOutputEngine,
+        )
+        assertTrue(viewModel.uiState.value.inflectMicroAvailability is ModelAvailabilityState.Preparing)
+    }
+
+    @Test
+    fun `selecting Inflect after a failed bundle keeps retryable state reachable`() = runTest {
+        modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
+            put(KernelModel.INFLECT_MICRO_DURATION, DownloadState.Error("network timeout"))
+            put(KernelModel.INFLECT_MICRO_DECODE, DownloadState.Downloaded("/models/decode.onnx"))
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.setVoiceOutputEngine(VoiceOutputEngine.InflectMicroExperimental)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            VoiceOutputEngine.InflectMicroExperimental,
+            viewModel.uiState.value.selectedOutputEngine,
+        )
+        assertEquals(
+            ModelAvailabilityState.ActionRequired(ActionReason.DownloadFailed("network timeout")),
+            viewModel.uiState.value.inflectMicroAvailability,
+        )
+    }
+
+    @Test
+    fun `selected Inflect exposes missing Sherpa frontend pack without engine switching`() = runTest {
+        modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
+            InflectMicroModelSpec.requiredModels.forEach { required ->
+                put(
+                    KernelModel.entries.first { it.fileName == required.fileName },
+                    DownloadState.Downloaded("/models/${required.fileName}"),
+                )
+            }
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(ModelAvailabilityState.Ready, viewModel.uiState.value.inflectMicroAvailability)
+        assertFalse(viewModel.uiState.value.isInflectMicroReady)
+        viewModel.setVoiceOutputEngine(VoiceOutputEngine.InflectMicroExperimental)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            VoiceOutputEngine.InflectMicroExperimental,
+            viewModel.uiState.value.selectedOutputEngine,
+        )
+        assertEquals(
+            VoicePackDownloadState.NotDownloaded,
+            viewModel.uiState.value.sherpaVoices
+                .first { it.voice == SherpaPiperVoice.JennyDioco }
+                .downloadState,
+        )
+        io.mockk.verify(exactly = 0) {
+            sherpaVoicePackDownloadManager.startDownload(any())
+        }
+
+        viewModel.downloadSherpaVoice(SherpaPiperVoice.JennyDioco)
+
+        io.mockk.verify(exactly = 1) {
+            sherpaVoicePackDownloadManager.startDownload(SherpaPiperVoice.JennyDioco)
         }
     }
 
@@ -586,7 +666,7 @@ class VoiceViewModelTest {
     }
 
     @Test
-    fun `persistently demotes Inflect when a required graph becomes unavailable`() = runTest {
+    fun `keeps Inflect selected when a required graph becomes unavailable`() = runTest {
         modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
             InflectMicroModelSpec.requiredModels.forEach { required ->
                 put(
@@ -611,14 +691,15 @@ class VoiceViewModelTest {
         }
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(VoiceOutputEngine.AndroidTts, viewModel.uiState.value.selectedOutputEngine)
-        coVerify(exactly = 1) {
+        assertEquals(VoiceOutputEngine.InflectMicroExperimental, viewModel.uiState.value.selectedOutputEngine)
+        assertFalse(viewModel.uiState.value.isInflectMicroReady)
+        coVerify(exactly = 0) {
             voiceOutputPreferences.setSelectedEngine(VoiceOutputEngine.AndroidTts)
         }
     }
 
     @Test
-    fun `persistently demotes Inflect when the selected Sherpa voice becomes unavailable`() = runTest {
+    fun `keeps Inflect selected when the selected Sherpa voice becomes unavailable`() = runTest {
         modelDownloadStates.value = modelDownloadStates.value.toMutableMap().apply {
             InflectMicroModelSpec.requiredModels.forEach { required ->
                 put(
@@ -640,8 +721,9 @@ class VoiceViewModelTest {
         }
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(VoiceOutputEngine.AndroidTts, viewModel.uiState.value.selectedOutputEngine)
-        coVerify(exactly = 1) {
+        assertEquals(VoiceOutputEngine.InflectMicroExperimental, viewModel.uiState.value.selectedOutputEngine)
+        assertFalse(viewModel.uiState.value.isInflectMicroReady)
+        coVerify(exactly = 0) {
             voiceOutputPreferences.setSelectedEngine(VoiceOutputEngine.AndroidTts)
         }
     }


### PR DESCRIPTION
## Description
Closes #1528

## Scope
- Keep Inflect Micro visible and selectable on eligible devices before prerequisites are ready.
- Make selection persistence-only: selecting Inflect never starts downloads or demotes back to Android TTS while assets are downloading, failed, or incomplete.
- Aggregate both Inflect graph files and the shared selected Sherpa/eSpeak frontend prerequisite into one logical Inflect setup/model card.
- Expose truthful Download, Preparing + Cancel, Action Required + Retry, Ready + Delete states for the aggregate.
- Make Inflect Download start only missing/failed graph and frontend assets; downloaded assets are skipped.
- Remove Inflect-specific frontend/Jenny/Sherpa controls from the Inflect path. The full Sherpa Piper voice configuration remains unchanged when Sherpa Piper is selected.
- Delete only Inflect graph files; preserve the shared Sherpa voice pack used by Sherpa Piper.
- Keep runtime selection and Android fallback behavior unchanged.

## Risk Tier
High — voice settings selection and model/voice readiness UX.

## Evidence
- `./gradlew :feature:settings:testDebugUnitTest` — passed after final changes.
- `./gradlew :feature:settings:lintDebug` — passed.
- `./gradlew assembleDebug` — passed.
- `./gradlew assembleRelease` — passed.
- Physical validation on SM-G991B (Galaxy S21), Android 15: installed the final debug APK and confirmed Inflect presents one logical selected/setup-required card with Download and no Jenny/frontend card or Sherpa voice controls.
- Physical graphs-ready/frontend-missing path: downloaded Inflect graphs and the shared frontend; removed only the shared frontend while confirming both graph files remained; restarted the app; Inflect showed setup required and Not available; tapping the single Inflect Download showed Preparing/Cancel, restored the frontend, and returned the aggregate to Ready without redownloading graphs.
- Physical persistence smoke: after force-stop/restart, Voice showed Active engine: Inflect Micro and “selected and ready to speak.” Auto-speak chat was enabled and a chat response completed from the active Inflect selection.
- Physical clean-install smoke: cleared the debug app data, launched from a clean state, and confirmed Voice defaults to Android TTS with no automatic Inflect download.
- Regression coverage includes selection side-effect freedom, partial/failed/downloading/ready aggregate states, missing-frontend retry, missing-only orchestration, downloaded-asset skipping, cancellation, selected-voice recomputation, release eligibility, and runtime fallback readiness.

### Pre-merge Checklist

**For code/build/behaviour changes:**
- [x] `./gradlew assembleDebug` passes.
- [x] `./gradlew assembleRelease` passes.
- [x] Targeted settings lint passes.
- [x] Targeted settings unit tests pass.
- [x] One logical Inflect card owns graph + frontend readiness and actions.
- [x] Inflect exposes no separate frontend/Jenny UI; Sherpa-only controls remain Sherpa-only.
- [x] Shared Sherpa pack is preserved when deleting Inflect graphs.
- [x] Physical S21 / Android 15 validation covers initial, frontend-missing retry, ready, persistence, and clean-install states.
- [x] Runtime fallback and Android TTS/Piper paths unchanged.
- [x] No documentation update needed; behavior is isolated to the existing Voice settings lifecycle.

### Limitations
- [x] No known limitations introduced.
- [x] Backward-compatibility impact assessed: eligible-device Inflect selection and setup presentation become readiness-independent; runtime fallback remains unchanged.

## Documentation
Docs not needed: this is a focused bug fix within the existing Voice settings lifecycle.

Do not merge — wait for review.