### PR TITLE
fix(#1530): show contextual chat weather permission flow

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -239,6 +239,7 @@ fun ChatScreen(
     val voicePlaybackState by viewModel.voicePlaybackState.collectAsStateWithLifecycle()
     val voiceMode by viewModel.voiceMode.collectAsStateWithLifecycle()
     val microphoneState by viewModel.microphoneState.collectAsStateWithLifecycle()
+    val weatherLocationState by viewModel.weatherLocationState.collectAsStateWithLifecycle()
     val mealPlannerActivity by viewModel.mealPlannerActivity.collectAsStateWithLifecycle()
     val clipboardManager = LocalClipboardManager.current
     val snackbarHostState = remember { SnackbarHostState() }
@@ -306,6 +307,34 @@ fun ChatScreen(
             val copyThinking by viewModel.copyThinking.collectAsStateWithLifecycle()
             // Track which voice action is pending while we await the permission result.
             var pendingVoiceAction by rememberSaveable { mutableStateOf<String?>(null) }
+            val weatherLocationPermissionLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.RequestPermission(),
+            ) { granted ->
+                if (granted) {
+                    viewModel.onWeatherLocationPermissionGranted()
+                } else {
+                    viewModel.onWeatherLocationPermissionDenied(
+                        shouldShowRationale = ActivityCompat.shouldShowRequestPermissionRationale(
+                            context as android.app.Activity,
+                            Manifest.permission.ACCESS_COARSE_LOCATION,
+                        ),
+                    )
+                }
+            }
+
+            LaunchedEffect(Unit) {
+                viewModel.events.collect { event ->
+                    when (event) {
+                        ChatViewModel.UiEvent.RequestWeatherLocationPermission ->
+                            weatherLocationPermissionLauncher.launch(
+                                Manifest.permission.ACCESS_COARSE_LOCATION,
+                            )
+                        ChatViewModel.UiEvent.RepairWeatherLocationPermission ->
+                            openRuntimePermissionRepair(Manifest.permission.ACCESS_COARSE_LOCATION)
+                    }
+                }
+            }
+
             val micPermissionLauncher = rememberLauncherForActivityResult(
                 contract = ActivityResultContracts.RequestPermission(),
             ) { granted ->
@@ -357,6 +386,11 @@ fun ChatScreen(
                             Manifest.permission.RECORD_AUDIO,
                         ) == PackageManager.PERMISSION_GRANTED
                         viewModel.onChatMicRepairResumeCheck(micGranted)
+                        val locationGranted = ContextCompat.checkSelfPermission(
+                            context,
+                            Manifest.permission.ACCESS_COARSE_LOCATION,
+                        ) == PackageManager.PERMISSION_GRANTED
+                        viewModel.onChatWeatherLocationRepairResumeCheck(locationGranted)
                     }
                 }
                 lifecycleOwner.lifecycle.addObserver(observer)
@@ -487,6 +521,66 @@ fun ChatScreen(
                     )
                 }
             }
+            weatherLocationState?.let { weatherState ->
+                PermissionOverlayDialog(
+                    title = if (weatherState.isPermanentlyDenied) {
+                        "Location permission is blocked"
+                    } else {
+                        "Use your location for local weather?"
+                    },
+                    body = if (weatherState.isPermanentlyDenied) {
+                        "Android will not show the Location permission prompt. Open system settings to allow local weather, " +
+                            "or ask for weather in a named place instead."
+                    } else {
+                        "Jandal can use approximate location to answer weather questions for where you are now. " +
+                            "You can also type a place instead."
+                    },
+                    actions = if (weatherState.isPermanentlyDenied) {
+                        listOf(
+                            PermissionDialogAction(
+                                label = "Open Location permission settings",
+                                testTag = "permission_dialog_open_app_permissions",
+                                onClick = {
+                                    viewModel.onWeatherLocationOpenAppPermissions()
+                                },
+                                isPrimary = true,
+                            ),
+                            PermissionDialogAction(
+                                label = "Use a named location",
+                                testTag = "permission_dialog_location_type_place",
+                                onClick = { viewModel.onWeatherLocationTypePlace() },
+                            ),
+                            PermissionDialogAction(
+                                label = "Not now",
+                                testTag = "permission_dialog_location_not_now",
+                                onClick = { viewModel.dismissWeatherLocationDialog() },
+                            ),
+                        )
+                    } else {
+                        listOf(
+                            PermissionDialogAction(
+                                label = "Use my location",
+                                testTag = "permission_dialog_location_use_my_location",
+                                onClick = { viewModel.onWeatherLocationRequestPermission() },
+                                isPrimary = true,
+                            ),
+                            PermissionDialogAction(
+                                label = "Use a named location",
+                                testTag = "permission_dialog_location_type_place",
+                                onClick = { viewModel.onWeatherLocationTypePlace() },
+                            ),
+                            PermissionDialogAction(
+                                label = "Not now",
+                                testTag = "permission_dialog_location_not_now",
+                                onClick = { viewModel.dismissWeatherLocationDialog() },
+                            ),
+                        )
+                    },
+                    dialogTestTag = "permission_dialog_location",
+                    onDismissRequest = { viewModel.dismissWeatherLocationDialog() },
+                )
+            }
+
             // Model settings overlay — always shown on icon tap, not guarded by
             // modelCapabilities/currentModel null-check (#961).
             if (showModelSettings) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -192,10 +192,28 @@ class ChatViewModel @Inject constructor(
     data class MicrophoneState(
         val isPermanentlyDenied: Boolean = false,
     )
-    
+
+    /** One-shot UI actions emitted for permission requests and repair navigation. */
+    sealed interface UiEvent {
+        data object RequestWeatherLocationPermission : UiEvent
+        data object RepairWeatherLocationPermission : UiEvent
+    }
+
+    /** State for the contextual local-weather location permission dialog. */
+    data class WeatherLocationState(
+        val isPermanentlyDenied: Boolean = false,
+    )
+
+    private data class PendingWeatherLocationAction(
+        val query: String,
+        val intentName: String,
+        val params: Map<String, String>,
+        val submitMode: SubmitMode,
+    )
+
     /** The voice mode the user chose before requesting mic permission (OneShot or BackAndForth). */
     private val _pendingChatMicMode = MutableStateFlow<VoiceMode?>(null)
-    
+
     /** True while we are waiting for the user to return from mic settings after repair CTA. */
     private val _awaitingChatMicSettingsReturn = MutableStateFlow(false)
 
@@ -213,8 +231,14 @@ class ChatViewModel @Inject constructor(
     private val _inputText = MutableStateFlow("")
     private val _error = MutableStateFlow<String?>(null)
     private val _microphoneState = MutableStateFlow<MicrophoneState?>(null)
+    private val _weatherLocationState = MutableStateFlow<WeatherLocationState?>(null)
+    private val _events = MutableSharedFlow<UiEvent>(extraBufferCapacity = 1)
+    private var pendingWeatherLocationAction: PendingWeatherLocationAction? = null
+    private var awaitingWeatherLocationSettingsReturn = false
     private val denialClassifier = PermissionDenialClassifier()
     val microphoneState: StateFlow<MicrophoneState?> = _microphoneState.asStateFlow()
+    val weatherLocationState: StateFlow<WeatherLocationState?> = _weatherLocationState.asStateFlow()
+    val events: SharedFlow<UiEvent> = _events.asSharedFlow()
     private val _conversationTitle = MutableStateFlow<String?>(null)
     private var conversationId: String? = null
     private val contextWindowManager = ContextWindowManager()
@@ -1199,6 +1223,72 @@ class ChatViewModel @Inject constructor(
             speakAssistantReplyIfNeeded(content, spokenSummary)
         }
     }
+    /**
+     * Re-executes a weather QIR call after permission repair. The user message was already
+     * persisted by [sendMessage], so this path appends only the resulting assistant message.
+     */
+    private suspend fun retryWeatherLocationAction(
+        convId: String,
+        pending: PendingWeatherLocationAction,
+    ) {
+        val directSkill = skillRegistry.get(pending.intentName)
+        val (skill, callParams) = if (directSkill != null) {
+            directSkill to pending.params
+        } else {
+            skillRegistry.get("run_intent") to
+                (mapOf("intent_name" to pending.intentName) + pending.params)
+        }
+        if (skill == null) {
+            appendAssistantMessage(
+                convId = convId,
+                content = "I couldn't complete that weather request.",
+                shouldIndex = false,
+            )
+            return
+        }
+
+        when (val result = skill.execute(SkillCall(skill.name, callParams))) {
+            is SkillResult.DirectReply -> appendAssistantMessageWithToolCall(
+                convId = convId,
+                content = result.content,
+                skillName = pending.intentName,
+                requestJson = callParams.toString(),
+                isSuccess = true,
+                presentation = result.presentation,
+                spokenSummary = spokenSummaryFrom(result),
+            )
+            is SkillResult.Success -> appendAssistantMessage(
+                convId = convId,
+                content = result.content,
+                shouldIndex = false,
+                spokenSummary = spokenSummaryFrom(result),
+            )
+            is SkillResult.Failure -> appendAssistantMessage(
+                convId = convId,
+                content = result.error,
+                shouldIndex = false,
+                spokenSummary = result.error,
+            )
+            is SkillResult.CapabilityRequired -> {
+                if (result.capabilityKey == CapabilityKey.WeatherCurrentLocation) {
+                    pendingWeatherLocationAction = pending
+                    _weatherLocationState.value = WeatherLocationState()
+                } else {
+                    appendAssistantMessage(
+                        convId = convId,
+                        content = capabilityRequiredMessage(result),
+                        shouldIndex = false,
+                        spokenSummary = capabilityRequiredMessage(result),
+                    )
+                }
+            }
+            else -> appendAssistantMessage(
+                convId = convId,
+                content = "I couldn't complete that weather request.",
+                shouldIndex = false,
+            )
+        }
+    }
 
 
     fun retryDownload(model: KernelModel) {
@@ -1380,6 +1470,87 @@ class ChatViewModel @Inject constructor(
         } else {
             _microphoneState.value = MicrophoneState(isPermanentlyDenied = true)
             // Keep _pendingChatMicMode alive for another repair attempt.
+        }
+    }
+
+
+    /** Requests ACCESS_COARSE_LOCATION through ChatScreen's runtime permission launcher. */
+    fun onWeatherLocationRequestPermission() {
+        _error.value = null
+        viewModelScope.launch {
+            _events.emit(UiEvent.RequestWeatherLocationPermission)
+        }
+    }
+
+    /** Switches the pending local-weather request to the named-place fallback. */
+    fun onWeatherLocationTypePlace() {
+        awaitingWeatherLocationSettingsReturn = false
+        pendingWeatherLocationAction = null
+        _weatherLocationState.value = null
+        denialClassifier.clear(Manifest.permission.ACCESS_COARSE_LOCATION)
+        pendingVoiceReply = false
+        _error.value = "Type a place name in the chat input, like \"weather in Tokyo\"."
+    }
+
+    /** Dismisses the weather permission surface without executing the pending request. */
+    fun dismissWeatherLocationDialog() {
+        awaitingWeatherLocationSettingsReturn = false
+        pendingWeatherLocationAction = null
+        _weatherLocationState.value = null
+        denialClassifier.clear(Manifest.permission.ACCESS_COARSE_LOCATION)
+        pendingVoiceReply = false
+        _error.value = null
+    }
+
+    /** Retries the original local-weather request after ACCESS_COARSE_LOCATION is granted. */
+    fun onWeatherLocationPermissionGranted() {
+        awaitingWeatherLocationSettingsReturn = false
+        denialClassifier.clear(Manifest.permission.ACCESS_COARSE_LOCATION)
+        val pending = pendingWeatherLocationAction ?: return
+        pendingWeatherLocationAction = null
+        _weatherLocationState.value = null
+        pendingVoiceReply = pending.submitMode == SubmitMode.Voice
+        viewModelScope.launch {
+            val convId = conversationId ?: return@launch
+            retryWeatherLocationAction(convId, pending)
+        }
+    }
+
+    /** Keeps the contextual dialog on a retryable denial and promotes later denials to repair. */
+    fun onWeatherLocationPermissionDenied(shouldShowRationale: Boolean = false) {
+        val currentState = _weatherLocationState.value ?: return
+        when (denialClassifier.classify(
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            shouldShowRationale,
+        )) {
+            DenialOutcome.RepairOnlyDenied ->
+                _weatherLocationState.value = currentState.copy(isPermanentlyDenied = true)
+            DenialOutcome.RetryableDenied ->
+                _weatherLocationState.value = currentState
+        }
+    }
+
+    /** Opens Android's app-permission settings for manual location repair. */
+    fun onWeatherLocationOpenAppPermissions() {
+        awaitingWeatherLocationSettingsReturn = true
+        _weatherLocationState.value = null
+        _error.value = null
+        viewModelScope.launch {
+            _events.emit(UiEvent.RepairWeatherLocationPermission)
+        }
+    }
+
+    /**
+     * Called from ChatScreen after returning from permission settings. A grant retries the
+     * original request; a still-denied permission restores the blocked repair surface.
+     */
+    fun onChatWeatherLocationRepairResumeCheck(hasPermission: Boolean) {
+        if (!awaitingWeatherLocationSettingsReturn) return
+        awaitingWeatherLocationSettingsReturn = false
+        if (hasPermission) {
+            onWeatherLocationPermissionGranted()
+        } else if (pendingWeatherLocationAction != null) {
+            _weatherLocationState.value = WeatherLocationState(isPermanentlyDenied = true)
         }
     }
 
@@ -2242,17 +2413,33 @@ class ChatViewModel @Inject constructor(
                             systemContext = "[System: ${matchedIntent.intentName} failed — ${skillResult.error}]"
                         }
                         is com.kernel.ai.core.skills.SkillResult.CapabilityRequired -> {
-                            val message = capabilityRequiredMessage(skillResult)
-                            appendAssistantMessage(
-                                convId = convId,
-                                content = message,
-                                shouldIndex = false,
-                                spokenSummary = message,
-                            )
-                            Log.d(
-                                "KernelAI",
-                                "ADB_TOOL_COMPLETE commandId=$commandId intent=${matchedIntent.intentName} result=capability_required_no_llm",
-                            )
+                            if (skillResult.capabilityKey == CapabilityKey.WeatherCurrentLocation) {
+                                pendingWeatherLocationAction = PendingWeatherLocationAction(
+                                    query = text,
+                                    intentName = matchedIntent.intentName,
+                                    params = callParams,
+                                    submitMode = submitMode,
+                                )
+                                _weatherLocationState.value = WeatherLocationState()
+                                _error.value = null
+                                Log.d(
+                                    "KernelAI",
+                                    "ADB_TOOL_COMPLETE commandId=$commandId intent=${matchedIntent.intentName} " +
+                                        "result=capability_required_weather_permission",
+                                )
+                            } else {
+                                val message = capabilityRequiredMessage(skillResult)
+                                appendAssistantMessage(
+                                    convId = convId,
+                                    content = message,
+                                    shouldIndex = false,
+                                    spokenSummary = message,
+                                )
+                                Log.d(
+                                    "KernelAI",
+                                    "ADB_TOOL_COMPLETE commandId=$commandId intent=${matchedIntent.intentName} result=capability_required_no_llm",
+                                )
+                            }
                             return@launch
                         }
                         else -> { /* UnknownSkill/ParseError — fall through to E4B unchanged */ }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelQuickIntentRouterTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelQuickIntentRouterTest.kt
@@ -16,6 +16,8 @@ import com.kernel.ai.core.inference.hardware.HardwareTier
 import com.kernel.ai.core.memory.entity.ConversationEntity
 import com.kernel.ai.core.memory.rag.RagRepository
 import com.kernel.ai.core.memory.repository.ConversationRepository
+import com.kernel.ai.feature.chat.model.ChatMessage
+import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.memory.repository.ModelSettingsRepository
 import com.kernel.ai.core.memory.repository.MealPlanSessionRepository
@@ -57,10 +59,14 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.async
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -69,6 +75,8 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -265,7 +273,7 @@ class ChatViewModelQuickIntentRouterTest {
     }
 
     @Test
-    fun `weather capability required surfaces repair message and skips LLM`() = runTest(dispatcher) {
+    fun `weather capability required opens contextual dialog without assistant failure`() = runTest(dispatcher) {
         val input = "what's the weather"
         weatherSkillResult = SkillResult.CapabilityRequired(
             capabilityKey = CapabilityKey.WeatherCurrentLocation,
@@ -274,17 +282,155 @@ class ChatViewModelQuickIntentRouterTest {
 
         val viewModel = createViewModel()
         advanceUntilIdle()
-
         viewModel.onInputChanged(input)
         viewModel.sendMessage()
         advanceUntilIdle()
 
         verify(exactly = 0) { inferenceEngine.generate(any()) }
+        assertEquals(ChatViewModel.WeatherLocationState(), viewModel.weatherLocationState.value)
+        val conversation = viewModel.getConversationAsText()
+        assertEquals(1, conversation.lines().count { it.startsWith("You:") })
+        assertEquals(0, conversation.lines().count { it.startsWith("Jandal:") })
+        assertFalse(conversation.contains("Location access"))
+    }
 
-        val chatText = viewModel.getConversationAsText()
-        assertTrue(chatText.contains("Location access"), "Expected location-repair guidance, got: $chatText")
-        assertTrue(chatText.contains("named city"), "Expected named-city fallback guidance, got: $chatText")
-        assertTrue(!chatText.contains("get_weather"), "Did not expect raw tool JSON or tool name in: $chatText")
+    @Test
+    fun `grant retries weather skill and appends only one assistant message`() = runTest(dispatcher) {
+        weatherSkillResult = SkillResult.CapabilityRequired(
+            capabilityKey = CapabilityKey.WeatherCurrentLocation,
+            skillName = "get_weather",
+        )
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onInputChanged("what's the weather")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        weatherSkillResult = SkillResult.Success("Currently 18°C and partly cloudy in your area.")
+        viewModel.onWeatherLocationPermissionGranted()
+        advanceUntilIdle()
+
+        val conversation = viewModel.getConversationAsText()
+        assertNull(viewModel.weatherLocationState.value)
+        assertEquals(1, conversation.lines().count { it.startsWith("You:") })
+        assertEquals(1, conversation.lines().count { it.startsWith("Jandal:") })
+        assertTrue(viewModel.getConversationAsText().contains("partly cloudy"))
+    }
+
+    @Test
+    fun `first weather denial remains retryable`() = runTest(dispatcher) {
+        val viewModel = submitWeatherCapabilityRequest()
+        advanceUntilIdle()
+
+        viewModel.onWeatherLocationPermissionDenied(shouldShowRationale = false)
+
+        assertEquals(ChatViewModel.WeatherLocationState(), viewModel.weatherLocationState.value)
+    }
+
+    @Test
+    fun `second weather denial becomes blocked repair state`() = runTest(dispatcher) {
+        val viewModel = submitWeatherCapabilityRequest()
+        advanceUntilIdle()
+
+        viewModel.onWeatherLocationPermissionDenied(shouldShowRationale = true)
+        viewModel.onWeatherLocationPermissionDenied(shouldShowRationale = false)
+
+        assertEquals(
+            ChatViewModel.WeatherLocationState(isPermanentlyDenied = true),
+            viewModel.weatherLocationState.value,
+        )
+    }
+
+    @Test
+    fun `location settings grant retries pending weather request`() = runTest(dispatcher) {
+        weatherSkillResult = SkillResult.CapabilityRequired(
+            capabilityKey = CapabilityKey.WeatherCurrentLocation,
+            skillName = "get_weather",
+        )
+        val viewModel = submitWeatherCapabilityRequest()
+        advanceUntilIdle()
+        viewModel.onWeatherLocationOpenAppPermissions()
+        advanceUntilIdle()
+        weatherSkillResult = SkillResult.Success("Weather restored.")
+        viewModel.onChatWeatherLocationRepairResumeCheck(hasPermission = true)
+        advanceUntilIdle()
+
+        assertNull(viewModel.weatherLocationState.value)
+        assertTrue(viewModel.getConversationAsText().contains("Weather restored."))
+    }
+
+    @Test
+    fun `location settings return without grant restores blocked repair state`() = runTest(dispatcher) {
+        val viewModel = submitWeatherCapabilityRequest()
+        advanceUntilIdle()
+
+        viewModel.onWeatherLocationOpenAppPermissions()
+        advanceUntilIdle()
+        viewModel.onChatWeatherLocationRepairResumeCheck(hasPermission = false)
+
+        assertEquals(
+            ChatViewModel.WeatherLocationState(isPermanentlyDenied = true),
+            viewModel.weatherLocationState.value,
+        )
+    }
+
+    @Test
+    fun `named place fallback clears pending weather permission and guides chat input`() = runTest(dispatcher) {
+        val viewModel = submitWeatherCapabilityRequest()
+        advanceUntilIdle()
+
+        val errorState = async {
+            viewModel.uiState
+                .filterIsInstance<ChatUiState.Ready>()
+                .first()
+        }
+        viewModel.onWeatherLocationTypePlace()
+        assertNull(viewModel.weatherLocationState.value)
+        assertEquals(
+            "Type a place name in the chat input, like \"weather in Tokyo\".",
+            errorState.await().error,
+        )
+    }
+
+    @Test
+    fun `not now dismisses pending weather permission without assistant output`() = runTest(dispatcher) {
+        val viewModel = submitWeatherCapabilityRequest()
+        advanceUntilIdle()
+
+        viewModel.dismissWeatherLocationDialog()
+
+        assertNull(viewModel.weatherLocationState.value)
+        assertEquals(
+            1,
+            viewModel.getConversationAsText().lines().count { it.startsWith("You:") },
+        )
+    }
+
+    @Test
+    fun `unrelated capability required keeps generic assistant guidance`() = runTest(dispatcher) {
+        weatherSkillResult = SkillResult.CapabilityRequired(
+            capabilityKey = CapabilityKey.ContactLookup,
+            skillName = "get_weather",
+        )
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onInputChanged("what's the weather")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        assertNull(viewModel.weatherLocationState.value)
+        assertTrue(viewModel.getConversationAsText().contains("Permission required for get_weather."))
+    }
+
+    @Test
+    fun `weather permission request emits runtime launcher event`() = runTest(dispatcher) {
+        val viewModel = submitWeatherCapabilityRequest()
+        advanceUntilIdle()
+        val event = async { viewModel.events.first() }
+
+        viewModel.onWeatherLocationRequestPermission()
+
+        assertEquals(ChatViewModel.UiEvent.RequestWeatherLocationPermission, event.await())
     }
 
     @Test
@@ -326,6 +472,19 @@ class ChatViewModelQuickIntentRouterTest {
         viewModel.onInputChanged(input)
         viewModel.sendMessage()
         advanceUntilIdle()
+    }
+
+    private suspend fun TestScope.submitWeatherCapabilityRequest(): ChatViewModel {
+        weatherSkillResult = SkillResult.CapabilityRequired(
+            capabilityKey = CapabilityKey.WeatherCurrentLocation,
+            skillName = "get_weather",
+        )
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onInputChanged("what's the weather")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+        return viewModel
     }
 
     private fun createViewModel(): ChatViewModel = ChatViewModel(


### PR DESCRIPTION
## Description
Closes #1530

## Scope
Chat direct local-weather requests use the existing contextual location permission UX, preserve the pending request across grant/settings repair, retry without duplicate user messages, and retain retryable/permanent denial behavior. Named-location weather and unrelated capability handling remain unchanged.

Remediation commit `f240e65c` fixes the voice-originated pending-weather cancellation lifecycle: `Not now` and `Use a named location` reuse `stopVoiceInput()` for `SubmitMode.Voice`. This leaves capture idle, clears the active voice mode and pending reply, resets voice playback-completion gating, and prevents Back-and-Forth re-arm. Text-originated behavior is unchanged. Quick Actions, routing, weather skill, denial classifier, and general permission orchestration were not changed.

## Risk Tier
Medium — Chat permission flow and Android runtime/settings boundary.

## Evidence
- `./gradlew :feature:chat:testDebugUnitTest` — passed.
- `./gradlew :feature:chat:testDebugUnitTest --tests '*.ChatViewModelVoiceTest'` — passed; covers voice Not now in Back-and-Forth and voice named-place fallback.
- `./gradlew :feature:chat:lintDebug` — passed.
- `./gradlew assembleDebug` — passed.
- `./gradlew assembleRelease` — passed on the PR #1531 implementation head.
- `git diff --check` — passed.
- Existing #1530 S21 / Android 15 validation remains green: missing→grant, denial transitions, settings repair→retry, named-location bypass, and Quick Actions regression.
- Device: Samsung SM-G991B, Android 15.

The existing permission scenario runner exercised the device path and captured screenshots, but failed its final schema validation because `artifact_refs` emits objects while the schema expects strings. No harness source was changed; manual Quick Actions validation covered the regression.

## Documentation
Docs not needed: this is a focused lifecycle remediation using existing permission UX and voice cleanup behavior.

Do not request GitHub Copilot Review. Human/ChatGPT review plus repo evidence is the expected review path.